### PR TITLE
Reverted Smart Factor Spacing to 14.1, Added relative rmse comparison and Imu bias tester adder

### DIFF
--- a/astrobee/config/graph_localizer.config
+++ b/astrobee/config/graph_localizer.config
@@ -90,6 +90,7 @@ smart_projection_adder_rotation_only_fallback = false
 smart_projection_adder_splitting = true 
 smart_projection_adder_scale_noise_with_num_points = true 
 smart_projection_adder_noise_scale = 5
+smart_projection_adder_use_allowed_timestamps = true 
 -- Optical Flow Projection Factors 
 projection_adder_enabled = false 
 projection_adder_enable_EPI = false 

--- a/astrobee/config/graph_localizer.config
+++ b/astrobee/config/graph_localizer.config
@@ -65,7 +65,7 @@ feature_tracker_sliding_window_duration = 3.5
 -- Standstill
 max_standstill_feature_track_avg_distance_from_mean = 0.075
 standstill_min_num_points_per_track = 4 
-standstill_feature_tracker_sliding_window_duration = 1 
+standstill_feature_track_duration = 1 
 standstill_adder_add_velocity_prior = true 
 standstill_adder_add_pose_between_factor = true 
 standstill_adder_prior_velocity_stddev = 0.01

--- a/astrobee/config/graph_localizer.config
+++ b/astrobee/config/graph_localizer.config
@@ -81,7 +81,7 @@ smart_projection_adder_dynamic_outlier_rejection_threshold = 50
 smart_projection_adder_retriangulation_threshold = 1e-5
 smart_projection_adder_verbose_cheirality = false 
 smart_projection_adder_robust = true 
-smart_projection_adder_max_num_factors = 13 
+smart_projection_adder_max_num_factors = 10
 smart_projection_adder_min_num_points = 2 
 smart_projection_adder_max_num_points_per_factor = 5 
 smart_projection_adder_measurement_spacing = 2 
@@ -89,7 +89,7 @@ smart_projection_adder_feature_track_min_separation = 0
 smart_projection_adder_rotation_only_fallback = false 
 smart_projection_adder_splitting = true 
 smart_projection_adder_scale_noise_with_num_points = true 
-smart_projection_adder_noise_scale = 5
+smart_projection_adder_noise_scale = 2 
 smart_projection_adder_use_allowed_timestamps = true 
 -- Optical Flow Projection Factors 
 projection_adder_enabled = false 

