### PR TITLE
Fix tf prefix noetic

### DIFF
--- a/astrobee/launch/astrobee.launch
+++ b/astrobee/launch/astrobee.launch
@@ -66,9 +66,8 @@
   <group ns="/$(arg ns)">
 
     <!-- Set the TF prefix, create a robot description and joint state publisher -->
-    <param name="tf_prefix" value="$(arg ns)" />
     <param name="robot_description"
-           command='$(find xacro)/xacro --inorder $(find description)/urdf/model.urdf.xacro world:="$(arg world)" top_aft:="$(arg top_aft)" bot_aft:="$(arg bot_aft)" bot_front:="$(arg bot_front)" ns:="_$(arg ns)"' />
+           command='$(find xacro)/xacro --inorder $(find description)/urdf/model.urdf.xacro world:="$(arg world)" top_aft:="$(arg top_aft)" bot_aft:="$(arg bot_aft)" bot_front:="$(arg bot_front)" ns:="_$(arg ns)" prefix:="$(arg ns)/"'/>
     <node pkg="robot_state_publisher" type="robot_state_publisher"
           name="astrobee_state_publisher" />
 

--- a/astrobee/resources/rviz/iss.rviz
+++ b/astrobee/resources/rviz/iss.rviz
@@ -4,12 +4,11 @@ Panels:
     Name: Displays
     Property Tree Widget:
       Expanded:
-        - /Handrail1
         - /Debug1
         - /Debug1/Sensors1
         - /Debug1/Mobility1/Mapper1
-      Splitter Ratio: 0.579250693
-    Tree Height: 187
+      Splitter Ratio: 0.579250693321228
+    Tree Height: 202
   - Class: rviz/Selection
     Name: Selection
   - Class: rviz/Tool Properties
@@ -18,7 +17,7 @@ Panels:
       - /2D Nav Goal1
       - /Publish Point1
     Name: Tool Properties
-    Splitter Ratio: 0.588679016
+    Splitter Ratio: 0.5886790156364441
   - Class: rviz/Views
     Expanded:
       - /Current View1
@@ -28,7 +27,11 @@ Panels:
     Experimental: false
     Name: Time
     SyncMode: 0
-    SyncSource: Features
+    SyncSource: ""
+Preferences:
+  PromptSaveOnExit: true
+Toolbars:
+  toolButtonStyle: 2
 Visualization Manager:
   Class: ""
   Displays:
@@ -37,10 +40,6 @@ Visualization Manager:
       Frame Timeout: 15
       Frames:
         All Enabled: false
-        ar_tag:
-          Value: true
-        body:
-          Value: true
         dock/berth1:
           Value: true
         dock/berth1/approach:
@@ -55,12 +54,6 @@ Visualization Manager:
           Value: true
         dock/body:
           Value: true
-        dock_cam:
-          Value: true
-        flashlight_aft:
-          Value: true
-        flashlight_front:
-          Value: true
         granite/body:
           Value: true
         handrail/approach:
@@ -69,93 +62,72 @@ Visualization Manager:
           Value: true
         handrail/complete:
           Value: true
-        haz_cam:
+        honey/ar_tag:
           Value: true
-        imu:
+        honey/body:
           Value: true
-        inertial_link:
+        honey/dock/body:
+          Value: true
+        honey/dock_cam:
+          Value: true
+        honey/flashlight_aft:
+          Value: true
+        honey/flashlight_front:
+          Value: true
+        honey/haz_cam:
+          Value: true
+        honey/imu:
+          Value: true
+        honey/inertial_link:
+          Value: true
+        honey/laser:
+          Value: true
+        honey/nav_cam:
+          Value: true
+        honey/payload/bottom_aft:
+          Value: true
+        honey/payload/bottom_front:
+          Value: true
+        honey/payload/top_aft:
+          Value: true
+        honey/payload/top_front:
+          Value: true
+        honey/perch_cam:
+          Value: true
+        honey/sci_cam:
+          Value: true
+        honey/top_aft:
+          Value: true
+        honey/top_aft_arm_distal_link:
+          Value: true
+        honey/top_aft_arm_proximal_link:
+          Value: true
+        honey/top_aft_gripper_left_distal_link:
+          Value: true
+        honey/top_aft_gripper_left_proximal_link:
+          Value: true
+        honey/top_aft_gripper_right_distal_link:
+          Value: true
+        honey/top_aft_gripper_right_proximal_link:
+          Value: true
+        honey/truth:
           Value: true
         iss/body:
           Value: true
