### PR TITLE
add check if Astrobee is dynamically stopped in truth mode

### DIFF
--- a/communications/ff_msgs/msg/MotionState.msg
+++ b/communications/ff_msgs/msg/MotionState.msg
@@ -33,7 +33,6 @@ int8 PLANNING            = 7
 int8 PREPARING           = 8
 int8 CONTROLLING         = 9
 int8 REPLANNING          = 10
-int8 HALTING			 = 11
 
 # A human readble version of the (event) -> [state] transition
 string fsm_event

--- a/communications/ff_msgs/msg/MotionState.msg
+++ b/communications/ff_msgs/msg/MotionState.msg
@@ -33,6 +33,7 @@ int8 PLANNING            = 7
 int8 PREPARING           = 8
 int8 CONTROLLING         = 9
 int8 REPLANNING          = 10
+int8 HALTING			 = 11
 
 # A human readble version of the (event) -> [state] transition
 string fsm_event

--- a/gnc/ctl/include/ctl/ctl.h
+++ b/gnc/ctl/include/ctl/ctl.h
@@ -66,14 +66,16 @@ class Ctl {
   // Declaration of all possible states
   enum : ff_util::FSM::State {
     WAITING        = 1,
-    NOMINAL        = 2
+    NOMINAL        = 2,
+    STOPPING       = 3
   };
 
   // Declaration of all possible events
   enum : ff_util::FSM::Event {
     GOAL_COMPLETE  = (1<<0),
     GOAL_NOMINAL   = (1<<1),
-    GOAL_CANCEL    = (1<<2)
+    GOAL_CANCEL    = (1<<2),
+    GOAL_STOP      = (1<<3)
   };
 
   // Maximum acceptable latency
@@ -174,6 +176,8 @@ class Ctl {
   bool inertia_received_;
   bool control_enabled_;
   bool use_truth_;
+  float stopping_vel_thresh_squared_;
+  float stopping_omega_thresh_squared_;
 };
 
 }  // end namespace ctl

--- a/gnc/ctl/src/ctl.cc
+++ b/gnc/ctl/src/ctl.cc
@@ -69,7 +69,7 @@ Ctl::Ctl(ros::NodeHandle* nh, std::string const& name) :
     });
   // [1]
   fsm_.Add(NOMINAL,
-    GOAL_COMPLETE,
+    GOAL_STOP,
     [this](FSM::Event const& event) -> FSM::State {
       if (!Control(ff_msgs::ControlCommand::MODE_STOP))
         return Result(RESPONSE::CONTROL_FAILED);
@@ -355,7 +355,7 @@ void Ctl::TimerCallback(const ros::TimerEvent& event) {
     if (setpoint_ == segment_.end()) {
       mutex_segment_.unlock();
       NODELET_DEBUG_STREAM("Final setpoint " << idx);
-      return fsm_.Update(GOAL_COMPLETE);
+      return fsm_.Update(GOAL_STOP);
     }
     // Otherwise, we have at least one more setpoint
     msg.current = *setpoint_;

--- a/gnc/ctl/src/ctl.cc
+++ b/gnc/ctl/src/ctl.cc
@@ -69,7 +69,7 @@ Ctl::Ctl(ros::NodeHandle* nh, std::string const& name) :
     });
   // [1]
   fsm_.Add(NOMINAL,
-    GOAL_STOP,
+    GOAL_COMPLETE,
     [this](FSM::Event const& event) -> FSM::State {
       if (!Control(ff_msgs::ControlCommand::MODE_STOP))
         return Result(RESPONSE::CONTROL_FAILED);
@@ -355,7 +355,7 @@ void Ctl::TimerCallback(const ros::TimerEvent& event) {
     if (setpoint_ == segment_.end()) {
       mutex_segment_.unlock();
       NODELET_DEBUG_STREAM("Final setpoint " << idx);
-      return fsm_.Update(GOAL_STOP);
+      return fsm_.Update(GOAL_COMPLETE);
     }
     // Otherwise, we have at least one more setpoint
     msg.current = *setpoint_;

--- a/gnc/ctl/statemachine.dot
+++ b/gnc/ctl/statemachine.dot
@@ -15,8 +15,8 @@ digraph G {
   # Actions
   WAITING -> NOMINAL
     [label="[0]\nGOAL_NOMINAL\nControl(NOMINAL, Segment)", color=black];
-  NOMINAL -> STOPPING
-    [label="[1]\nGOAL_STOP\nControl(STOP)", color=black];
+  NOMINAL -> WAITING
+    [label="[1]\nGOAL_COMPLETE\nControl(STOP)\nResult(SUCCESS)", color=black];
   NOMINAL -> WAITING
     [label="[2]\nGOAL_CANCEL\nControl(STOP)\nResult(CANCELLED)", color=black];
   WAITING -> STOPPING

--- a/gnc/ctl/statemachine.dot
+++ b/gnc/ctl/statemachine.dot
@@ -15,8 +15,8 @@ digraph G {
   # Actions
   WAITING -> NOMINAL
     [label="[0]\nGOAL_NOMINAL\nControl(NOMINAL, Segment)", color=black];
-  NOMINAL -> WAITING
-    [label="[1]\nGOAL_COMPLETE\nControl(STOP)\nResult(SUCCESS)", color=black];
+  NOMINAL -> STOPPING
+    [label="[1]\nGOAL_STOP\nControl(STOP)", color=black];
   NOMINAL -> WAITING
     [label="[2]\nGOAL_CANCEL\nControl(STOP)\nResult(CANCELLED)", color=black];
   WAITING -> STOPPING

--- a/gnc/ctl/statemachine.dot
+++ b/gnc/ctl/statemachine.dot
@@ -16,7 +16,12 @@ digraph G {
   WAITING -> NOMINAL
     [label="[0]\nGOAL_NOMINAL\nControl(NOMINAL, Segment)", color=black];
   NOMINAL -> WAITING
-    [label="[1]\nGOAL_COMPLETE\nControl(STOP)\nResult(SUCCESS)", color=green];
+    [label="[1]\nGOAL_COMPLETE\nControl(STOP)\nResult(SUCCESS)", color=black];
   NOMINAL -> WAITING
-    [label="[2]\nGOAL_CANCEL\nControl(STOP)\nResult(CANCELLED)", color=red];
+    [label="[2]\nGOAL_CANCEL\nControl(STOP)\nResult(CANCELLED)", color=black];
+  WAITING -> STOPPING
+    [label="[3]\nGOAL_STOP\nControl(STOP)", color=black];
+  STOPPING -> WAITING
+   [label="[4]\nGOAL_COMPLETE\nResult(SUCCESS)", color=black];
+
 }


### PR DESCRIPTION
Added check for determining if Astrobee is dynamically stopped in truth mode. Previously the check was only done in the ekf, i.e when not using truth mode. This pull request should only have changed the TwistCallback function in gnc/ctl/src/ctl.cc, compared to the pull request earlier for the controller.

Changes has been tested in simulation using the iss.world, by initiating a stop command for the controller both in truth mode and not in truth mode.