### PR TITLE
Optionally publish NavCam and DockCam images in raw Bayer format that can later be de-Bayered to RGB

### DIFF
--- a/astrobee/config/cameras.config
+++ b/astrobee/config/cameras.config
@@ -17,6 +17,13 @@
 
 require "context"
 
+-- bayer_enable: Set to true to enable publishing raw Bayer images (can
+--   be converted to RGB). May incur significant I/O overhead.
+
+-- bayer_throttle_ratio: Set to n to publish 1 raw Bayer image for
+--   every n images grabbed. With n = 1, every image is
+--   published. Larger n reduces I/O overhead.
+
 nav_cam = {
   width                = 1280,
   height               = 960,
@@ -28,7 +35,9 @@ nav_cam = {
   gain                 = robot_camera_calibrations.nav_cam.gain,
   exposure             = robot_camera_calibrations.nav_cam.exposure,
   calibration_gain     = 105,
-  calibration_exposure = 30
+  calibration_exposure = 30,
+  bayer_enable = false,
+  bayer_throttle_ratio = 3
 };
 
 dock_cam = {
@@ -42,7 +51,9 @@ dock_cam = {
   gain=            robot_camera_calibrations.dock_cam.gain,
   exposure=        robot_camera_calibrations.dock_cam.exposure,
   calibration_gain     = 105,
-  calibration_exposure = 30
+  calibration_exposure = 30,
+  bayer_enable = false,
+  bayer_throttle_ratio = 3
 };
 
 -- The haz and perch cam params below are ignored for the time being.

--- a/hardware/is_camera/include/is_camera/camera.h
+++ b/hardware/is_camera/include/is_camera/camera.h
@@ -46,18 +46,22 @@ struct V4LStruct;
 // Nodelet class
 class CameraNodelet : public ff_util::FreeFlyerNodelet {
  public:
-  static constexpr size_t kImageMsgBuffer = 15;  // 17.6 Mb of buffer space. This
-                                                 // number is so large because
-                                                 // this sets the life time for
-                                                 // each image message sent
-                                                 // out. Eventually we'll write
-                                                 // over the pointer we've
-                                                 // handed out. 15 frames means
-                                                 // .. an image will stay valid
-                                                 // for 1.0 seconds.
-                                                 // Localization can process at
-                                                 // 2 Hz, so it only needs an
-                                                 // image for 0.5 seconds.
+  // The size of the image message ring buffer for publishing
+  // grayscale images.  15 images = 17.6 MB of buffer space. This
+  // number is so large because it sets the lifetime for each image
+  // message sent out. Eventually we'll write over the pointer we've
+  // handed out. At 15 Hz, 15 frames means an image will stay valid
+  // for 1.0 seconds.  Localization can process at 2 Hz, so it only
+  // needs an image for 0.5 seconds.
+  static constexpr size_t kImageMsgBuffer = 15;
+
+  // The size of the image message ring buffer for publishing raw
+  // Bayer format images.  The same comments apply about message
+  // lifetime, but in this case we're expecting the subscriber
+  // callback to at most de-Bayer the image before passing it on, so
+  // the buffer doesn't need to be so long.
+  static constexpr size_t kBayerImageMsgBufferLength = 5;
+
   static constexpr size_t kImageWidth = 1280;
   static constexpr size_t kImageHeight = 960;
 
@@ -71,22 +75,36 @@ class CameraNodelet : public ff_util::FreeFlyerNodelet {
  private:
   void PublishLoop();
   bool EnableService(ff_msgs::SetBool::Request& req, ff_msgs::SetBool::Response& res);  // NOLINT
+  size_t getNumBayerSubscribers();
 
   sensor_msgs::ImagePtr img_msg_buffer_[kImageMsgBuffer];
+  sensor_msgs::ImagePtr bayer_img_msg_buffer_[kBayerImageMsgBufferLength];
   size_t img_msg_buffer_idx_;
+  size_t bayer_img_msg_buffer_idx_;
   std::thread thread_;
   std::atomic<bool> thread_running_;
   ros::Publisher pub_;
+  ros::Publisher bayer_pub_;
   std::shared_ptr<V4LStruct> v4l_;
 
   config_reader::ConfigReader config_;
   ros::Timer config_timer_;
-  std::string output_topic_;
   std::string camera_device_;
   std::string camera_topic_;
+  std::string bayer_camera_topic_;
   std::string config_name_;
   int camera_gain_, camera_exposure_;
   bool calibration_mode_;
+
+  // bayer_enable: Set to true to enable publishing raw Bayer image
+  // (can be converted to RGB). May incur significant I/O overhead.
+  bool bayer_enable_;
+
+  // bayer_throttle_ratio: Set to n to publish 1 raw Bayer image for
+  // every n images grabbed. With n = 1, every image is
+  // published. Larger n reduces I/O overhead.
+  unsigned int bayer_throttle_ratio_;
+  size_t bayer_throttle_ratio_counter_;
 };
 
 }  // end namespace is_camera

--- a/hardware/is_camera/src/camera.cc
+++ b/hardware/is_camera/src/camera.cc
@@ -162,7 +162,12 @@ namespace is_camera {
   };
 
   CameraNodelet::CameraNodelet() : ff_util::FreeFlyerNodelet(),
-    img_msg_buffer_idx_(0), thread_running_(false), camera_topic_(""), calibration_mode_(false)
+    img_msg_buffer_idx_(0),
+    bayer_img_msg_buffer_idx_(0),
+    thread_running_(false),
+    camera_topic_(""),
+    calibration_mode_(false),
+    bayer_throttle_ratio_counter_(0)
     {}
 
   CameraNodelet::~CameraNodelet() {
@@ -196,6 +201,10 @@ namespace is_camera {
       config_.CheckFilesUpdated(std::bind(&CameraNodelet::ReadParams, this));}, false, true);
 
     pub_ = nh->advertise<sensor_msgs::Image>(camera_topic_, 1);
+    if (bayer_enable_) {
+      bayer_camera_topic_ = camera_topic_ + "_bayer";
+      bayer_pub_ = nh->advertise<sensor_msgs::Image>(bayer_camera_topic_, 1);
+    }
 
     // Allocate space for our output msg buffer
     for (size_t i = 0; i < kImageMsgBuffer; i++) {
@@ -207,9 +216,29 @@ namespace is_camera {
       img_msg_buffer_[i]->data.resize(kImageWidth * kImageHeight);
     }
 
+    if (bayer_enable_) {
+      // Allocate space for our Bayer output msg buffer
+      for (size_t i = 0; i < kBayerImageMsgBufferLength; i++) {
+        img_msg_buffer_[i].reset(new sensor_msgs::Image());
+        bayer_img_msg_buffer_[i]->width = kImageWidth;
+        bayer_img_msg_buffer_[i]->height = kImageHeight;
+        bayer_img_msg_buffer_[i]->encoding = "bayer_grgb8";
+        bayer_img_msg_buffer_[i]->step = kImageWidth;
+        bayer_img_msg_buffer_[i]->data.resize(kImageWidth * kImageHeight);
+      }
+    }
+
     v4l_.reset(new V4LStruct(camera_device_, camera_gain_, camera_exposure_));
     thread_running_ = true;
     thread_ = std::thread(&CameraNodelet::PublishLoop, this);
+  }
+
+  size_t CameraNodelet::getNumBayerSubscribers(void) {
+    if (bayer_enable_) {
+      return bayer_pub_.getNumSubscribers();
+    } else {
+      return 0;
+    }
   }
 
   void CameraNodelet::ReadParams(void) {
@@ -251,6 +280,18 @@ namespace is_camera {
       }
     }
 
+    if (!camera.GetBool("bayer_enable", &bayer_enable_)) {
+      FF_FATAL("Bayer enable not specified.");
+      exit(EXIT_FAILURE);
+    }
+
+    if (bayer_enable_) {
+      if (!camera.GetUInt("bayer_throttle_ratio", &bayer_throttle_ratio_)) {
+        FF_FATAL("Bayer throttle ratio not specified.");
+        exit(EXIT_FAILURE);
+      }
+    }
+
     if (thread_running_) {
       v4l_->SetParameters(camera_gain_, camera_exposure_);
     }
@@ -261,7 +302,7 @@ namespace is_camera {
 
     while (thread_running_) {
       if (!camera_running) {
-        while ((pub_.getNumSubscribers() == 0) && thread_running_)
+        while ((pub_.getNumSubscribers() + getNumBayerSubscribers() == 0) && thread_running_)
           usleep(100000);
         if (!thread_running_)
           break;
@@ -299,34 +340,63 @@ namespace is_camera {
       int last_buf = v4l_->buf.index;
 
       v4l_->buf.index = (last_buf + 1) % v4l_->req.count;
-      if (pub_.getNumSubscribers() != 0)
+      if (pub_.getNumSubscribers() + getNumBayerSubscribers() > 0)
         xioctl(v4l_->fd, VIDIOC_QBUF, &v4l_->buf);
       else
         camera_running = false;
       ros::Time timestamp = ros::Time::now();
 
-      // Select our output msg buffer
-      img_msg_buffer_idx_ = (img_msg_buffer_idx_ + 1) % kImageMsgBuffer;
-
       if (!failed) {
-        // Wrap the buffer with cv::Mat so we can manipulate it.
-        cv::Mat wrapped(v4l_->fmt.fmt.pix.height,
-            v4l_->fmt.fmt.pix.width,
-            cv::DataType<uint8_t>::type,
-            v4l_->buffers[last_buf].start,
-            v4l_->fmt.fmt.pix.width);  // does not copy
-        cv::Mat owrapped(kImageHeight, kImageWidth,
-            cv::DataType<uint8_t>::type,
-            &(img_msg_buffer_[img_msg_buffer_idx_]->data[0]),
-            kImageWidth);
-        cv::cvtColor(wrapped, owrapped,
-            CV_BayerGR2GRAY);
+        if (pub_.getNumSubscribers() > 0) {
+          sensor_msgs::ImagePtr& out_image = img_msg_buffer_[img_msg_buffer_idx_];
 
-        // Attach the time
-        img_msg_buffer_[img_msg_buffer_idx_]->header = std_msgs::Header();
-        img_msg_buffer_[img_msg_buffer_idx_]->header.stamp = timestamp;
+          // Use OpenCV to convert raw Bayer format to grayscale (writing the result
+          // into the pre-allocated slot in the image message ring buffer).
+          cv::Mat wrapped(v4l_->fmt.fmt.pix.height,
+                          v4l_->fmt.fmt.pix.width,
+                          cv::DataType<uint8_t>::type,
+                          v4l_->buffers[last_buf].start,
+                          v4l_->fmt.fmt.pix.width);  // does not copy
+          cv::Mat owrapped(kImageHeight, kImageWidth,
+                           cv::DataType<uint8_t>::type,
+                           &(out_image->data[0]),
+                           kImageWidth);
+          cv::cvtColor(wrapped, owrapped,
+                       CV_BayerGR2GRAY);
 
-        pub_.publish(img_msg_buffer_[img_msg_buffer_idx_]);
+          // Attach the time
+          out_image->header = std_msgs::Header();
+          out_image->header.stamp = timestamp;
+
+          pub_.publish(out_image);
+
+          // Increment index in ring buffer
+          img_msg_buffer_idx_ = (img_msg_buffer_idx_ + 1) % kImageMsgBuffer;
+        }
+
+        if (getNumBayerSubscribers() > 0) {
+          bayer_throttle_ratio_counter_ = (bayer_throttle_ratio_counter_ + 1)
+            % bayer_throttle_ratio_;
+
+          if (bayer_throttle_ratio_counter_ == 0) {
+            sensor_msgs::ImagePtr& out_image = bayer_img_msg_buffer_[bayer_img_msg_buffer_idx_];
+
+            // Copy the raw Bayer format data into the pre-allocated
+            // slot in the image message ring buffer.
+            memcpy(&(out_image->data[0]),
+                   v4l_->buffers[last_buf].start,
+                   kImageWidth * kImageHeight);
+
+            // Attach the time
+            out_image->header = std_msgs::Header();
+            out_image->header.stamp = timestamp;
+
+            bayer_pub_.publish(out_image);
+
+            // Increment index in ring buffer
+            bayer_img_msg_buffer_idx_ = (bayer_img_msg_buffer_idx_ + 1) % kBayerImageMsgBufferLength;
+          }
+        }
       }
 
       ros::spinOnce();


### PR DESCRIPTION
Not tested yet!

Adds a feature to the is_camera driver for NavCam and DockCam that optionally publishes images in raw Bayer format. The feature is disabled by default in cameras.config (bayer_enable parameter). The rate of publishing Bayer images can be throttled (bayer_throttle_ratio parameter).

The implementation is much like the existing grayscale output but instead of converting Bayer to grayscale, it just copies the raw Bayer imagery into the output message (ROS supports tagging the image as Bayer encoded).

There are a number of ways we could use it downstream. Perhaps the most ROS-idiomatic approach would be to run the Bayer-encoded images through the ROS image_proc package's debayer nodelet, and then subscribe to the resulting color image topic in the image sampler.