-        laser:
-          Value: true
-        nav_cam:
-          Value: true
-        payload/bottom_aft:
-          Value: true
-        payload/bottom_front:
-          Value: true
-        payload/top_aft:
-          Value: true
-        payload/top_front:
-          Value: true
-        perch_cam:
+        perch/body:
           Value: true
         rviz:
           Value: true
-        top_aft:
-          Value: true
-        top_aft_arm_distal_link:
-          Value: true
-        top_aft_arm_proximal_link:
-          Value: true
-        top_aft_gripper_left_distal_link:
-          Value: true
-        top_aft_gripper_left_proximal_link:
-          Value: true
-        top_aft_gripper_right_distal_link:
-          Value: true
-        top_aft_gripper_right_proximal_link:
-          Value: true
-        truth:
-          Value: true
         world:
           Value: true
-      Marker Scale: 0.300000012
+      Marker Alpha: 1
+      Marker Scale: 0.30000001192092896
       Name: TF
       Show Arrows: false
       Show Axes: true
       Show Names: true
       Tree:
         world:
-          body:
-            ar_tag:
-              {}
-            dock_cam:
-              {}
-            flashlight_aft:
-              {}
-            flashlight_front:
-              {}
-            haz_cam:
-              {}
-            imu:
-              {}
-            inertial_link:
-              {}
-            laser:
-              {}
-            nav_cam:
-              {}
-            payload/bottom_aft:
-              {}
-            payload/bottom_front:
-              {}
-            payload/top_aft:
-              {}
-            payload/top_front:
-              {}
-            perch_cam:
-              {}
-            top_aft:
-              top_aft_arm_proximal_link:
-                top_aft_arm_distal_link:
-                  top_aft_gripper_left_proximal_link:
-                    top_aft_gripper_left_distal_link:
-                      {}
-                  top_aft_gripper_right_proximal_link:
-                    top_aft_gripper_right_distal_link:
-                      {}
           dock/body:
             dock/berth1:
               dock/berth1/approach:
@@ -169,60 +141,100 @@ Visualization Manager:
                 {}
           granite/body:
             {}
-          handrail/body:
-            handrail/approach:
+          honey/body:
+            honey/ar_tag:
               {}
-            handrail/complete:
+            honey/dock_cam:
               {}
+            honey/flashlight_aft:
+              {}
+            honey/flashlight_front:
+              {}
+            honey/haz_cam:
+              {}
+            honey/imu:
+              {}
+            honey/inertial_link:
+              {}
+            honey/laser:
+              {}
+            honey/nav_cam:
+              {}
+            honey/payload/bottom_aft:
+              {}
+            honey/payload/bottom_front:
+              {}
+            honey/payload/top_aft:
+              {}
+            honey/payload/top_front:
+              {}
+            honey/perch_cam:
+              {}
+            honey/sci_cam:
+              {}
+            honey/top_aft:
+              honey/top_aft_arm_proximal_link:
+                honey/top_aft_arm_distal_link:
+                  honey/top_aft_gripper_left_proximal_link:
+                    honey/top_aft_gripper_left_distal_link:
+                      {}
+                  honey/top_aft_gripper_right_proximal_link:
+                    honey/top_aft_gripper_right_distal_link:
+                      {}
+          honey/dock/body:
+            {}
+          honey/truth:
+            {}
           iss/body:
             {}
-          rviz:
+          perch/body:
             {}
-          truth:
+          rviz:
             {}
       Update Interval: 0
       Value: true
     - Class: rviz/Group
       Displays:
-        - Class: rviz/Axes
+        - Alpha: 1
+          Class: rviz/Axes
           Enabled: true
           Length: 3
           Name: Axes
-          Radius: 0.00999999978
+          Radius: 0.009999999776482582
           Reference Frame: world
           Value: true
-        - Alpha: 0.100000001
+        - Alpha: 0.10000000149011612
           Cell Size: 1
           Class: rviz/Grid
           Color: 255; 255; 127
           Enabled: true
           Line Style:
-            Line Width: 0.0299999993
+            Line Width: 0.029999999329447746
             Value: Billboards
           Name: Grid 1m
           Normal Cell Count: 0
           Offset:
             X: 0
             Y: 0
-            Z: 4.8499999
+            Z: 4.849999904632568
           Plane: XY
           Plane Cell Count: 100
           Reference Frame: world
           Value: true
-        - Alpha: 0.100000001
-          Cell Size: 0.100000001
+        - Alpha: 0.10000000149011612
+          Cell Size: 0.10000000149011612
           Class: rviz/Grid
           Color: 160; 160; 164
           Enabled: true
           Line Style:
