### PR TITLE
Add null check for image data from hazcam

### DIFF
--- a/simulation/src/gazebo_sensor_plugin_haz_cam/gazebo_sensor_plugin_haz_cam.cc
+++ b/simulation/src/gazebo_sensor_plugin_haz_cam/gazebo_sensor_plugin_haz_cam.cc
@@ -260,6 +260,12 @@ class GazeboSensorPluginHazCam : public FreeFlyerSensorPlugin {
     // seems to be not fresh. The ImageCallback() above publishes the
     // correct intensity on a separate topic.
     const unsigned char * image_data = camera_->ImageData();
+	
+    if (!image_data) {
+        gzerr << "No image data received for haz cam cloud.\n";
+        return;
+    }
+
     for (size_t i = 0; i < num_floats / num_channels_; i++)
       cloud_data[num_channels_ * i + num_channels_ - 1] = static_cast<float>(image_data[i]);
 

--- a/simulation/src/gazebo_sensor_plugin_haz_cam/gazebo_sensor_plugin_haz_cam.cc
+++ b/simulation/src/gazebo_sensor_plugin_haz_cam/gazebo_sensor_plugin_haz_cam.cc
@@ -262,8 +262,8 @@ class GazeboSensorPluginHazCam : public FreeFlyerSensorPlugin {
     const unsigned char * image_data = camera_->ImageData();
 
     if (!image_data) {
-        //first frame of image data may not be received
-        return;
+      // first frame of image data may not be received
+      return;
     }
     for (size_t i = 0; i < num_floats / num_channels_; i++)
       cloud_data[num_channels_ * i + num_channels_ - 1] = static_cast<float>(image_data[i]);

--- a/simulation/src/gazebo_sensor_plugin_haz_cam/gazebo_sensor_plugin_haz_cam.cc
+++ b/simulation/src/gazebo_sensor_plugin_haz_cam/gazebo_sensor_plugin_haz_cam.cc
@@ -260,12 +260,11 @@ class GazeboSensorPluginHazCam : public FreeFlyerSensorPlugin {
     // seems to be not fresh. The ImageCallback() above publishes the
     // correct intensity on a separate topic.
     const unsigned char * image_data = camera_->ImageData();
-	
+
     if (!image_data) {
-        gzerr << "No image data received for haz cam cloud.\n";
+        //first frame of image data may not be received
         return;
     }
-
     for (size_t i = 0; i < num_floats / num_channels_; i++)
       cloud_data[num_channels_ * i + num_channels_ - 1] = static_cast<float>(image_data[i]);
 


### PR DESCRIPTION
Camera image data was returning NULL, causing segfault on launch.