### PR TITLE
updating the link for the doxygen version to sourceforge

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -27,7 +27,7 @@ jobs:
         sudo apt-get install graphviz
     - name: Install doxygen
       run: |
-        wget http://doxygen.nl/files/doxygen-1.8.20.src.tar.gz
+        wget 'https://sourceforge.net/projects/doxygen/files/rel-1.8.20/doxygen-1.8.20.src.tar.gz'
         tar -zxvf doxygen-1.8.20.src.tar.gz
         cd doxygen-1.8.20
         mkdir build


### PR DESCRIPTION
The version was pushed up and the file changed link, updating to the sourceforge link that should last a long time.