-            Line Width: 0.0299999993
+            Line Width: 0.029999999329447746
             Value: Lines
           Name: Grid 0.1m
           Normal Cell Count: 0
           Offset:
             X: 0
             Y: 0
-            Z: 4.8499999
+            Z: 4.849999904632568
           Plane: XY
           Plane Cell Count: 1000
           Reference Frame: world
@@ -233,14 +245,14 @@ Visualization Manager:
           Color: 160; 160; 164
           Enabled: true
           Line Style:
-            Line Width: 0.0299999993
+            Line Width: 0.029999999329447746
             Value: Lines
           Name: Grid 10m
           Normal Cell Count: 0
           Offset:
             X: 0
             Y: 0
-            Z: 4.8499999
+            Z: 4.849999904632568
           Plane: XY
           Plane Cell Count: 10
           Reference Frame: world
@@ -320,9 +332,53 @@ Visualization Manager:
         Expand Link Details: false
         Expand Tree: false
         Link Tree Style: Links in Alphabetic Order
+        honey/body:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        honey/inertial_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        honey/top_aft:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        honey/top_aft_arm_distal_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        honey/top_aft_arm_proximal_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        honey/top_aft_gripper_left_distal_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        honey/top_aft_gripper_left_proximal_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        honey/top_aft_gripper_right_distal_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        honey/top_aft_gripper_right_proximal_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
       Name: Honey
       Robot Description: /honey/robot_description
-      TF Prefix: honey
+      TF Prefix: ""
       Update Interval: 0
       Value: true
       Visual Enabled: true
@@ -338,7 +394,7 @@ Visualization Manager:
         Link Tree Style: Links in Alphabetic Order
       Name: Bumble
       Robot Description: /bumble/robot_description
-      TF Prefix: bumble
+      TF Prefix: ""
       Update Interval: 0
       Value: true
       Visual Enabled: true
@@ -352,9 +408,53 @@ Visualization Manager:
         Expand Link Details: false
         Expand Tree: false
         Link Tree Style: Links in Alphabetic Order
+        queen/body:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        queen/inertial_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        queen/top_aft:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        queen/top_aft_arm_distal_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        queen/top_aft_arm_proximal_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        queen/top_aft_gripper_left_distal_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        queen/top_aft_gripper_left_proximal_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        queen/top_aft_gripper_right_distal_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        queen/top_aft_gripper_right_proximal_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
       Name: Queen
       Robot Description: /queen/robot_description
-      TF Prefix: queen
+      TF Prefix: ""
       Update Interval: 0
       Value: true
       Visual Enabled: true
@@ -370,50 +470,6 @@ Visualization Manager:
             Expand Link Details: false
             Expand Tree: false
             Link Tree Style: Links in Alphabetic Order
-            body:
-              Alpha: 1
-              Show Axes: false
-              Show Trail: false
-              Value: true
-            inertial_link:
-              Alpha: 1
-              Show Axes: false
-              Show Trail: false
-            top_aft:
-              Alpha: 1
-              Show Axes: false
-              Show Trail: false
-              Value: true
-            top_aft_arm_distal_link:
-              Alpha: 1
-              Show Axes: false
-              Show Trail: false
-              Value: true
-            top_aft_arm_proximal_link:
-              Alpha: 1
-              Show Axes: false
-              Show Trail: false
-              Value: true
-            top_aft_gripper_left_distal_link:
-              Alpha: 1
-              Show Axes: false
-              Show Trail: false
-              Value: true
-            top_aft_gripper_left_proximal_link:
-              Alpha: 1
-              Show Axes: false
-              Show Trail: false
-              Value: true
-            top_aft_gripper_right_distal_link:
-              Alpha: 1
-              Show Axes: false
-              Show Trail: false
-              Value: true
-            top_aft_gripper_right_proximal_link:
-              Alpha: 1
-              Show Axes: false
-              Show Trail: false
-              Value: true
           Name: /
           Robot Description: /robot_description
           TF Prefix: ""
@@ -493,8 +549,8 @@ Visualization Manager:
             - Alpha: 1
               Autocompute Intensity Bounds: true
               Autocompute Value Bounds:
-                Max Value: 0.541443229
-                Min Value: -0.164811939
+                Max Value: 0.5414432287216187
+                Min Value: -0.16481193900108337
                 Value: true
               Axis: Y
               Channel Name: intensity
