### PR TITLE
Install tools in share

### DIFF
--- a/cmake/CreateToolTargets.cmake
+++ b/cmake/CreateToolTargets.cmake
@@ -66,16 +66,6 @@ function(create_tool_targets)
     if (tool_DEPS)
       add_dependencies(${execname} ${tool_DEPS})
     endif (tool_DEPS)
-    install(TARGETS ${execname} DESTINATION bin)
-
-    # Create symlinks so our executables can be found with rosrun. This is done
-    # inside an 'install' so that it happens after the installation.
-    install(CODE "execute_process(
-      COMMAND mkdir -p share/${PROJECT_NAME}
-      COMMAND ln -s ../../bin/${execname} share/${PROJECT_NAME}/${execname}
-      WORKING_DIRECTORY ${CMAKE_INSTALL_PREFIX}
-      OUTPUT_QUIET
-      ERROR_QUIET
-      )")
+    install(TARGETS ${execname} DESTINATION share/${PROJECT_NAME})
   endforeach()
 endfunction()

--- a/debian/astrobee0.dirs
+++ b/debian/astrobee0.dirs
@@ -1,5 +1,4 @@
 opt/astrobee
-opt/astrobee/bin
 opt/astrobee/lib
 opt/astrobee/lib/pkgconfig
 opt/astrobee/lib/python2.7

--- a/debian/astrobee0.install
+++ b/debian/astrobee0.install
@@ -6,7 +6,6 @@ opt/astrobee/setup.zsh
 opt/astrobee/_setup_util.py
 opt/astrobee/version.txt
 opt/astrobee/.catkin
-opt/astrobee/bin/*
 opt/astrobee/lib/*.so
 opt/astrobee/lib/python2.7/*
 opt/astrobee/lib/astrobee/*


### PR DESCRIPTION
I changed the cmake such that it installs the tools in share, given that the debian doesn't install the symlinks. I also removed the bin folder from the install dirs, because it is not populated anymore so it threw an error.