### PR TITLE
add fix for expired ROS apt key. 

### DIFF
--- a/scripts/docker/astrobee_base_kinetic.Dockerfile
+++ b/scripts/docker/astrobee_base_kinetic.Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get update \
     lsb-release \
     sudo \
     wget \
+    curl \
   && rm -rf /var/lib/apt/lists/*
 COPY ./scripts/setup/*.sh /setup/astrobee/
 COPY ./scripts/setup/debians /setup/astrobee/debians

--- a/scripts/setup/add_ros_repository.sh
+++ b/scripts/setup/add_ros_repository.sh
@@ -24,3 +24,5 @@ sudo apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31
 # Gazebo stuff
 sudo sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -sc) main" > /etc/apt/sources.list.d/gazebo-stable.list'
 wget http://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add
+
+curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | sudo apt-key add -


### PR DESCRIPTION
Info: https://discourse.ros.org/t/ros-gpg-key-expiration-incident/20669

I'm not sure if this was fixed already (I didn't see something in the commits, unless I missed it), but this is what I had to do to get things working again. I'm also not sure if this is the best way to fix it.

cc @KhaledSharif @marinagmoreira @bcoltin 