### PR TITLE
Ignore astrobee astrobee bridge when dds is false

### DIFF
--- a/astrobee/config/robots/sim_pub.config
+++ b/astrobee/config/robots/sim_pub.config
@@ -16,4 +16,4 @@
 -- under the License.
 require "robots/sim"
 
-nodes_not_running = {"dds_ros_bridge"}
+nodes_not_running = {"dds_ros_bridge", "astrobee_astrobee_bridge"}


### PR DESCRIPTION
Added the astrobee to astrobee bridge to the list of nodes ignored when
using the sim_pub robot. This prevents an astrobee to astrobee bridge
heartbeat fault when the dds flag is set to false.