### PR TITLE
Predict function called with wrong arguments

### DIFF
--- a/localization/vive_localization/src/vive.h
+++ b/localization/vive_localization/src/vive.h
@@ -265,8 +265,8 @@ static void Correct(T const* params, T * angle, bool correct) {
     ideal[0] = angle[0];
     ideal[1] = angle[1];
     for (size_t i = 0; i < 10; i++) {
-      xyz[0] = xyz[0] = T(-1.0) / tan(ideal[0]);
-      xyz[1] = xyz[0] = T(-1.0) / tan(ideal[1]);
+      xyz[0] = T(-1.0) / tan(ideal[0]);
+      xyz[1] = T(-1.0) / tan(ideal[1]);
       xyz[2] = T(1.0);
       Predict(params, xyz, pred, correct);
       ideal[0] += (angle[0] - pred[0]);

--- a/localization/vive_localization/src/vive.h
+++ b/localization/vive_localization/src/vive.h
@@ -243,7 +243,7 @@ static void Predict(T const* params, T const* xyz, T* ang, bool correct) {
       c = -xyz[0];
     }
     // Ideal angle in radians [0, 2pi] relative to the start of the sweep
-    ang[i] = atan2(a, b);
+    ang[i] = atan2(b, a);
     // Perturb this angle based on the base station parameters
     if (correct) {
       T const* p = &params[i*NUM_PARAMS];

--- a/localization/vive_localization/src/vive.h
+++ b/localization/vive_localization/src/vive.h
@@ -243,7 +243,7 @@ static void Predict(T const* params, T const* xyz, T* ang, bool correct) {
       c = -xyz[0];
     }
     // Ideal angle in radians [0, 2pi] relative to the start of the sweep
-    ang[i] = atan2(b, a);
+    ang[i] = atan2(a, b);
     // Perturb this angle based on the base station parameters
     if (correct) {
       T const* p = &params[i*NUM_PARAMS];
@@ -265,8 +265,8 @@ static void Correct(T const* params, T * angle, bool correct) {
     ideal[0] = angle[0];
     ideal[1] = angle[1];
     for (size_t i = 0; i < 10; i++) {
-      xyz[0] = tan(ideal[0]);
-      xyz[1] = tan(ideal[1]);
+      xyz[0] = xyz[0] = T(-1.0) / tan(ideal[0]);
+      xyz[1] = xyz[0] = T(-1.0) / tan(ideal[1]);
       xyz[2] = T(1.0);
       Predict(params, xyz, pred, correct);
       ideal[0] += (angle[0] - pred[0]);


### PR DESCRIPTION
Hi!

I was looking at you implementation of the Vive localization functionality. It seems as the arguments of an atan has been reversed. 