### PR TITLE
Fix typo in ff_util and add missing catkin_pkg line in ff_msgs

### DIFF
--- a/communications/ff_msgs/CMakeLists.txt
+++ b/communications/ff_msgs/CMakeLists.txt
@@ -23,9 +23,19 @@ find_package(catkin2 REQUIRED COMPONENTS
   geometry_msgs
   actionlib_msgs
   trajectory_msgs
-  geometry_msgs
   sensor_msgs
 )
 
 create_msg_targets(DIR msg SDIR srv ADIR action
-  DEPS std_msgs geometry_msgs actionlib_msgs trajectory_msgs geometry_msgs sensor_msgs)
+  DEPS std_msgs geometry_msgs actionlib_msgs trajectory_msgs sensor_msgs)
+
+catkin_package(
+ # INCLUDE_DIRS include
+  LIBRARIES
+  CATKIN_DEPENDS message_runtime  geometry_msgs actionlib_msgs trajectory_msgs sensor_msgs
+)
+
+include_directories(
+  include
+  ${catkin_INCLUDE_DIRS}
+)

--- a/communications/ff_msgs/package.xml
+++ b/communications/ff_msgs/package.xml
@@ -20,10 +20,12 @@
   <build_depend>std_msgs</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>sensor_msgs</build_depend>
+  <build_depend>trajectory_msgs</build_depend>
   <build_depend>actionlib_msgs</build_depend>
   <run_depend>std_msgs</run_depend>
   <run_depend>geometry_msgs</run_depend>
   <run_depend>sensor_msgs</run_depend>
+  <run_depend>trajectory_msgs</run_depend>
   <run_depend>actionlib_msgs</run_depend>
   <export></export>
 </package>

--- a/shared/ff_util/CMakeLists.txt
+++ b/shared/ff_util/CMakeLists.txt
@@ -20,7 +20,7 @@ project(ff_util)
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES ff_nodelet config_server config_client perf_timer
-  CATKIN_DEPENDS roscpp nodelet dynamic_reconfigure ff_msgs diagnostics_msgs tf2_geometry_msgs actionlib
+  CATKIN_DEPENDS roscpp nodelet dynamic_reconfigure ff_msgs diagnostic_msgs tf2_geometry_msgs actionlib
 )
 
 create_library(TARGET ff_nodelet
@@ -41,7 +41,7 @@ create_library(TARGET config_server
   DIR src/config_server
   LIBS ${catkin_LIBRARIES} config_reader
   INC ${catkin_INCLUDE_DIRS}
-  DEPS config_reader diagnostics_msgs
+  DEPS config_reader diagnostic_msgs
 )
 
 create_library(TARGET config_client

--- a/shared/ff_util/package.xml
+++ b/shared/ff_util/package.xml
@@ -19,7 +19,7 @@
   <build_depend>nodelet</build_depend>
   <build_depend>pluginlib</build_depend>
   <build_depend>actionlib</build_depend>
-  <build_depend>diagnostics_msgs</build_depend>
+  <build_depend>diagnostic_msgs</build_depend>
   <build_depend>dynamic_reconfigure</build_depend>
   <build_depend>ff_msgs</build_depend>
   <build_depend>tf2_geometry_msgs</build_depend>
@@ -28,7 +28,7 @@
   <run_depend>nodelet</run_depend>
   <run_depend>pluginlib</run_depend>
   <run_depend>actionlib</run_depend>
-  <run_depend>diagnostics_msgs</run_depend>
+  <run_depend>diagnostic_msgs</run_depend>
   <run_depend>dynamic_reconfigure</run_depend>
   <run_depend>ff_msgs</run_depend>
   <run_depend>tf2_geometry_msgs</run_depend>


### PR DESCRIPTION
I am working with  the Astrobee Gazebo simulation and some of our in-house ROS packages. I ran across a couple of issues when trying to overlay the astrobee workspace with our Lab workspace, specifically a typo in ff_util and the lack of a catkin line in ff_msgs. Oddly enough, these errors only showed up when I tried to overlay workspaces.

This PR fixes the issues I found. After using these changes, I was able to build an overlaid workspace and use some of the astrobee's packages from said ws.