### PR TITLE
correcting workfows true

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -68,5 +68,5 @@ jobs:
         NAME=`git show -s --format='%an' HEAD`
         git config user.email "$EMAIL"
         git config user.name "$NAME"
-        git commit -m "Automatic update for $GITHUB_SHA."
-        { git push origin gh-pages || true; }
+        { git commit -m "Automatic update for $GITHUB_SHA." || true; }
+        git push origin gh-pages


### PR DESCRIPTION
If there is no updates to the documentation the gh-pages action fails with:
    nothing to commit, working tree clean
    Error: Process completed with exit code 1.
 I thought it was on push that did that, but it was actually the commit, correcting that.