--- a/localization/graph_localizer/include/graph_localizer/feature_track.h
+++ b/localization/graph_localizer/include/graph_localizer/feature_track.h
@@ -41,6 +41,7 @@ class FeatureTrack {
   bool empty() const;
   std::vector<localization_measurements::FeaturePoint> AllowedPoints(
     const std::set<localization_common::Time>& allowed_timestamps) const;
+  std::vector<localization_measurements::FeaturePoint> LatestPointsInWindow(const double duration) const;
   std::vector<localization_measurements::FeaturePoint> LatestPoints(const int spacing = 0) const;
   bool SpacingFits(const int spacing, const int max_num_points) const;
   int MaxSpacing(const int max_num_points) const;

--- a/localization/graph_localizer/include/graph_localizer/feature_track.h
+++ b/localization/graph_localizer/include/graph_localizer/feature_track.h
@@ -22,6 +22,7 @@
 #include <localization_measurements/feature_point.h>
 
 #include <map>
+#include <set>
 #include <vector>
 
 namespace graph_localizer {
@@ -38,6 +39,8 @@ class FeatureTrack {
   const localization_measurements::FeatureId& id() const;
   size_t size() const;
   bool empty() const;
+  std::vector<localization_measurements::FeaturePoint> AllowedPoints(
+    const std::set<localization_common::Time>& allowed_timestamps) const;
   std::vector<localization_measurements::FeaturePoint> LatestPoints(const int spacing = 0) const;
   bool SpacingFits(const int spacing, const int max_num_points) const;
   int MaxSpacing(const int max_num_points) const;

--- a/localization/graph_localizer/include/graph_localizer/feature_tracker.h
+++ b/localization/graph_localizer/include/graph_localizer/feature_tracker.h
@@ -39,6 +39,7 @@ class FeatureTracker {
   // detections.
   void UpdateFeatureTracks(const localization_measurements::FeaturePoints& feature_points);
   const FeatureTrackIdMap& feature_tracks() const;
+  const std::set<localization_common::Time>& smart_factor_timestamp_allow_list() const;
   const FeatureTrackLengthMap& feature_tracks_length_ordered() const;
   int NumTracksWithAtLeastNPoints(int n) const;
   void RemoveUndetectedFeatures(const localization_common::Time& feature_point);
@@ -46,6 +47,8 @@ class FeatureTracker {
     boost::optional<localization_common::Time> oldest_allowed_time = boost::none);
   void AddOrUpdateTrack(const localization_measurements::FeaturePoint& feature_point);
   void UpdateLengthMap();
+  void UpdateAllowList(const localization_common::Time& timestamp);
+  void SlideAllowList(const localization_common::Time& oldest_allowed_time);
   boost::optional<const FeatureTrack&> LongestFeatureTrack() const;
   size_t size() const;
   bool empty() const;
@@ -66,6 +69,8 @@ class FeatureTracker {
   FeatureTrackIdMap feature_track_id_map_;
   FeatureTrackLengthMap feature_track_length_map_;
   FeatureTrackerParams params_;
+  // TODO(rsoussan): Move ths somewhere else?
+  std::set<localization_common::Time> smart_factor_timestamp_allow_list_;
 };
 }  // namespace graph_localizer
 

--- a/localization/graph_localizer/include/graph_localizer/feature_tracker.h
+++ b/localization/graph_localizer/include/graph_localizer/feature_tracker.h
@@ -28,6 +28,7 @@
 
 #include <deque>
 #include <map>
+#include <set>
 
 namespace graph_localizer {
 using FeatureTrackIdMap = std::map<localization_measurements::FeatureId, std::shared_ptr<FeatureTrack>>;

--- a/localization/graph_localizer/include/graph_localizer/feature_tracker_params.h
+++ b/localization/graph_localizer/include/graph_localizer/feature_tracker_params.h
@@ -22,6 +22,8 @@ namespace graph_localizer {
 struct FeatureTrackerParams {
   // Max duration, feature tracker trims measurements outside of this window or outside of graph window
   double sliding_window_duration;
+  int smart_projection_adder_measurement_spacing;
+  bool use_allowed_timestamps;
 };
 }  // namespace graph_localizer
 

--- a/localization/graph_localizer/include/graph_localizer/graph_localizer_params.h
+++ b/localization/graph_localizer/include/graph_localizer/graph_localizer_params.h
@@ -33,7 +33,6 @@ struct GraphLocalizerParams {
   CalibrationParams calibration;
   FactorParams factor;
   FeatureTrackerParams feature_tracker;
-  FeatureTrackerParams standstill_feature_tracker;
   GraphValuesParams graph_values;
   NoiseParams noise;
   GraphInitializerParams graph_initializer;
@@ -51,8 +50,8 @@ struct GraphLocalizerParams {
   int standstill_min_num_points_per_track;
   double huber_k;
   int log_rate;
-  int optical_flow_measurement_spacing;
   bool estimate_world_T_dock_using_loc;
+  double standstill_feature_track_duration;
   localization_measurements::FanSpeedMode initial_fan_speed_mode;
 };
 }  // namespace graph_localizer

--- a/localization/graph_localizer/include/graph_localizer/parameter_reader.h
+++ b/localization/graph_localizer/include/graph_localizer/parameter_reader.h
@@ -45,7 +45,6 @@ void LoadSmartProjectionFactorAdderParams(config_reader::ConfigReader& config,
                                           SmartProjectionFactorAdderParams& params);
 void LoadStandstillFactorAdderParams(config_reader::ConfigReader& config, StandstillFactorAdderParams& params);
 void LoadFeatureTrackerParams(config_reader::ConfigReader& config, FeatureTrackerParams& params);
-void LoadStandstillFeatureTrackerParams(config_reader::ConfigReader& config, FeatureTrackerParams& params);
 void LoadGraphValuesParams(config_reader::ConfigReader& config, GraphValuesParams& params);
 void LoadImuIntegrationParams(config_reader::ConfigReader& config, GraphInitializerParams& params);
 void LoadNoiseParams(config_reader::ConfigReader& config, NoiseParams& params);

--- a/localization/graph_localizer/include/graph_localizer/smart_projection_cumulative_factor_adder.h
+++ b/localization/graph_localizer/include/graph_localizer/smart_projection_cumulative_factor_adder.h
@@ -41,6 +41,10 @@ class SmartProjectionCumulativeFactorAdder : public CumulativeFactorAdder<SmartP
     const FeatureTrackLengthMap& feature_tracks, const int spacing, const double feature_track_min_separation,
     FactorsToAdd& smart_factors_to_add,
     std::unordered_map<localization_measurements::FeatureId, localization_measurements::FeaturePoint>& added_points);
+  void AddAllowedFactors(
+    const FeatureTrackLengthMap& feature_tracks, const double feature_track_min_separation,
+    FactorsToAdd& smart_factors_to_add,
+    std::unordered_map<localization_measurements::FeatureId, localization_measurements::FeaturePoint>& added_points);
 
  private:
   void AddSmartFactor(const std::vector<localization_measurements::FeaturePoint>& feature_track_points,

--- a/localization/graph_localizer/include/graph_localizer/smart_projection_factor_adder_params.h
+++ b/localization/graph_localizer/include/graph_localizer/smart_projection_factor_adder_params.h
@@ -45,6 +45,7 @@ struct SmartProjectionFactorAdderParams : public FactorAdderParams {
   bool splitting;
   bool scale_noise_with_num_points;
   double noise_scale;
+  bool use_allowed_timestamps;
   gtsam::Pose3 body_T_cam;
   boost::shared_ptr<gtsam::Cal3_S2> cam_intrinsics;
   gtsam::SharedIsotropic cam_noise;

--- a/localization/graph_localizer/include/graph_localizer/utilities.h
+++ b/localization/graph_localizer/include/graph_localizer/utilities.h
@@ -51,7 +51,7 @@ namespace graph_localizer {
 bool ValidPointSet(const int num_points, const double average_distance_from_mean,
                    const double min_avg_distance_from_mean, const int min_num_points);
 
-double AverageDistanceFromMean(const FeatureTrack::Points& points);
+double AverageDistanceFromMean(const std::vector<localization_measurements::FeaturePoint>& points);
 
 bool ValidVLMsg(const ff_msgs::VisualLandmarks& visual_landmarks_msg, const int min_num_landmarks);
 

--- a/localization/graph_localizer/src/feature_track.cc
+++ b/localization/graph_localizer/src/feature_track.cc
@@ -42,6 +42,16 @@ size_t FeatureTrack::size() const { return points_.size(); }
 
 bool FeatureTrack::empty() const { return points_.empty(); }
 
+std::vector<lm::FeaturePoint> FeatureTrack::AllowedPoints(const std::set<lc::Time>& allowed_timestamps) const {
+  std::vector<lm::FeaturePoint> allowed_points;
+  // Start with oldest points
+  for (auto point_it = points_.rbegin(); point_it != points_.rend(); ++point_it) {
+    if (allowed_timestamps.count(point_it->second.timestamp) <= 0) continue;
+    allowed_points.emplace_back(point_it->second);
+  }
+  return allowed_points;
+}
+
 std::vector<lm::FeaturePoint> FeatureTrack::LatestPoints(const int spacing) const {
   std::vector<lm::FeaturePoint> latest_points;
   int i = 0;

--- a/localization/graph_localizer/src/feature_track.cc
+++ b/localization/graph_localizer/src/feature_track.cc
@@ -45,7 +45,7 @@ bool FeatureTrack::empty() const { return points_.empty(); }
 std::vector<lm::FeaturePoint> FeatureTrack::AllowedPoints(const std::set<lc::Time>& allowed_timestamps) const {
   std::vector<lm::FeaturePoint> allowed_points;
   // Start with oldest points
-  for (auto point_it = points_.rbegin(); point_it != points_.rend(); ++point_it) {
+  for (auto point_it = points_.begin(); point_it != points_.end(); ++point_it) {
     if (allowed_timestamps.count(point_it->second.timestamp) <= 0) continue;
     allowed_points.emplace_back(point_it->second);
   }
@@ -56,7 +56,7 @@ std::vector<lm::FeaturePoint> FeatureTrack::LatestPoints(const int spacing) cons
   std::vector<lm::FeaturePoint> latest_points;
   int i = 0;
   // Start with latest points
-  for (auto point_it = points_.begin(); point_it != points_.end(); ++point_it) {
+  for (auto point_it = points_.rbegin(); point_it != points_.rend(); ++point_it) {
     if (i++ % (spacing + 1) != 0) continue;
     latest_points.push_back(point_it->second);
   }

--- a/localization/graph_localizer/src/feature_track.cc
+++ b/localization/graph_localizer/src/feature_track.cc
@@ -55,7 +55,8 @@ std::vector<lm::FeaturePoint> FeatureTrack::AllowedPoints(const std::set<lc::Tim
 std::vector<lm::FeaturePoint> FeatureTrack::LatestPoints(const int spacing) const {
   std::vector<lm::FeaturePoint> latest_points;
   int i = 0;
-  for (auto point_it = points_.rbegin(); point_it != points_.rend(); ++point_it) {
+  // Start with latest points
+  for (auto point_it = points_.begin(); point_it != points_.end(); ++point_it) {
     if (i++ % (spacing + 1) != 0) continue;
     latest_points.push_back(point_it->second);
   }

--- a/localization/graph_localizer/src/feature_track.cc
+++ b/localization/graph_localizer/src/feature_track.cc
@@ -52,6 +52,19 @@ std::vector<lm::FeaturePoint> FeatureTrack::AllowedPoints(const std::set<lc::Tim
   return allowed_points;
 }
 
+std::vector<lm::FeaturePoint> FeatureTrack::LatestPointsInWindow(const double duration) const {
+  std::vector<lm::FeaturePoint> latest_points;
+  const auto latest_timestamp = LatestTimestamp();
+  if (!latest_timestamp) return {};
+  const lc::Time oldest_allowed_time = *latest_timestamp - duration;
+  // Start with latest points
+  for (auto point_it = points_.rbegin(); point_it != points_.rend(); ++point_it) {
+    if (point_it->second.timestamp < oldest_allowed_time) break;
+    latest_points.push_back(point_it->second);
+  }
+  return latest_points;
+}
+
 std::vector<lm::FeaturePoint> FeatureTrack::LatestPoints(const int spacing) const {
   std::vector<lm::FeaturePoint> latest_points;
   int i = 0;

--- a/localization/graph_localizer/src/feature_tracker.cc
+++ b/localization/graph_localizer/src/feature_tracker.cc
@@ -42,10 +42,10 @@ void FeatureTracker::UpdateFeatureTracks(const lm::FeaturePoints& feature_points
   const auto feature_points_timestamp = feature_points.front().timestamp;
   RemoveUndetectedFeatures(feature_points_timestamp);
   UpdateLengthMap();
+  UpdateAllowList(feature_points.front().timestamp);
   const int removed_num_feature_tracks = post_add_num_feature_tracks - size();
   LogDebug("UpdateFeatureTracks: Removed feature tracks: " << removed_num_feature_tracks);
   LogDebug("UpdateFeatureTracks: Final total num feature tracks: " << size());
-  UpdateAllowList(feature_points.front().feature_id);
 }
 
 void FeatureTracker::UpdateAllowList(const lc::Time& timestamp) {

--- a/localization/graph_localizer/src/graph_localizer.cc
+++ b/localization/graph_localizer/src/graph_localizer.cc
@@ -310,7 +310,9 @@ void GraphLocalizer::CheckForStandstill() {
   double total_average_distance_from_mean = 0;
   int num_valid_feature_tracks = 0;
   for (const auto& feature_track : feature_tracker_->feature_tracks()) {
-    const double average_distance_from_mean = AverageDistanceFromMean(feature_track.second->points());
+    // TODO(rsoussan): Use allowed points or all points?
+    const double average_distance_from_mean = AverageDistanceFromMean(
+      feature_track.second->AllowedPoints(feature_tracker_->smart_factor_timestamp_allow_list()));
     // Only consider long enough feature tracks for standstill candidates
     if (static_cast<int>(feature_track.second->size()) >= params_.standstill_min_num_points_per_track) {
       total_average_distance_from_mean += average_distance_from_mean;

--- a/localization/graph_localizer/src/graph_localizer.cc
+++ b/localization/graph_localizer/src/graph_localizer.cc
@@ -310,9 +310,8 @@ void GraphLocalizer::CheckForStandstill() {
   double total_average_distance_from_mean = 0;
   int num_valid_feature_tracks = 0;
   for (const auto& feature_track : feature_tracker_->feature_tracks()) {
-    // TODO(rsoussan): Use allowed points or all points?
-    const double average_distance_from_mean = AverageDistanceFromMean(
-      feature_track.second->AllowedPoints(feature_tracker_->smart_factor_timestamp_allow_list()));
+    const double average_distance_from_mean =
+      AverageDistanceFromMean(feature_track.second->LatestPointsInWindow(params_.standstill_feature_track_duration));
     // Only consider long enough feature tracks for standstill candidates
     if (static_cast<int>(feature_track.second->size()) >= params_.standstill_min_num_points_per_track) {
       total_average_distance_from_mean += average_distance_from_mean;

--- a/localization/graph_localizer/src/graph_localizer_nodelet.cc
+++ b/localization/graph_localizer/src/graph_localizer_nodelet.cc
@@ -32,8 +32,7 @@ namespace graph_localizer {
 namespace lc = localization_common;
 namespace mc = msg_conversions;
 
-GraphLocalizerNodelet::GraphLocalizerNodelet()
-    : ff_util::FreeFlyerNodelet(NODE_GRAPH_LOC, true) {
+GraphLocalizerNodelet::GraphLocalizerNodelet() : ff_util::FreeFlyerNodelet(NODE_GRAPH_LOC, true) {
   private_nh_.setCallbackQueue(&private_queue_);
   heartbeat_.node = GetName();
   heartbeat_.nodelet_manager = ros::this_node::getName();

--- a/localization/graph_localizer/src/parameter_reader.cc
+++ b/localization/graph_localizer/src/parameter_reader.cc
@@ -163,10 +163,6 @@ void LoadFeatureTrackerParams(config_reader::ConfigReader& config, FeatureTracke
   params.smart_projection_adder_measurement_spacing = mc::LoadInt(config, "smart_projection_adder_measurement_spacing");
 }
 
-void LoadStandstillFeatureTrackerParams(config_reader::ConfigReader& config, FeatureTrackerParams& params) {
-  params.sliding_window_duration = mc::LoadDouble(config, "standstill_feature_tracker_sliding_window_duration");
-}
-
 void LoadGraphValuesParams(config_reader::ConfigReader& config, GraphValuesParams& params) {
   params.ideal_duration = mc::LoadDouble(config, "ideal_duration");
   params.min_num_states = mc::LoadInt(config, "min_num_states");
@@ -204,7 +200,6 @@ void LoadGraphLocalizerParams(config_reader::ConfigReader& config, GraphLocalize
   LoadGraphInitializerParams(config, params.graph_initializer);
   LoadFactorParams(config, params.factor);
   LoadFeatureTrackerParams(config, params.feature_tracker);
-  LoadStandstillFeatureTrackerParams(config, params.standstill_feature_tracker);
   LoadGraphValuesParams(config, params.graph_values);
   LoadNoiseParams(config, params.noise);
   params.verbose = mc::LoadBool(config, "verbose");
@@ -222,6 +217,7 @@ void LoadGraphLocalizerParams(config_reader::ConfigReader& config, GraphLocalize
     mc::LoadDouble(config, "max_standstill_feature_track_avg_distance_from_mean");
   params.standstill_min_num_points_per_track = mc::LoadInt(config, "standstill_min_num_points_per_track");
   params.log_rate = mc::LoadInt(config, "log_rate");
+  params.standstill_feature_track_duration = mc::LoadDouble(config, "standstill_feature_track_duration");
   params.estimate_world_T_dock_using_loc = mc::LoadBool(config, "estimate_world_T_dock_using_loc");
 }
 

--- a/localization/graph_localizer/src/parameter_reader.cc
+++ b/localization/graph_localizer/src/parameter_reader.cc
@@ -139,6 +139,7 @@ void LoadSmartProjectionFactorAdderParams(config_reader::ConfigReader& config,
   params.splitting = mc::LoadBool(config, "smart_projection_adder_splitting");
   params.scale_noise_with_num_points = mc::LoadBool(config, "smart_projection_adder_scale_noise_with_num_points");
   params.noise_scale = mc::LoadDouble(config, "smart_projection_adder_noise_scale");
+  params.use_allowed_timestamps = mc::LoadBool(config, "smart_projection_adder_use_allowed_timestamps");
   params.body_T_cam = lc::LoadTransform(config, "nav_cam_transform");
   params.cam_intrinsics.reset(new gtsam::Cal3_S2(lc::LoadCameraIntrinsics(config, "nav_cam")));
   params.cam_noise =
@@ -159,6 +160,7 @@ void LoadStandstillFactorAdderParams(config_reader::ConfigReader& config, Stands
 
 void LoadFeatureTrackerParams(config_reader::ConfigReader& config, FeatureTrackerParams& params) {
   params.sliding_window_duration = mc::LoadDouble(config, "feature_tracker_sliding_window_duration");
+  params.smart_projection_adder_measurement_spacing = mc::LoadInt(config, "smart_projection_adder_measurement_spacing");
 }
 
 void LoadStandstillFeatureTrackerParams(config_reader::ConfigReader& config, FeatureTrackerParams& params) {

--- a/localization/graph_localizer/src/smart_projection_cumulative_factor_adder.cc
+++ b/localization/graph_localizer/src/smart_projection_cumulative_factor_adder.cc
@@ -49,7 +49,7 @@ void SmartProjectionCumulativeFactorAdder::AddFactors(
     const auto points = feature_track.LatestPoints(spacing);
     // Skip already added tracks
     if (added_points.count(points.front().feature_id) > 0) continue;
-    const double average_distance_from_mean = AverageDistanceFromMean(feature_track.points());
+    const double average_distance_from_mean = AverageDistanceFromMean(points);
     if (ValidPointSet(points.size(), average_distance_from_mean, params().min_avg_distance_from_mean,
                       params().min_num_points) &&
         !TooClose(added_points, points.front(), feature_track_min_separation)) {
@@ -66,7 +66,7 @@ std::vector<FactorsToAdd> SmartProjectionCumulativeFactorAdder::AddFactors() {
   if (params().use_allowed_timestamps) {
     for (const auto& feature_track : feature_tracker_->feature_tracks()) {
       const auto points = feature_track.second->AllowedPoints(feature_tracker_->smart_factor_timestamp_allow_list());
-      const double average_distance_from_mean = AverageDistanceFromMean(feature_track.second->points());
+      const double average_distance_from_mean = AverageDistanceFromMean(points);
       if (ValidPointSet(points.size(), average_distance_from_mean, params().min_avg_distance_from_mean,
                         params().min_num_points) &&
           static_cast<int>(smart_factors_to_add.size()) < params().max_num_factors) {

--- a/localization/graph_localizer/src/smart_projection_cumulative_factor_adder.cc
+++ b/localization/graph_localizer/src/smart_projection_cumulative_factor_adder.cc
@@ -89,6 +89,7 @@ std::vector<FactorsToAdd> SmartProjectionCumulativeFactorAdder::AddFactors() {
       AddFactors(feature_tracks, spacing, 0, smart_factors_to_add, added_points);
     }
   }
+  if (smart_factors_to_add.empty()) return {};
   const auto latest_timestamp = feature_tracker_->LatestTimestamp();
   if (!latest_timestamp) {
     LogError("AddFactors: Failed to get latest timestamp.");

--- a/localization/graph_localizer/src/smart_projection_cumulative_factor_adder.cc
+++ b/localization/graph_localizer/src/smart_projection_cumulative_factor_adder.cc
@@ -69,7 +69,7 @@ std::vector<FactorsToAdd> SmartProjectionCumulativeFactorAdder::AddFactors() {
       const double average_distance_from_mean = AverageDistanceFromMean(feature_track.second->points());
       if (ValidPointSet(points.size(), average_distance_from_mean, params().min_avg_distance_from_mean,
                         params().min_num_points) &&
-          smart_factors_to_add.size() < params().max_num_factors) {
+          static_cast<int>(smart_factors_to_add.size()) < params().max_num_factors) {
         AddSmartFactor(points, smart_factors_to_add);
       }
     }

--- a/localization/graph_localizer/src/smart_projection_cumulative_factor_adder.cc
+++ b/localization/graph_localizer/src/smart_projection_cumulative_factor_adder.cc
@@ -63,19 +63,31 @@ void SmartProjectionCumulativeFactorAdder::AddFactors(
 std::vector<FactorsToAdd> SmartProjectionCumulativeFactorAdder::AddFactors() {
   // Add smart factor for each valid feature track
   FactorsToAdd smart_factors_to_add(GraphAction::kDeleteExistingSmartFactors);
-  const auto& feature_tracks = feature_tracker_->feature_tracks_length_ordered();
-  const auto& longest_feature_track = feature_tracker_->LongestFeatureTrack();
-  if (!longest_feature_track) {
-    LogDebug("AddFactors: Failed to get longest feature track.");
-    return {};
-  }
-  const int spacing = longest_feature_track->MaxSpacing(params().max_num_points_per_factor);
+  if (params().use_allowed_timestamps) {
+    for (const auto& feature_track : feature_tracker_->feature_tracks()) {
+      const auto points = feature_track.second->AllowedPoints(feature_tracker_->smart_factor_timestamp_allow_list());
+      const double average_distance_from_mean = AverageDistanceFromMean(feature_track.second->points());
+      if (ValidPointSet(points.size(), average_distance_from_mean, params().min_avg_distance_from_mean,
+                        params().min_num_points) &&
+          smart_factors_to_add.size() < params().max_num_factors) {
+        AddSmartFactor(points, smart_factors_to_add);
+      }
+    }
+  } else {
+    const auto& feature_tracks = feature_tracker_->feature_tracks_length_ordered();
+    const auto& longest_feature_track = feature_tracker_->LongestFeatureTrack();
+    if (!longest_feature_track) {
+      LogDebug("AddFactors: Failed to get longest feature track.");
+      return {};
+    }
+    const int spacing = longest_feature_track->MaxSpacing(params().max_num_points_per_factor);
 
-  std::unordered_map<lm::FeatureId, lm::FeaturePoint> added_points;
-  AddFactors(feature_tracks, spacing, params().feature_track_min_separation, smart_factors_to_add, added_points);
-  if (static_cast<int>(smart_factors_to_add.size()) < params().max_num_factors) {
-    // Zero min separation so any valid feature track is added as a fallback to try to add up to max_num_factors
-    AddFactors(feature_tracks, spacing, 0, smart_factors_to_add, added_points);
+    std::unordered_map<lm::FeatureId, lm::FeaturePoint> added_points;
+    AddFactors(feature_tracks, spacing, params().feature_track_min_separation, smart_factors_to_add, added_points);
+    if (static_cast<int>(smart_factors_to_add.size()) < params().max_num_factors) {
+      // Zero min separation so any valid feature track is added as a fallback to try to add up to max_num_factors
+      AddFactors(feature_tracks, spacing, 0, smart_factors_to_add, added_points);
+    }
   }
   const auto latest_timestamp = feature_tracker_->LatestTimestamp();
   if (!latest_timestamp) {

--- a/localization/graph_localizer/src/utilities.cc
+++ b/localization/graph_localizer/src/utilities.cc
@@ -39,17 +39,17 @@ bool ValidPointSet(const int num_points, const double average_distance_from_mean
   return (average_distance_from_mean >= min_avg_distance_from_mean);
 }
 
-double AverageDistanceFromMean(const FeatureTrack::Points& points) {
+double AverageDistanceFromMean(const std::vector<lm::FeaturePoint>& points) {
   // Calculate mean point and avg distance from mean
   Eigen::Vector2d sum_of_points = Eigen::Vector2d::Zero();
   for (const auto& point : points) {
-    sum_of_points += point.second.image_point;
+    sum_of_points += point.image_point;
   }
   const Eigen::Vector2d mean_point = sum_of_points / points.size();
 
   double sum_of_distances_from_mean = 0;
   for (const auto& point : points) {
-    const Eigen::Vector2d mean_centered_point = point.second.image_point - mean_point;
+    const Eigen::Vector2d mean_centered_point = point.image_point - mean_point;
     sum_of_distances_from_mean += mean_centered_point.norm();
   }
   const double average_distance_from_mean = sum_of_distances_from_mean / points.size();

--- a/localization/graph_localizer/src/utilities.cc
+++ b/localization/graph_localizer/src/utilities.cc
@@ -80,7 +80,7 @@ ff_msgs::GraphState GraphStateMsg(const lc::CombinedNavState& combined_nav_state
 
   // Set Confidence
   // Controller can't handle a confidence other than 0.  TODO(rsoussan): switch back when this is fixed.
-  loc_msg.confidence = 0; //covariances.PoseConfidence(position_log_det_threshold, orientation_log_det_threshold);
+  loc_msg.confidence = 0;  // covariances.PoseConfidence(position_log_det_threshold, orientation_log_det_threshold);
 
   // Set Graph Feature Counts/Information
   loc_msg.num_detected_of_features = detected_feature_counts.of;

--- a/localization/graph_localizer/src/utilities.cc
+++ b/localization/graph_localizer/src/utilities.cc
@@ -79,7 +79,8 @@ ff_msgs::GraphState GraphStateMsg(const lc::CombinedNavState& combined_nav_state
   lc::CombinedNavStateCovariancesToMsg(covariances, loc_msg);
 
   // Set Confidence
-  loc_msg.confidence = covariances.PoseConfidence(position_log_det_threshold, orientation_log_det_threshold);
+  // Controller can't handle a confidence other than 0.  TODO(rsoussan): switch back when this is fixed.
+  loc_msg.confidence = 0; //covariances.PoseConfidence(position_log_det_threshold, orientation_log_det_threshold);
 
   // Set Graph Feature Counts/Information
   loc_msg.num_detected_of_features = detected_feature_counts.of;

--- a/localization/imu_augmentor/src/imu_augmentor_nodelet.cc
+++ b/localization/imu_augmentor/src/imu_augmentor_nodelet.cc
@@ -27,8 +27,7 @@
 namespace imu_augmentor {
 namespace lc = localization_common;
 
-ImuAugmentorNodelet::ImuAugmentorNodelet()
-    : ff_util::FreeFlyerNodelet(NODE_IMU_AUG, true) {
+ImuAugmentorNodelet::ImuAugmentorNodelet() : ff_util::FreeFlyerNodelet(NODE_IMU_AUG, true) {
   imu_nh_.setCallbackQueue(&imu_queue_);
   loc_nh_.setCallbackQueue(&loc_queue_);
   heartbeat_.node = GetName();

--- a/tools/graph_bag/include/graph_bag/graph_bag.h
+++ b/tools/graph_bag/include/graph_bag/graph_bag.h
@@ -49,14 +49,6 @@ class GraphBag {
   void InitializeGraph();
   void SaveOpticalFlowTracksImage(const sensor_msgs::ImageConstPtr& image_msg,
                                   const GraphLocalizerSimulator& graph_localizer);
-  void SaveImuBiasTesterPredictedStates(
-    const std::vector<localization_common::CombinedNavState>& imu_bias_tester_predicted_states);
-  template <typename MsgType>
-  void SaveMsg(const MsgType& msg, const std::string& topic) {
-    const ros::Time timestamp = localization_common::RosTimeFromHeader(msg.header);
-    results_bag_.write("/" + topic, timestamp, msg);
-  }
-
   std::unique_ptr<GraphLocalizerSimulator> graph_localizer_simulator_;
   std::unique_ptr<LiveMeasurementSimulator> live_measurement_simulator_;
   rosbag::Bag results_bag_;

--- a/tools/graph_bag/include/graph_bag/imu_bias_tester_adder.h
+++ b/tools/graph_bag/include/graph_bag/imu_bias_tester_adder.h
@@ -1,0 +1,42 @@
+/* Copyright (c) 2017, United States Government, as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ *
+ * All rights reserved.
+ *
+ * The Astrobee platform is licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef GRAPH_BAG_IMU_BIAS_TESTER_ADDER_H_
+#define GRAPH_BAG_IMU_BIAS_TESTER_ADDER_H_
+
+#include <imu_bias_tester/imu_bias_tester_wrapper.h>
+
+#include <rosbag/bag.h>
+#include <rosbag/view.h>
+
+#include <string>
+
+namespace graph_bag {
+class ImuBiasTesterAdder {
+ public:
+  ImuBiasTesterAdder(const std::string& input_bag_name, const std::string& output_bag_name);
+  void AddPredictions();
+
+ private:
+  imu_bias_tester::ImuBiasTesterWrapper imu_bias_tester_wrapper_;
+  rosbag::Bag input_bag_;
+  rosbag::Bag output_bag_;
+};
+}  // end namespace graph_bag
+
+#endif  // GRAPH_BAG_IMU_BIAS_TESTER_ADDER_H_

--- a/tools/graph_bag/include/graph_bag/live_measurement_simulator.h
+++ b/tools/graph_bag/include/graph_bag/live_measurement_simulator.h
@@ -56,8 +56,6 @@ class LiveMeasurementSimulator {
   boost::optional<ff_msgs::FlightMode> GetFlightModeMessage(const localization_common::Time current_time);
 
  private:
-  bool string_ends_with(const std::string& str, const std::string& ending);
-
   ff_msgs::Feature2dArray GenerateOFFeatures(const sensor_msgs::ImageConstPtr& image_msg);
 
   bool GenerateVLFeatures(const sensor_msgs::ImageConstPtr& image_msg, ff_msgs::VisualLandmarks& vl_features);

--- a/tools/graph_bag/include/graph_bag/utilities.h
+++ b/tools/graph_bag/include/graph_bag/utilities.h
@@ -28,6 +28,7 @@
 #include <rosbag/bag.h>
 #include <sensor_msgs/Image.h>
 
+#include <string>
 #include <vector>
 
 namespace graph_bag {

--- a/tools/graph_bag/include/graph_bag/utilities.h
+++ b/tools/graph_bag/include/graph_bag/utilities.h
@@ -21,9 +21,11 @@
 #include <camera/camera_params.h>
 #include <graph_localizer/feature_tracker.h>
 #include <graph_localizer/graph_localizer.h>
+#include <localization_common/utilities.h>
 
 #include <opencv2/core/mat.hpp>
 
+#include <rosbag/bag.h>
 #include <sensor_msgs/Image.h>
 
 #include <vector>
@@ -46,6 +48,17 @@ boost::optional<sensor_msgs::ImagePtr> CreateFeatureTrackImage(
 cv::Point Distort(const Eigen::Vector2d& undistorted_point, const camera::CameraParameters& params);
 
 std::vector<const SmartFactor*> SmartFactors(const graph_localizer::GraphLocalizer& graph);
+
+bool string_ends_with(const std::string& str, const std::string& ending);
+
+void SaveImuBiasTesterPredictedStates(
+  const std::vector<localization_common::CombinedNavState>& imu_bias_tester_predicted_states, rosbag::Bag& bag);
+
+template <typename MsgType>
+void SaveMsg(const MsgType& msg, const std::string& topic, rosbag::Bag& bag) {
+  const ros::Time timestamp = localization_common::RosTimeFromHeader(msg.header);
+  bag.write("/" + topic, timestamp, msg);
+}
 }  // namespace graph_bag
 
 #endif  // GRAPH_BAG_UTILITIES_H_

--- a/tools/graph_bag/scripts/merge_all_bags.py
+++ b/tools/graph_bag/scripts/merge_all_bags.py
@@ -29,6 +29,7 @@ import rosbag
 if __name__ == '__main__':
   parser = argparse.ArgumentParser()
   parser.add_argument('--merged-bag', default='')
+  parser.add_argument('--only-loc-topics', dest='only_loc_topics', action='store_true')
   args = parser.parse_args()
 
   # Find bagfiles with bag prefix in current directory, fail if none found
@@ -44,4 +45,4 @@ if __name__ == '__main__':
     print('Found ' + str(len(bag_names)) + ' bag file prefixes.')
 
   for bag_name in bag_names:
-    merge_bags.merge_bag(bag_name, args.merged_bag)
+    merge_bags.merge_bag(bag_name, args.merged_bag, args.only_loc_topics)

--- a/tools/graph_bag/scripts/merge_bags.py
+++ b/tools/graph_bag/scripts/merge_bags.py
@@ -31,7 +31,7 @@ def natural_sort(l):
   return sorted(l, key=alphanum_key)
 
 
-def merge_bag(input_bag_prefix, merged_bag):
+def merge_bag(input_bag_prefix, merged_bag, only_loc_topics=False):
   # Find bagfiles with bag prefix in current directory, fail if none found
   bag_names = [
     bag for bag in os.listdir('.') if os.path.isfile(bag) and bag.startswith(input_bag_prefix) and bag.endswith('.bag')
@@ -48,10 +48,13 @@ def merge_bag(input_bag_prefix, merged_bag):
 
   sorted_bag_names = natural_sort(bag_names)
 
-  topics = [
-    '/hw/imu', '/loc/of/features', '/loc/ml/features', '/loc/ar/features', '/mgt/img_sampler/nav_cam/image_record',
-    '/graph_loc/state', '/gnc/ekf', '/sparse_mapping/pose', '/mob/flight_mode', '/beh/inspection/feedback', '/beh/inspection/goal', '/beh/inspection/result'
-  ]
+  topics = None
+  if only_loc_topics:
+    topics = [
+      '/hw/imu', '/loc/of/features', '/loc/ml/features', '/loc/ar/features', '/mgt/img_sampler/nav_cam/image_record',
+      '/graph_loc/state', '/gnc/ekf', '/sparse_mapping/pose', '/mob/flight_mode', '/beh/inspection/feedback',
+      '/beh/inspection/goal', '/beh/inspection/result'
+    ]
 
   with rosbag.Bag(merged_bag_name, 'w') as merged_bag:
     for sorted_bag_name in sorted_bag_names:
@@ -64,5 +67,7 @@ if __name__ == '__main__':
   parser = argparse.ArgumentParser()
   parser.add_argument('input_bag_prefix')
   parser.add_argument('--merged-bag', default='')
+  parser.add_argument('--only-loc-topics', dest='only_loc_topics', action='store_true')
+  parser.add_argument('--merged-bag', default='')
   args = parser.parse_args()
-  merge_bag(args.input_bag_prefix, args.merged_bag)
+  merge_bag(args.input_bag_prefix, args.merged_bag, args.only_loc_topics)

--- a/tools/graph_bag/scripts/plot_bag_sweep_results.py
+++ b/tools/graph_bag/scripts/plot_bag_sweep_results.py
@@ -132,15 +132,23 @@ def create_plot(output_file, csv_file, label_1='', csv_file_2=None, label_2='', 
   dataframe.sort_values(by=['Bag'], inplace=True)
   # Graph rmses
   rmses = dataframe['rmse']
+  rel_rmses = dataframe['rel_rmse']
   integrated_rmses = dataframe['integrated_rmse']
+  rel_integrated_rmses = dataframe['rel_integrated_rmse']
   orientation_rmses = dataframe['orientation_rmse']
+  rel_orientation_rmses = dataframe['rel_orientation_rmse']
   # IMU augmented rmses
   imu_augmented_rmses = dataframe['imu_augmented_rmse']
+  rel_imu_augmented_rmses = dataframe['rel_imu_augmented_rmse']
   imu_augmented_integrated_rmses = dataframe['imu_augmented_integrated_rmse']
+  rel_imu_augmented_integrated_rmses = dataframe['rel_imu_augmented_integrated_rmse']
   imu_augmented_orientation_rmses = dataframe['imu_augmented_orientation_rmse']
+  rel_imu_augmented_orientation_rmses = dataframe['rel_imu_augmented_orientation_rmse']
   # IMU bias tester rmses
   imu_bias_tester_rmses = dataframe['imu_bias_tester_rmse']
+  rel_imu_bias_tester_rmses = dataframe['rel_imu_bias_tester_rmse']
   imu_bias_tester_orientation_rmses = dataframe['imu_bias_tester_orientation_rmse']
+  rel_imu_bias_tester_orientation_rmses = dataframe['rel_imu_bias_tester_orientation_rmse']
 
   bag_names = dataframe['Bag'].tolist()
   max_name_length = 45
@@ -149,29 +157,45 @@ def create_plot(output_file, csv_file, label_1='', csv_file_2=None, label_2='', 
   ]
   x_axis_vals = range(len(shortened_bag_names))
   rmses_2 = None
+  rel_rmses_2 = None
   integrated_rmses_2 = None
+  rel_integrated_rmses_2 = None
   orientation_rmses_2 = None
+  rel_orientation_rmses_2 = None
   imu_augmented_rmses_2 = None
+  rel_imu_augmented_rmses_2 = None
   imu_augmented_integrated_rmses_2 = None
+  rel_imu_augmented_integrated_rmses_2 = None
   imu_augmented_orientation_rmses_2 = None
+  rel_imu_augmented_orientation_rmses_2 = None
   imu_bias_tester_rmses_2 = None
+  rel_imu_bias_tester_rmses_2 = None
   imu_bias_tester_orientation_rmses_2 = None
+  rel_imu_bias_tester_orientation_rmses_2 = None
 
   if (csv_file_2):
     dataframe_2 = pd.read_csv(csv_file_2)
     dataframe_2.sort_values(by=['Bag'], inplace=True)
     # Graph rmses
     rmses_2 = dataframe_2['rmse']
+    rel_rmses_2 = dataframe_2['rel_rmse']
     integrated_rmses_2 = dataframe_2['integrated_rmse']
+    rel_integrated_rmses_2 = dataframe_2['rel_integrated_rmse']
     orientation_rmses_2 = dataframe_2['orientation_rmse']
+    rel_orientation_rmses_2 = dataframe_2['rel_orientation_rmse']
     if (imu_augmented_2):
       # IMU augmented rmses
       imu_augmented_rmses_2 = dataframe_2['imu_augmented_rmse']
+      rel_imu_augmented_rmses_2 = dataframe_2['rel_imu_augmented_rmse']
       imu_augmented_integrated_rmses_2 = dataframe_2['imu_augmented_integrated_rmse']
+      rel_imu_augmented_integrated_rmses_2 = dataframe_2['rel_imu_augmented_integrated_rmse']
       imu_augmented_orientation_rmses_2 = dataframe_2['imu_augmented_orientation_rmse']
+      rel_imu_augmented_orientation_rmses_2 = dataframe_2['rel_imu_augmented_orientation_rmse']
       # IMU bias tester rmses
       imu_bias_tester_rmses_2 = dataframe_2['imu_bias_tester_rmse']
+      rel_imu_bias_tester_rmses_2 = dataframe_2['rel_imu_bias_tester_rmse']
       imu_bias_tester_orientation_rmses_2 = dataframe_2['imu_bias_tester_orientation_rmse']
+      rel_imu_bias_tester_orientation_rmses_2 = dataframe_2['rel_imu_bias_tester_orientation_rmse']
 
     bag_names_2 = dataframe_2['Bag'].tolist()
     if bag_names != bag_names_2:
@@ -180,20 +204,35 @@ def create_plot(output_file, csv_file, label_1='', csv_file_2=None, label_2='', 
   with PdfPages(output_file) as pdf:
     rmse_plots(pdf, x_axis_vals, shortened_bag_names, rmses, integrated_rmses, orientation_rmses, '', label_1, rmses_2,
                integrated_rmses_2, orientation_rmses_2, label_2)
+    rmse_plots(pdf, x_axis_vals, shortened_bag_names, rel_rmses, rel_integrated_rmses, rel_orientation_rmses, 'rel',
+               label_1, rel_rmses_2, rel_integrated_rmses_2, rel_orientation_rmses_2, label_2)
     if imu_augmented_2:
       rmse_plots(pdf, x_axis_vals, shortened_bag_names, imu_augmented_rmses, imu_augmented_integrated_rmses,
                  imu_augmented_orientation_rmses, 'imu_augmented', label_1, imu_augmented_rmses_2,
                  imu_augmented_integrated_rmses_2, imu_augmented_orientation_rmses_2, label_2)
+      rmse_plots(pdf, x_axis_vals, shortened_bag_names, rel_imu_augmented_rmses, rel_imu_augmented_integrated_rmses,
+                 rel_imu_augmented_orientation_rmses, 'rel_imu_augmented', label_1, rel_imu_augmented_rmses_2,
+                 rel_imu_augmented_integrated_rmses_2, rel_imu_augmented_orientation_rmses_2, label_2)
       rmse_plots(pdf, x_axis_vals, shortened_bag_names, imu_bias_tester_rmses, None, imu_bias_tester_orientation_rmses,
                  'imu_bias_tester', label_1, imu_bias_tester_rmses_2, None, imu_bias_tester_orientation_rmses_2,
                  label_2)
+      rmse_plots(pdf, x_axis_vals, shortened_bag_names, rel_imu_bias_tester_rmses, None,
+                 rel_imu_bias_tester_orientation_rmses, 'rel_imu_bias_tester', label_1, rel_imu_bias_tester_rmses_2,
+                 None, rel_imu_bias_tester_orientation_rmses_2, label_2)
+
     else:
       rmse_plots(pdf, x_axis_vals, shortened_bag_names, imu_augmented_rmses, imu_augmented_integrated_rmses,
                  imu_augmented_orientation_rmses, 'imu_augmented', label_1, rmses_2, integrated_rmses_2,
                  orientation_rmses_2, label_2 + ' no imu aug')
+      rmse_plots(pdf, x_axis_vals, shortened_bag_names, rel_imu_augmented_rmses, rel_imu_augmented_integrated_rmses,
+                 rel_imu_augmented_orientation_rmses, 'rel_imu_augmented', label_1, rel_rmses_2, rel_integrated_rmses_2,
+                 rel_orientation_rmses_2, label_2 + ' no imu aug')
       rmse_plots(pdf, x_axis_vals, shortened_bag_names, imu_bias_tester_rmses, None, imu_bias_tester_orientation_rmses,
                  'imu_bias_tester', label_1, imu_bias_tester_rmses_2, None, imu_bias_tester_orientation_rmses_2,
                  label_2)
+      rmse_plots(pdf, x_axis_vals, shortened_bag_names, rel_imu_bias_tester_rmses, None,
+                 rel_imu_bias_tester_orientation_rmses, 'rel_imu_bias_tester', label_1, rel_imu_bias_tester_rmses_2,
+                 None, rel_imu_bias_tester_orientation_rmses_2, label_2)
 
 
 if __name__ == '__main__':

--- a/tools/graph_bag/scripts/plot_parameter_sweep_results.py
+++ b/tools/graph_bag/scripts/plot_parameter_sweep_results.py
@@ -86,13 +86,22 @@ def create_plots(output_file, csv_file, value_combos_file):
     create_plot(pdf, csv_file, value_combos_file)
     create_plot(pdf, csv_file, value_combos_file, 'orientation_')
     create_plot(pdf, csv_file, value_combos_file, 'integrated_')
+    create_plot(pdf, csv_file, value_combos_file, 'rel_')
+    create_plot(pdf, csv_file, value_combos_file, 'rel_orientation_')
+    create_plot(pdf, csv_file, value_combos_file, 'rel_integrated_')
     # IMU Augmented RMSEs
     create_plot(pdf, csv_file, value_combos_file, 'imu_augmented_')
     create_plot(pdf, csv_file, value_combos_file, 'imu_augmented_orientation_')
     create_plot(pdf, csv_file, value_combos_file, 'imu_augmented_integrated_')
+    create_plot(pdf, csv_file, value_combos_file, 'rel_imu_augmented_')
+    create_plot(pdf, csv_file, value_combos_file, 'rel_imu_augmented_orientation_')
+    create_plot(pdf, csv_file, value_combos_file, 'rel_imu_augmented_integrated_')
+
     # IMU Bias Tester RMSEs
     create_plot(pdf, csv_file, value_combos_file, 'imu_bias_tester_')
     create_plot(pdf, csv_file, value_combos_file, 'imu_bias_tester_orientation_')
+    create_plot(pdf, csv_file, value_combos_file, 'rel_imu_bias_tester_')
+    create_plot(pdf, csv_file, value_combos_file, 'rel_imu_bias_tester_orientation_')
 
 
 if __name__ == '__main__':

--- a/tools/graph_bag/scripts/plot_results.py
+++ b/tools/graph_bag/scripts/plot_results.py
@@ -374,6 +374,21 @@ def plot_loc_state_stats(pdf,
                          plot_integrated_velocities=True,
                          rmse_rel_start_time=0,
                          rmse_rel_end_time=-1):
+  plot_loc_state_stats_abs(pdf, localization_states, sparse_mapping_poses, output_csv_file, prefix, atol,
+                           plot_integrated_velocities, rmse_rel_start_time, rmse_rel_end_time)
+  plot_loc_state_stats_rel(pdf, localization_states, sparse_mapping_poses, output_csv_file, prefix, atol,
+                           plot_integrated_velocities, rmse_rel_start_time, rmse_rel_end_time)
+
+
+def plot_loc_state_stats_abs(pdf,
+                             localization_states,
+                             sparse_mapping_poses,
+                             output_csv_file,
+                             prefix='',
+                             atol=0,
+                             plot_integrated_velocities=True,
+                             rmse_rel_start_time=0,
+                             rmse_rel_end_time=-1):
   rmse = rmse_utilities.rmse_timestamped_poses(localization_states, sparse_mapping_poses, True, atol,
                                                rmse_rel_start_time, rmse_rel_end_time)
   integrated_rmse = []
@@ -390,6 +405,39 @@ def plot_loc_state_stats(pdf,
     csv_writer.writerow([prefix + 'orientation_rmse', str(rmse[1])])
     if plot_integrated_velocities:
       csv_writer.writerow([prefix + 'integrated_rmse', str(integrated_rmse[0])])
+  plt.figure()
+  plt.axis('off')
+  plt.text(0.0, 0.5, stats)
+  pdf.savefig()
+
+
+def plot_loc_state_stats_rel(pdf,
+                             localization_states,
+                             sparse_mapping_poses,
+                             output_csv_file,
+                             prefix='',
+                             atol=0,
+                             plot_integrated_velocities=True,
+                             rmse_rel_start_time=0,
+                             rmse_rel_end_time=-1):
+  rmse = rmse_utilities.rmse_timestamped_poses_relative(localization_states, sparse_mapping_poses, True, atol,
+                                                        rmse_rel_start_time, rmse_rel_end_time)
+  integrated_rmse = []
+  if plot_integrated_velocities:
+    integrated_localization_states = utilities.integrate_velocities(localization_states)
+    integrated_rmse = rmse_utilities.rmse_timestamped_poses_relative(integrated_localization_states,
+                                                                     sparse_mapping_poses, False, atol,
+                                                                     rmse_rel_start_time, rmse_rel_end_time)
+  stats = prefix + ' rel pos rmse: ' + str(rmse[0]) + '\n' + 'rel orientation rmse: ' + str(rmse[1])
+  if plot_integrated_velocities:
+    stats += '\n' + 'rel integrated rmse: ' + str(integrated_rmse[0])
+
+  with open(output_csv_file, 'a') as output_csv:
+    csv_writer = csv.writer(output_csv, lineterminator='\n')
+    csv_writer.writerow(['rel_' + prefix + 'rmse', str(rmse[0])])
+    csv_writer.writerow(['rel_' + prefix + 'orientation_rmse', str(rmse[1])])
+    if plot_integrated_velocities:
+      csv_writer.writerow(['rel_' + prefix + 'integrated_rmse', str(integrated_rmse[0])])
   plt.figure()
   plt.axis('off')
   plt.text(0.0, 0.5, stats)

--- a/tools/graph_bag/scripts/rmse_utilities.py
+++ b/tools/graph_bag/scripts/rmse_utilities.py
@@ -22,6 +22,7 @@ import poses
 import numpy as np
 import scipy.spatial.transform
 
+import bisect
 import math
 
 
@@ -99,6 +100,53 @@ def rmse_timestamped_poses(poses_a, poses_b, add_orientation_rmse=True, abs_tol=
       b_rot = trimmed_poses_b.orientations.get_rotation(index)
       orientation_squared_error = orientation_squared_difference(a_rot, b_rot)
       mean_squared_orientation_error += (orientation_squared_error - mean_squared_orientation_error) / (index + 1)
+  position_rmse = math.sqrt(mean_squared_position_error)
+  orientation_rmse = math.sqrt(mean_squared_orientation_error)
+  return position_rmse, orientation_rmse
+
+
+# Relative RMSE between two sequences of poses. Only uses poses with the same timestamp
+def rmse_timestamped_poses_relative(poses_a,
+                                    poses_b,
+                                    add_orientation_rmse=True,
+                                    abs_tol=0,
+                                    rel_start_time=0,
+                                    rel_end_time=-1,
+                                    min_relative_elapsed_time=10, max_relative_elapsed_time=20):
+  trimmed_poses_a, trimmed_poses_b = get_same_timestamp_poses(poses_a, poses_b, add_orientation_rmse, abs_tol,
+                                                              rel_start_time, rel_end_time)
+  assert len(trimmed_poses_a.times) == len(trimmed_poses_b.times), 'Length mismatch of poses'
+  num_poses = len(trimmed_poses_a.times)
+  mean_squared_position_error = 0
+  mean_squared_orientation_error = 0
+  count = 0
+  for index1 in range(num_poses):
+    # Position Error
+    a_vec1 = trimmed_poses_a.positions.get_numpy_vector(index1)
+    b_vec1 = trimmed_poses_b.positions.get_numpy_vector(index1)
+    time1 = trimmed_poses_a.times[index1]
+    index2 = bisect.bisect_left(trimmed_poses_a.times, time1 + min_relative_elapsed_time)
+    if (index2 == len(trimmed_poses_a.times)):
+      continue
+    time2 = trimmed_poses_a.times[index2]
+    if (time2 - time1 > max_relative_elapsed_time):
+      continue
+    a_vec2 = trimmed_poses_a.positions.get_numpy_vector(index2)
+    b_vec2 = trimmed_poses_b.positions.get_numpy_vector(index2)
+    a_rel_vec = a_vec2 - a_vec1
+    b_rel_vec = b_vec2 - b_vec1
+
+    position_squared_error = position_squared_difference(a_rel_vec, b_rel_vec)
+    count += 1
+    # Use rolling mean to avoid overflow
+    mean_squared_position_error += (position_squared_error - mean_squared_position_error) / float(count)
+    # Orientation Error
+    if add_orientation_rmse:
+      # TODO(rsoussan): Add relative calculations for orientations
+      a_rot = trimmed_poses_a.orientations.get_rotation(index1)
+      b_rot = trimmed_poses_b.orientations.get_rotation(index1)
+      orientation_squared_error = orientation_squared_difference(a_rot, b_rot)
+      mean_squared_orientation_error += (orientation_squared_error - mean_squared_orientation_error) / float(count)
   position_rmse = math.sqrt(mean_squared_position_error)
   orientation_rmse = math.sqrt(mean_squared_orientation_error)
   return position_rmse, orientation_rmse

--- a/tools/graph_bag/src/bag_imu_filterer.cc
+++ b/tools/graph_bag/src/bag_imu_filterer.cc
@@ -18,23 +18,13 @@
 
 #include <ff_util/ff_names.h>
 #include <graph_bag/bag_imu_filterer.h>
+#include <graph_bag/utilities.h>
 #include <imu_integration/imu_filter_params.h>
 #include <localization_common/utilities.h>
 #include <localization_measurements/imu_measurement.h>
 #include <msg_conversions/msg_conversions.h>
 
 #include <sensor_msgs/Imu.h>
-
-namespace {
-// TODO(rsoussan): Unify this with live measurement simulator, put in utilities
-bool string_ends_with(const std::string& str, const std::string& ending) {
-  if (str.length() >= ending.length()) {
-    return (0 == str.compare(str.length() - ending.length(), ending.length(), ending));
-  } else {
-    return false;
-  }
-}
-}  // namespace
 
 namespace graph_bag {
 namespace ii = imu_integration;

--- a/tools/graph_bag/src/imu_bias_tester_adder.cc
+++ b/tools/graph_bag/src/imu_bias_tester_adder.cc
@@ -1,0 +1,43 @@
+/* Copyright (c) 2017, United States Government, as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ *
+ * All rights reserved.
+ *
+ * The Astrobee platform is licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <ff_util/ff_names.h>
+#include <graph_bag/imu_bias_tester_adder.h>
+#include <graph_bag/utilities.h>
+#include <imu_bias_tester/imu_bias_tester_wrapper.h>
+
+namespace graph_bag {
+ImuBiasTesterAdder::ImuBiasTesterAdder(const std::string& input_bag_name, const std::string& output_bag_name)
+    : input_bag_(input_bag_name, rosbag::bagmode::Read), output_bag_(output_bag_name, rosbag::bagmode::Write) {}
+
+void ImuBiasTesterAdder::AddPredictions() {
+  rosbag::View view(input_bag_);
+  for (const rosbag::MessageInstance msg : view) {
+    if (string_ends_with(msg.getTopic(), TOPIC_GRAPH_LOC_STATE)) {
+      const ff_msgs::GraphState::ConstPtr localization_msg = msg.instantiate<ff_msgs::GraphState>();
+      const auto imu_bias_tester_predicted_states =
+        imu_bias_tester_wrapper_.LocalizationStateCallback(*localization_msg);
+      SaveImuBiasTesterPredictedStates(imu_bias_tester_predicted_states, output_bag_);
+    } else if (string_ends_with(msg.getTopic(), TOPIC_HARDWARE_IMU)) {
+      sensor_msgs::ImuConstPtr imu_msg = msg.instantiate<sensor_msgs::Imu>();
+      imu_bias_tester_wrapper_.ImuCallback(*imu_msg);
+    }
+    output_bag_.write(msg.getTopic(), msg.getTime(), msg);
+  }
+}
+}  // namespace graph_bag

--- a/tools/graph_bag/src/live_measurement_simulator.cc
+++ b/tools/graph_bag/src/live_measurement_simulator.cc
@@ -17,6 +17,7 @@
  */
 
 #include <graph_bag/live_measurement_simulator.h>
+#include <graph_bag/utilities.h>
 #include <localization_common/logger.h>
 
 #include <image_transport/image_transport.h>
@@ -69,14 +70,6 @@ LiveMeasurementSimulator::LiveMeasurementSimulator(const LiveMeasurementSimulato
 
   view_.reset(new rosbag::View(bag_, rosbag::TopicQuery(topics)));
   current_time_ = lc::TimeFromRosTime(view_->getBeginTime());
-}
-
-bool LiveMeasurementSimulator::string_ends_with(const std::string& str, const std::string& ending) {
-  if (str.length() >= ending.length()) {
-    return (0 == str.compare(str.length() - ending.length(), ending.length(), ending));
-  } else {
-    return false;
-  }
 }
 
 ff_msgs::Feature2dArray LiveMeasurementSimulator::GenerateOFFeatures(const sensor_msgs::ImageConstPtr& image_msg) {

--- a/tools/graph_bag/src/sparse_mapping_pose_adder.cc
+++ b/tools/graph_bag/src/sparse_mapping_pose_adder.cc
@@ -18,21 +18,11 @@
 
 #include <ff_util/ff_names.h>
 #include <graph_bag/sparse_mapping_pose_adder.h>
+#include <graph_bag/utilities.h>
 #include <graph_localizer/utilities.h>
 #include <localization_common/utilities.h>
 
 #include <ff_msgs/VisualLandmarks.h>
-
-namespace {
-// TODO(rsoussan): Unify this with live measurement simulator, put in utilities
-bool string_ends_with(const std::string& str, const std::string& ending) {
-  if (str.length() >= ending.length()) {
-    return (0 == str.compare(str.length() - ending.length(), ending.length(), ending));
-  } else {
-    return false;
-  }
-}
-}  // namespace
 
 namespace graph_bag {
 namespace lc = localization_common;

--- a/tools/graph_bag/tools/run_imu_bias_tester_adder.cc
+++ b/tools/graph_bag/tools/run_imu_bias_tester_adder.cc
@@ -1,0 +1,81 @@
+/* Copyright (c) 2017, United States Government, as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ *
+ * All rights reserved.
+ *
+ * The Astrobee platform is licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <ff_common/init.h>
+#include <graph_bag/imu_bias_tester_adder.h>
+#include <localization_common/logger.h>
+#include <localization_common/utilities.h>
+
+#include <boost/filesystem.hpp>
+#include <boost/program_options.hpp>
+
+namespace po = boost::program_options;
+namespace lc = localization_common;
+
+int main(int argc, char** argv) {
+  std::string robot_config_file;
+  std::string world;
+  po::options_description desc(
+    "Adds imu bias tester predictions to a new bag file using recorded localization states and imu msgs.");
+  desc.add_options()("help", "produce help message")("bagfile", po::value<std::string>()->required(), "Bagfile")(
+    "config-path,c", po::value<std::string>()->required(), "Config path")(
+    "robot-config-file,r", po::value<std::string>(&robot_config_file)->default_value("config/robots/bumble.config"),
+    "Robot config file")("world,w", po::value<std::string>(&world)->default_value("iss"), "World name");
+  po::positional_options_description p;
+  p.add("bagfile", 1);
+  p.add("config-path", 1);
+  po::variables_map vm;
+  try {
+    po::store(po::command_line_parser(argc, argv).options(desc).positional(p).run(), vm);
+    po::notify(vm);
+  } catch (std::exception& e) {
+    std::cerr << "Error: " << e.what() << "\n";
+    return 1;
+  }
+
+  if (vm.count("help")) {
+    std::cout << desc << "\n";
+    return 1;
+  }
+
+  const std::string input_bag = vm["bagfile"].as<std::string>();
+  const std::string config_path = vm["config-path"].as<std::string>();
+
+  // Only pass program name to free flyer so that boost command line options
+  // are ignored when parsing gflags.
+  int ff_argc = 1;
+  ff_common::InitFreeFlyerApplication(&ff_argc, &argv);
+
+  if (!boost::filesystem::exists(input_bag)) {
+    LogFatal("Bagfile " << input_bag << " not found.");
+  }
+
+  boost::filesystem::path input_bag_path(input_bag);
+  boost::filesystem::path output_bag_path =
+    input_bag_path.parent_path() /
+    boost::filesystem::path(input_bag_path.stem().string() + "_with_imu_bias_tester_predictions.bag");
+  lc::SetEnvironmentConfigs(config_path, world, robot_config_file);
+  /*  config_reader::ConfigReader config;
+    config.AddFile("geometry.config");
+    if (!config.ReadFiles()) {
+      LogFatal("Failed to read config files.");
+    }*/
+
+  graph_bag::ImuBiasTesterAdder imu_bias_tester_adder(input_bag, output_bag_path.string());
+  imu_bias_tester_adder.AddPredictions();
+}


### PR DESCRIPTION
Reverted smart factor spacing as the previous version was more robust.  Added option so this can still be switched to new spacing.  Also added support in scripts for relative rmse comparison and a tool to add imu bias estimates to an existing bag file.