### PR TITLE
fixed (updated) ROS debian package repo GPG key

### DIFF
--- a/scripts/setup/add_ros_repository.sh
+++ b/scripts/setup/add_ros_repository.sh
@@ -19,7 +19,7 @@
 
 sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
 
-sudo apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 421C365BD9FF1F717815A3895523BAEEB01FA116
+sudo apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
 
 # Gazebo stuff
 sudo sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list'


### PR DESCRIPTION
c.f. http://answers.ros.org/question/325039/apt-update-fails-cannot-install-pkgs-key-not-working/#js-post-body-325040