@@ -505,15 +561,13 @@ Visualization Manager:
               Enabled: true
               Invert Rainbow: false
               Max Color: 255; 255; 255
-              Max Intensity: 4096
               Min Color: 0; 0; 0
-              Min Intensity: 0
               Name: HazCam
               Position Transformer: XYZ
               Queue Size: 10
               Selectable: true
               Size (Pixels): 1
-              Size (m): 0.00999999978
+              Size (m): 0.009999999776482582
               Style: Points
               Topic: /hw/depth_haz/points
               Unreliable: false
@@ -535,15 +589,13 @@ Visualization Manager:
               Enabled: true
               Invert Rainbow: false
               Max Color: 255; 255; 255
-              Max Intensity: 4096
               Min Color: 0; 0; 0
-              Min Intensity: 0
               Name: PerchCam
               Position Transformer: XYZ
               Queue Size: 10
               Selectable: true
               Size (Pixels): 1
-              Size (m): 0.00999999978
+              Size (m): 0.009999999776482582
               Style: Points
               Topic: /hw/depth_perch/points
               Unreliable: false
@@ -569,15 +621,13 @@ Visualization Manager:
               Enabled: true
               Invert Rainbow: false
               Max Color: 255; 255; 255
-              Max Intensity: 4096
               Min Color: 0; 0; 0
-              Min Intensity: 0
               Name: Features
               Position Transformer: XYZ
               Queue Size: 10
               Selectable: true
               Size (Pixels): 3
-              Size (m): 0.0500000007
+              Size (m): 0.05000000074505806
               Style: Spheres
               Topic: /gnc/ekf/features
               Unreliable: false
@@ -586,15 +636,16 @@ Visualization Manager:
               Value: true
             - Alpha: 1
               Axes Length: 1
-              Axes Radius: 0.100000001
+              Axes Radius: 0.10000000149011612
               Class: rviz/Pose
               Color: 255; 255; 0
               Enabled: true
-              Head Length: 0.300000012
-              Head Radius: 0.100000001
+              Head Length: 0.30000001192092896
+              Head Radius: 0.10000000149011612
               Name: Ground Truth
+              Queue Size: 10
               Shaft Length: 0.5
-              Shaft Radius: 0.00999999978
+              Shaft Radius: 0.009999999776482582
               Shape: Arrow
               Topic: /loc/truth
               Unreliable: false
@@ -612,7 +663,7 @@ Visualization Manager:
               Marker Topic: /loc/registration
               Name: Registration
               Namespaces:
-                thick_traj: true
+                {}
               Queue Size: 100
               Value: true
           Enabled: true
@@ -624,11 +675,11 @@ Visualization Manager:
               Class: rviz/Path
               Color: 25; 255; 0
               Enabled: true
-              Head Diameter: 0.300000012
-              Head Length: 0.200000003
-              Length: 0.300000012
+              Head Diameter: 0.30000001192092896
+              Head Length: 0.20000000298023224
+              Length: 0.30000001192092896
               Line Style: Lines
-              Line Width: 0.0299999993
+              Line Width: 0.029999999329447746
               Name: CurrentPlan
               Offset:
                 X: 0
@@ -636,9 +687,10 @@ Visualization Manager:
                 Z: 0
               Pose Color: 255; 85; 255
               Pose Style: None
-              Radius: 0.0299999993
-              Shaft Diameter: 0.100000001
-              Shaft Length: 0.100000001
+              Queue Size: 10
+              Radius: 0.029999999329447746
+              Shaft Diameter: 0.10000000149011612
+              Shaft Length: 0.10000000149011612
               Topic: /mob/choreographer/segment
               Unreliable: false
               Value: true
@@ -658,10 +710,11 @@ Visualization Manager:
                   Color: 204; 51; 204
                   Enabled: true
                   History Length: 1
-                  Line Thickness: 0.100000001
+                  Line Thickness: 0.10000000149011612
                   Name: Trajectory
                   Plot Acceleration: false
                   Plot Velocity: false
+                  Queue Size: 10
                   Style: Mike
                   Tangent Samples: 25
                   Topic: /mob/planner_qp/trajectory
@@ -675,10 +728,11 @@ Visualization Manager:
                   Color: 255; 0; 0
                   Enabled: true
                   History Length: 1
-                  Line Thickness: 0.100000001
+                  Line Thickness: 0.10000000149011612
                   Name: TrajectoryDebug
                   Plot Acceleration: false
                   Plot Velocity: false
+                  Queue Size: 10
                   Style: Mike
                   Tangent Samples: 10
                   Topic: /mob/planner_qp/trajectory_debug
