### PR TITLE
Renamed the cpu monitor plugins to cpu mem monitor

### DIFF
--- a/simulation/CMakeLists.txt
+++ b/simulation/CMakeLists.txt
@@ -37,9 +37,9 @@ catkin_package(
     gazebo_model_plugin_flashlight_front
     gazebo_model_plugin_flashlight_aft
     gazebo_model_plugin_llp_disk_monitor
-    gazebo_model_plugin_llp_cpu_monitor
+    gazebo_model_plugin_llp_cpu_mem_monitor
     gazebo_model_plugin_mlp_disk_monitor
-    gazebo_model_plugin_mlp_cpu_monitor
+    gazebo_model_plugin_mlp_cpu_mem_monitor
     gazebo_model_plugin_speed_cam
     gazebo_model_plugin_signal_lights
     gazebo_sensor_plugin_imu
@@ -244,12 +244,12 @@ create_library(
     ff_hw_msgs
 )
 
-# Create a model plugin for the LLP CPU monitor
+# Create a model plugin for the LLP CPU mem monitor
 create_library(
   DIR
-    src/gazebo_model_plugin_llp_cpu_monitor
+    src/gazebo_model_plugin_llp_cpu_mem_monitor
   TARGET
-    gazebo_model_plugin_llp_cpu_monitor
+    gazebo_model_plugin_llp_cpu_mem_monitor
   LIBS
     ${GAZEBO_LIBRARIES}
     ${catkin_LIBRARIES}
@@ -280,12 +280,12 @@ create_library(
     ff_hw_msgs
 )
 
-# Create a model plugin for the MLP CPU monitor
+# Create a model plugin for the MLP CPU mem monitor
 create_library(
   DIR
-    src/gazebo_model_plugin_mlp_cpu_monitor
+    src/gazebo_model_plugin_mlp_cpu_mem_monitor
   TARGET
-    gazebo_model_plugin_mlp_cpu_monitor
+    gazebo_model_plugin_mlp_cpu_mem_monitor
   LIBS
     ${GAZEBO_LIBRARIES}
     ${catkin_LIBRARIES}
@@ -298,7 +298,7 @@ create_library(
     ff_hw_msgs
 )
 
-# Create a model plugin for the MMLP disk monitor
+# Create a model plugin for the MLP disk monitor
 create_library(
   DIR
     src/gazebo_model_plugin_mlp_disk_monitor

--- a/simulation/src/gazebo_model_plugin_llp_cpu_mem_monitor/gazebo_model_plugin_llp_cpu_mem_monitor.cc
+++ b/simulation/src/gazebo_model_plugin_llp_cpu_mem_monitor/gazebo_model_plugin_llp_cpu_mem_monitor.cc
@@ -27,12 +27,12 @@
 
 namespace gazebo {
 
-class GazeboModelPluginLlpCpuMonitor : public FreeFlyerModelPlugin {
+class GazeboModelPluginLlpCpuMemMonitor : public FreeFlyerModelPlugin {
  public:
-  GazeboModelPluginLlpCpuMonitor() : FreeFlyerModelPlugin(
-    "llp_cpu_monitor", "llp_cpu_monitor", true) {}
+  GazeboModelPluginLlpCpuMemMonitor() : FreeFlyerModelPlugin(
+    "llp_cpu_mem_monitor", "llp_cpu_mem_monitor", true) {}
 
-  ~GazeboModelPluginLlpCpuMonitor() {}
+  ~GazeboModelPluginLlpCpuMemMonitor() {}
 
  protected:
   // Called when the plugin is loaded into the simulator
@@ -46,6 +46,6 @@ class GazeboModelPluginLlpCpuMonitor : public FreeFlyerModelPlugin {
 };
 
 // Register this plugin with the simulator
-GZ_REGISTER_MODEL_PLUGIN(GazeboModelPluginLlpCpuMonitor)
+GZ_REGISTER_MODEL_PLUGIN(GazeboModelPluginLlpCpuMemMonitor)
 
 }   // namespace gazebo

--- a/simulation/src/gazebo_model_plugin_mlp_cpu_mem_monitor/gazebo_model_plugin_mlp_cpu_mem_monitor.cc
+++ b/simulation/src/gazebo_model_plugin_mlp_cpu_mem_monitor/gazebo_model_plugin_mlp_cpu_mem_monitor.cc
@@ -27,12 +27,12 @@
 
 namespace gazebo {
 
-class GazeboModelPluginMlpCpuMonitor : public FreeFlyerModelPlugin {
+class GazeboModelPluginMlpCpuMemMonitor : public FreeFlyerModelPlugin {
  public:
-  GazeboModelPluginMlpCpuMonitor() : FreeFlyerModelPlugin(
-    "mlp_cpu_monitor", "mlp_cpu_monitor", true) {}
+  GazeboModelPluginMlpCpuMemMonitor() : FreeFlyerModelPlugin(
+    "mlp_cpu_mem_monitor", "mlp_cpu_mem_monitor", true) {}
 
-  ~GazeboModelPluginMlpCpuMonitor() {}
+  ~GazeboModelPluginMlpCpuMemMonitor() {}
 
  protected:
   // Called when the plugin is loaded into the simulator
@@ -46,6 +46,6 @@ class GazeboModelPluginMlpCpuMonitor : public FreeFlyerModelPlugin {
 };
 
 // Register this plugin with the simulator
-GZ_REGISTER_MODEL_PLUGIN(GazeboModelPluginMlpCpuMonitor)
+GZ_REGISTER_MODEL_PLUGIN(GazeboModelPluginMlpCpuMemMonitor)
 
 }   // namespace gazebo


### PR DESCRIPTION
The cpu_monitor nodes were renamed to cpu_mem_monitor. The Gazebo
plugins have been renamed to reflect this change.