### PR TITLE
Changed the arm timeout from 4 to 10 seconds.

### DIFF
--- a/astrobee/config/management/executive.config
+++ b/astrobee/config/management/executive.config
@@ -25,7 +25,7 @@ led_service_available_timeout = 10
 gs_command_timeout = 4
 
 motion_feedback_timeout = 1
-arm_feedback_timeout = 4
+arm_feedback_timeout = 10
 
 dock_result_timeout = 360
 perch_result_timeout = 360


### PR DESCRIPTION
The gripper calibration takes longer than 4 seconds which was causing
the executive to error out on the first open gripper command. This has
been fixed.