@@ -695,7 +749,7 @@ Visualization Manager:
                   Marker Topic: /mob/mapper/zones
                   Name: Zones
                   Namespaces:
-                    zone_visualization: true
+                    {}
                   Queue Size: 100
                   Value: true
                 - Class: rviz/MarkerArray
@@ -714,7 +768,7 @@ Visualization Manager:
                     {}
                   Queue Size: 100
                   Value: false
-                - Alpha: 0.100000001
+                - Alpha: 0.10000000149011612
                   Autocompute Intensity Bounds: true
                   Autocompute Value Bounds:
                     Max Value: 10
@@ -729,15 +783,13 @@ Visualization Manager:
                   Enabled: false
                   Invert Rainbow: false
                   Max Color: 255; 255; 255
-                  Max Intensity: 4096
                   Min Color: 0; 0; 0
-                  Min Intensity: 0
                   Name: FreeSpace
                   Position Transformer: XYZ
                   Queue Size: 10
                   Selectable: true
                   Size (Pixels): 3
-                  Size (m): 0.100000001
+                  Size (m): 0.10000000149011612
                   Style: Boxes
                   Topic: /mob/mapper/free_space_cloud
                   Unreliable: false
@@ -747,8 +799,8 @@ Visualization Manager:
                 - Alpha: 1
                   Autocompute Intensity Bounds: true
                   Autocompute Value Bounds:
-                    Max Value: -3.6500001
-                    Min Value: -5.3499999
+                    Max Value: -3.6500000953674316
+                    Min Value: -5.349999904632568
                     Value: true
                   Axis: Z
                   Channel Name: intensity
@@ -759,15 +811,13 @@ Visualization Manager:
                   Enabled: true
                   Invert Rainbow: false
                   Max Color: 255; 255; 255
-                  Max Intensity: 4096
                   Min Color: 0; 0; 0
-                  Min Intensity: 0
                   Name: Map
                   Position Transformer: XYZ
                   Queue Size: 10
                   Selectable: true
                   Size (Pixels): 3
-                  Size (m): 0.100000001
+                  Size (m): 0.10000000149011612
                   Style: Boxes
                   Topic: /mob/mapper/obstacle_cloud
                   Unreliable: false
@@ -795,7 +845,10 @@ Visualization Manager:
     - Class: rviz/FocusCamera
     - Class: rviz/Measure
     - Class: rviz/SetInitialPose
+      Theta std deviation: 0.2617993950843811
       Topic: /initialpose
+      X std deviation: 0.5
+      Y std deviation: 0.5
     - Class: rviz/SetGoal
       Topic: /move_base_simple/goal
     - Class: rviz/PublishPoint
@@ -806,21 +859,21 @@ Visualization Manager:
     Current:
       Class: rviz/FPS
       Enable Stereo Rendering:
-        Stereo Eye Separation: 0.0599999987
+        Stereo Eye Separation: 0.05999999865889549
         Stereo Focal Distance: 1
         Swap Stereo Eyes: false
         Value: false
       Invert Z Axis: false
       Name: Current View
-      Near Clip Distance: 0.00999999978
-      Pitch: 0.959796906
+      Near Clip Distance: 0.009999999776482582
+      Pitch: 0.8697966933250427
       Position:
-        X: 8.61772633
-        Y: 8.51602364
-        Z: -1.08066916
+        X: 7.894586086273193
+        Y: 8.00870418548584
+        Z: -1.0062958002090454
+      Roll: 0
       Target Frame: rviz
-      Value: FPS (rviz)
-      Yaw: 0.420246959
+      Yaw: 0.5702470541000366
     Saved: ~
 Window Geometry:
   "DEBUG: DockCam":
@@ -836,7 +889,7 @@ Window Geometry:
   Height: 848
   Hide Left Dock: false
   Hide Right Dock: false
