### PR TITLE
fixing github action docs

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -22,9 +22,10 @@ jobs:
         ref: gh-pages
     - name: Install dependencies
       run: |
-        sudo apt-get install bison
-        sudo apt-get install flex
-        sudo apt-get install graphviz
+        sudo apt-get install -y bison
+        sudo apt-get install -y flex
+        sudo apt-get install -y graphviz
+        sudo apt-get install -y python-setuptools
     - name: Install doxygen
       run: |
         wget 'https://sourceforge.net/projects/doxygen/files/rel-1.8.20/doxygen-1.8.20.src.tar.gz'


### PR DESCRIPTION
github must have changed the base ubuntu 18 image to stop installing that package by default, I tested in my account and everything runs fine with it