-  QMainWindow State: 000000ff00000000fd00000004000000000000016a000002fcfc0200000014fb0000001a00440045004200550047003a0020004e0061007600430061006d010000003a000000f30000001600fffffffb0000001c00440045004200550047003a00200044006f0063006b00430061006d0100000133000000f00000001600fffffffb000000100044006900730070006c00610079007301000002290000010d000000c600fffffffb0000000a0056006900650077007300000002c2000000b50000009e00fffffffb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000002b3000002e100000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb0000000a0049006d00610067006500000002af000000f40000000000000000fb0000000a0049006d00610067006502000000c60000001d0000052f000003f4fb0000000a0049006d006100670065020000016600000075000004ab00000373fb0000000a0049006d00610067006501000004680000014d0000000000000000fb0000000a0049006d0061006700650000000028000003dd0000000000000000fb000000100044006f0063006b002000430061006d0100000143000001090000000000000000fb0000000e004e00610076002000430061006d010000019d000000af0000000000000000fb0000001a00440045004200550047003a002000530063006900430061006d0000000277000000bf0000001600fffffffb0000002e00440045004200550047003a002000480061007a00430061006d00200069006e00740065006e00730069007400790000000276000000c00000001600ffffff000000010000016a0000044ffc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a0049006d00610067006500000000330000029b0000000000000000fb0000001200530065006c0065006300740069006f006e010000025a000000b20000000000000000000000020000078000000115fc0100000001fb0000000a00560069006500770073030000004e00000080000002e1000001970000000300000780000000fffc0100000002fc00000000000004380000000000fffffffa000000000200000002fb0000001e004d006f00740069006f006e00200050006c0061006e006e0069006e00670100000000ffffffff0000000000000000fb0000000800540069006d00650000000000ffffffff0000003600fffffffb0000000800540069006d00650100000000000004500000000000000000000002c4000002fc00000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  QMainWindow State: 000000ff00000000fd00000004000000000000016a000002f6fc0200000014fb0000001a00440045004200550047003a0020004e0061007600430061006d010000003d000000f10000001600fffffffb0000001c00440045004200550047003a00200044006f0063006b00430061006d0100000134000000f20000001600fffffffb000000100044006900730070006c006100790073010000022c00000107000000c900fffffffb0000000a0056006900650077007300000002c2000000b5000000a400fffffffb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000002b3000002e100000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb0000000a0049006d00610067006500000002af000000f40000000000000000fb0000000a0049006d00610067006502000000c60000001d0000052f000003f4fb0000000a0049006d006100670065020000016600000075000004ab00000373fb0000000a0049006d00610067006501000004680000014d0000000000000000fb0000000a0049006d0061006700650000000028000003dd0000000000000000fb000000100044006f0063006b002000430061006d0100000143000001090000000000000000fb0000000e004e00610076002000430061006d010000019d000000af0000000000000000fb0000001a00440045004200550047003a002000530063006900430061006d0000000277000000bf0000001600fffffffb0000002e00440045004200550047003a002000480061007a00430061006d00200069006e00740065006e00730069007400790000000276000000c00000001600ffffff000000010000016a0000044ffc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a0049006d00610067006500000000330000029b0000000000000000fb0000001200530065006c0065006300740069006f006e010000025a000000b20000000000000000000000020000078000000115fc0100000001fb0000000a00560069006500770073030000004e00000080000002e1000001970000000300000780000000fffc0100000002fc00000000000004380000000000fffffffa000000000200000002fb0000001e004d006f00740069006f006e00200050006c0061006e006e0069006e00670100000000ffffffff0000000000000000fb0000000800540069006d00650000000000ffffffff0000003900fffffffb0000000800540069006d00650100000000000004500000000000000000000002c4000002f600000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
   Selection:
     collapsed: false
   Time:
@@ -846,5 +899,5 @@ Window Geometry:
   Views:
     collapsed: false
   Width: 1076
-  X: 0
-  Y: 6
+  X: 72
+  Y: 27

--- a/description/description/urdf/macro_perching_arm.urdf.xacro
+++ b/description/description/urdf/macro_perching_arm.urdf.xacro
@@ -22,7 +22,8 @@
     <xacro:property name="prox_effort" value="1.0"/>
     <xacro:property name="dist_effort" value="1.0"/>
     <xacro:property name="grip_effort" value="0.1"/>
-    <link name="${bay}">
+
+    <link name="${prefix}${bay}">
       <self_collide>false</self_collide>
       <inertial>
         <origin
@@ -63,11 +64,11 @@
         xyz="${xyz}"
         rpy="${rpy}" />
       <parent
-        link="body" />
+        link="${prefix}body" />
       <child
-        link="${bay}" />
+        link="${prefix}${bay}" />
     </joint>
-    <link name="${bay}_arm_proximal_link">
+    <link name="${prefix}${bay}_arm_proximal_link">
       <self_collide>false</self_collide>
       <inertial>
         <origin
@@ -108,9 +109,9 @@
         xyz="0.11945 0 0.065"
         rpy="0 1.57079632679 0" />
       <parent
-        link="${bay}" />
+        link="${prefix}${bay}" />
       <child
-        link="${bay}_arm_proximal_link" />
+        link="${prefix}${bay}_arm_proximal_link" />
       <axis
         xyz="0 -1 0" />
       <limit
@@ -119,7 +120,7 @@
         upper="1.57079"
         velocity="0.12" />
     </joint>
-    <link name="${bay}_arm_distal_link">
+    <link name="${prefix}${bay}_arm_distal_link">
       <self_collide>false</self_collide>
       <inertial>
         <origin
@@ -160,9 +161,9 @@
         xyz="-0.1 0 0"
         rpy="0 0 0" />
       <parent
-        link="${bay}_arm_proximal_link" />
+        link="${prefix}${bay}_arm_proximal_link" />
       <child
-        link="${bay}_arm_distal_link" />
+        link="${prefix}${bay}_arm_distal_link" />
       <axis
         xyz="0 0 1" />
       <limit
@@ -171,7 +172,7 @@
         upper="1.57079"
         velocity="0.12" />
     </joint>
-    <link name="${bay}_gripper_left_proximal_link">
+    <link name="${prefix}${bay}_gripper_left_proximal_link">
       <self_collide>false</self_collide>
       <inertial>
         <origin
@@ -212,9 +213,9 @@
         xyz="-0.039 -0.010002 -0.0497"
         rpy="0 0 0" />
       <parent
-        link="${bay}_arm_distal_link" />
+        link="${prefix}${bay}_arm_distal_link" />
       <child
-        link="${bay}_gripper_left_proximal_link" />
+        link="${prefix}${bay}_gripper_left_proximal_link" />
       <axis
         xyz="0 0 1" />
       <limit
@@ -223,7 +224,7 @@
         upper="0.698132"
         velocity="0.12" />
     </joint>
-    <link name="${bay}_gripper_left_distal_link">
+    <link name="${prefix}${bay}_gripper_left_distal_link">
       <self_collide>false</self_collide>
       <inertial>
         <origin
@@ -264,9 +265,9 @@
         xyz="-0.05 0 0"
         rpy="0 0 0" />
       <parent
-        link="${bay}_gripper_left_proximal_link" />
+        link="${prefix}${bay}_gripper_left_proximal_link" />
       <child
-        link="${bay}_gripper_left_distal_link" />
+        link="${prefix}${bay}_gripper_left_distal_link" />
       <axis
         xyz="0 0 1" />
       <limit
@@ -275,7 +276,7 @@
         upper="-0.69813"
         velocity="0.12" />
     </joint>
-    <link name="${bay}_gripper_right_proximal_link">
+    <link name="${prefix}${bay}_gripper_right_proximal_link">
       <self_collide>false</self_collide>
       <inertial>
         <origin
@@ -316,9 +317,9 @@
         xyz="-0.039 0.010002 -0.0497"
         rpy="0 0 0" />
       <parent
-        link="${bay}_arm_distal_link" />
+        link="${prefix}${bay}_arm_distal_link" />
       <child
-        link="${bay}_gripper_right_proximal_link" />
+        link="${prefix}${bay}_gripper_right_proximal_link" />
       <axis
         xyz="0 0 1" />
       <limit
@@ -327,7 +328,7 @@
         upper="-0.349066"
         velocity="0.12" />
     </joint>
-    <link name="${bay}_gripper_right_distal_link">
+    <link name="${prefix}${bay}_gripper_right_distal_link">
       <self_collide>false</self_collide>
       <inertial>
         <origin
@@ -368,9 +369,9 @@
         xyz="-0.05 0 0"
         rpy="0 0 0" />
       <parent
-        link="${bay}_gripper_right_proximal_link" />
+        link="${prefix}${bay}_gripper_right_proximal_link" />
       <child
-        link="${bay}_gripper_right_distal_link" />
+        link="${prefix}${bay}_gripper_right_distal_link" />
       <axis
         xyz="0 0 1" />
       <limit
@@ -389,6 +390,5 @@
         <gripper>0</gripper>
       </plugin>
     </gazebo>
-  -->
   </xacro:macro>
 </robot>

--- a/description/description/urdf/model.urdf.xacro
+++ b/description/description/urdf/model.urdf.xacro
@@ -26,6 +26,9 @@
   <xacro:property name="pay_bot_front" value="$(arg bot_front)"/>
   <xacro:property name="ns" value="$(arg ns)"/>
   <xacro:property name="prefix" value="$(arg prefix)"/>
+  <xacro:if value="${prefix == '/'}">
+    <xacro:property name="prefix" value=""/>
+  </xacro:if>
 
   <!-- BASE GEOMETRY -->
  <link name="${prefix}body">

--- a/description/description/urdf/model.urdf.xacro
+++ b/description/description/urdf/model.urdf.xacro
@@ -25,9 +25,10 @@
   <xacro:property name="pay_bot_aft" value="$(arg bot_aft)"/>
   <xacro:property name="pay_bot_front" value="$(arg bot_front)"/>
   <xacro:property name="ns" value="$(arg ns)"/>
+  <xacro:property name="prefix" value="$(arg prefix)"/>
 
   <!-- BASE GEOMETRY -->
- <link name="body">
+ <link name="${prefix}body">
     <self_collide>false</self_collide>
     <!-- body -->
     <visual name="body_visual">
@@ -94,7 +95,7 @@
     </collision>
   </link>
   <!-- This is a workaround for KDL -->
-  <link name="inertial_link">
+  <link name="${prefix}inertial_link">
     <self_collide>false</self_collide>
     <inertial>
       <mass value="9.0877"/>
@@ -104,8 +105,8 @@
   </link>
   <joint name="inertial_joint" type="fixed">
     <origin xyz="0 0 0" rpy="0 0 0" />
-    <parent link="body" />
-    <child link="inertial_link" />
+    <parent link="${prefix}body" />
+    <child link="${prefix}inertial_link" />
   </joint>
 
   <!-- MODEL -->

--- a/description/description/urdf/sensor_dock_cam.urdf.xacro
+++ b/description/description/urdf/sensor_dock_cam.urdf.xacro
@@ -18,7 +18,7 @@
 <!-- permissions and limitations under the License.                          -->
 
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <gazebo reference="body">
+  <gazebo reference="${prefix}body">
     <sensor name="dock_cam" type="wideanglecamera">
       <pose>0 0 0 0 0 0</pose>
       <always_on>true</always_on>

--- a/description/description/urdf/sensor_haz_cam.urdf.xacro
+++ b/description/description/urdf/sensor_haz_cam.urdf.xacro
@@ -18,7 +18,7 @@
 <!-- permissions and limitations under the License.                          -->
 
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <gazebo reference="body">
+  <gazebo reference="${prefix}body">
     <sensor name="haz_cam" type="depth">
       <pose>0 0 0 0 0 0</pose>
       <always_on>true</always_on>

--- a/description/description/urdf/sensor_imu.urdf.xacro
+++ b/description/description/urdf/sensor_imu.urdf.xacro
@@ -18,7 +18,7 @@
 <!-- permissions and limitations under the License.                          -->
 
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <gazebo reference="body">
+  <gazebo reference="${prefix}body">
     <sensor name="imu" type="imu">
       <pose>0 0 0 0 0 0</pose>
       <always_on>true</always_on>

--- a/description/description/urdf/sensor_nav_cam.urdf.xacro
+++ b/description/description/urdf/sensor_nav_cam.urdf.xacro
@@ -18,7 +18,7 @@
 <!-- permissions and limitations under the License.                          -->
 
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <gazebo reference="body">
+  <gazebo reference="${prefix}body">
     <sensor name="nav_cam" type="wideanglecamera">
       <pose>0 0 0 0 0 0</pose>
       <always_on>true</always_on>

--- a/description/description/urdf/sensor_perch_cam.urdf.xacro
+++ b/description/description/urdf/sensor_perch_cam.urdf.xacro
@@ -18,7 +18,7 @@
 <!-- permissions and limitations under the License.                          -->
 
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <gazebo reference="body">
+  <gazebo reference="${prefix}body">
     <sensor name="perch_cam" type="depth">
       <pose>0 0 0 0 0 0</pose>
       <always_on>true</always_on>

--- a/description/description/urdf/sensor_sci_cam.urdf.xacro
+++ b/description/description/urdf/sensor_sci_cam.urdf.xacro
@@ -18,7 +18,7 @@
 <!-- permissions and limitations under the License.                          -->
 
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <gazebo reference="body">
+  <gazebo reference="${prefix}body">
     <sensor name="sci_cam" type="camera">
       <pose>0 0 0 0 0 0</pose>
       <always_on>true</always_on>


### PR DESCRIPTION
tf_prefix is not supported on noetic for some reason:
https://github.com/ros/robot_state_publisher/pull/139

Given this, in order to have multiple robots, the only workaround is to pass the prefic to the xacro files and make the link names have the prefix.
Tested on ubuntu 16 and 20 and with no namespace and queen, everything seems functional. Also adjusted the rviz file not to expect tf_prefix.