### PR TITLE
fixing actionlib BUG in Ubuntu 20

### DIFF
--- a/shared/ff_util/include/ff_util/ff_action.h
+++ b/shared/ff_util/include/ff_util/ff_action.h
@@ -217,7 +217,7 @@ class FreeFlyerActionClient {
     timer_poll_ = nh->createTimer(to_poll_,
         &FreeFlyerActionClient::ConnectPollCallback, this, false, false);
     timer_response_delay_ = nh->createTimer(to_response_delay_,
-        &FreeFlyerActionClient::ResultDelayCallback, this, false, false);
+        &FreeFlyerActionClient::ResultDelayCallback, this, true, false);
     // Initialize the action client
     sac_ = std::shared_ptr < actionlib::SimpleActionClient < ActionSpec > > (
       new actionlib::SimpleActionClient < ActionSpec > (*nh, topic, false));
@@ -381,10 +381,6 @@ class FreeFlyerActionClient {
 
   // Called when a result is received
   void ResultDelayCallback(ros::TimerEvent const& event) {
-    // Feedback has been received after a result before. Stop tracking the goal
-    // so that this doesn't happen
-    timer_response_delay_.stop();
-
     // Call the result callback on the client side
     Complete(state_response_, result_);
 

--- a/shared/ff_util/include/ff_util/ff_action.h
+++ b/shared/ff_util/include/ff_util/ff_action.h
@@ -379,7 +379,11 @@ class FreeFlyerActionClient {
     StartOptionalTimer(timer_response_delay_, to_response_delay_);
   }
 
-  // Called when a result is received
+  // This delayed callback is necessary because an action is only considered
+  // finished once the ResultCallback returns. This raises the problem where,
+  // if another action of the same type is called in the ResultCallback
+  // or immediately afterwards, it returns failed because the previous action
+  // is technically not finished
   void ResultDelayCallback(ros::TimerEvent const& event) {
     // Call the result callback on the client side
     Complete(state_response_, result_);

--- a/shared/ff_util/include/ff_util/ff_action.h
+++ b/shared/ff_util/include/ff_util/ff_action.h
@@ -387,7 +387,7 @@ class FreeFlyerActionClient {
 
     // Call the result callback on the client side
     Complete(state_response_, result_);
-    
+
     // Return to waiting for a goal
     state_ = WAITING_FOR_GOAL;
   }

--- a/shared/ff_util/include/ff_util/ff_action.h
+++ b/shared/ff_util/include/ff_util/ff_action.h
@@ -161,11 +161,12 @@ class FreeFlyerActionClient {
     WAITING_FOR_RESPONSE, /*!< Goal accepted but no feedback/result yet */
     WAITING_FOR_DEADLINE  /*!< Deadline */
   };
-  static constexpr double DEFAULT_TIMEOUT_CONNECTED = 0.0;
-  static constexpr double DEFAULT_TIMEOUT_ACTIVE    = 0.0;
-  static constexpr double DEFAULT_TIMEOUT_RESPONSE  = 0.0;
-  static constexpr double DEFAULT_TIMEOUT_DEADLINE  = 0.0;
-  static constexpr double DEFAULT_POLL_DURATION     = 0.1;
+  static constexpr double DEFAULT_TIMEOUT_CONNECTED      = 0.0;
+  static constexpr double DEFAULT_TIMEOUT_ACTIVE         = 0.0;
+  static constexpr double DEFAULT_TIMEOUT_RESPONSE       = 0.0;
+  static constexpr double DEFAULT_TIMEOUT_DEADLINE       = 0.0;
+  static constexpr double DEFAULT_POLL_DURATION          = 0.1;
+  static constexpr double DEFAULT_TIMEOUT_RESPONSE_DELAY = 0.1;
 
  public:
   // Templated action definition
@@ -183,7 +184,8 @@ class FreeFlyerActionClient {
     to_active_(DEFAULT_TIMEOUT_ACTIVE),
     to_response_(DEFAULT_TIMEOUT_RESPONSE),
     to_deadline_(DEFAULT_TIMEOUT_DEADLINE),
-    to_poll_(DEFAULT_POLL_DURATION) {}
+    to_poll_(DEFAULT_POLL_DURATION),
+    to_response_delay_(DEFAULT_TIMEOUT_RESPONSE_DELAY) {}
 
   // Destructor
   ~FreeFlyerActionClient() {}
@@ -214,6 +216,8 @@ class FreeFlyerActionClient {
       &FreeFlyerActionClient::DeadlineTimeoutCallback, this, true, false);
     timer_poll_ = nh->createTimer(to_poll_,
         &FreeFlyerActionClient::ConnectPollCallback, this, false, false);
+    timer_response_delay_ = nh->createTimer(to_response_delay_,
+        &FreeFlyerActionClient::ResultDelayCallback, this, false, false);
     // Initialize the action client
     sac_ = std::shared_ptr < actionlib::SimpleActionClient < ActionSpec > > (
       new actionlib::SimpleActionClient < ActionSpec > (*nh, topic, false));
@@ -362,12 +366,28 @@ class FreeFlyerActionClient {
     // so that this doesn't happen
     sac_->stopTrackingGoal();
     // The response we send depends on the state
+    result_ = result;
+
+    // The response we send depends on the state
     if (action_state == actionlib::SimpleClientGoalState::SUCCEEDED)
-      Complete(FreeFlyerActionState::SUCCESS, result);
+      state_response_ = FreeFlyerActionState::SUCCESS;
     else if (action_state == actionlib::SimpleClientGoalState::PREEMPTED)
-      Complete(FreeFlyerActionState::PREEMPTED, result);
+      state_response_ = FreeFlyerActionState::PREEMPTED;
     else
-      Complete(FreeFlyerActionState::ABORTED, result);
+      state_response_ = FreeFlyerActionState::ABORTED;
+
+    StartOptionalTimer(timer_response_delay_, to_response_delay_);
+  }
+
+  // Called when a result is received
+  void ResultDelayCallback(ros::TimerEvent const& event) {
+    // Feedback has been received after a result before. Stop tracking the goal
+    // so that this doesn't happen
+    timer_response_delay_.stop();
+
+    // Call the result callback on the client side
+    Complete(state_response_, result_);
+    
     // Return to waiting for a goal
     state_ = WAITING_FOR_GOAL;
   }
@@ -379,6 +399,7 @@ class FreeFlyerActionClient {
   ros::Duration to_response_;
   ros::Duration to_deadline_;
   ros::Duration to_poll_;
+  ros::Duration to_response_delay_;
   std::shared_ptr < actionlib::SimpleActionClient < ActionSpec > > sac_;
   FeedbackCallbackType cb_feedback_;
   ResultCallbackType cb_result_;
@@ -389,6 +410,10 @@ class FreeFlyerActionClient {
   ros::Timer timer_response_;
   ros::Timer timer_deadline_;
   ros::Timer timer_poll_;
+  ros::Timer timer_response_delay_;
+  // Save response
+  FreeFlyerActionState::Enum state_response_;
+  ResultConstPtr result_;
 };
 
 }  // namespace ff_util

--- a/shared/ff_util/include/ff_util/ff_action.h
+++ b/shared/ff_util/include/ff_util/ff_action.h
@@ -383,7 +383,7 @@ class FreeFlyerActionClient {
   // an action is only considered finished once the ResultCallback returns.
   // This raises the problem where, if another action of the same type is
   // called in the ResultCallback or immediately afterwards, it returns
-  // failed because the previous action is technically not finished and 
+  // failed because the previous action is technically not finished and
   // returns an error.
   void ResultDelayCallback(ros::TimerEvent const& event) {
     // Call the result callback on the client side

--- a/shared/ff_util/include/ff_util/ff_action.h
+++ b/shared/ff_util/include/ff_util/ff_action.h
@@ -379,11 +379,12 @@ class FreeFlyerActionClient {
     StartOptionalTimer(timer_response_delay_, to_response_delay_);
   }
 
-  // This delayed callback is necessary because an action is only considered
-  // finished once the ResultCallback returns. This raises the problem where,
-  // if another action of the same type is called in the ResultCallback
-  // or immediately afterwards, it returns failed because the previous action
-  // is technically not finished
+  // This delayed callback is necessary because on Ubuntu 20 / ROS noetic,
+  // an action is only considered finished once the ResultCallback returns.
+  // This raises the problem where, if another action of the same type is
+  // called in the ResultCallback or immediately afterwards, it returns
+  // failed because the previous action is technically not finished and 
+  // returns an error.
   void ResultDelayCallback(ros::TimerEvent const& event) {
     // Call the result callback on the client side
     Complete(state_response_, result_);


### PR DESCRIPTION
This fixes the BUG on Ubuntu 20:
[ERROR] [1626285660.006720060, 10.360000000] : (ros.Astrobee.actionlib) BUG: Got a transition to CommState [ACTIVE] when in SimpleGoalState [DONE]
[ WARN] [1626285661.000143376, 11.360000000] : (ros.Astrobee) Freeflyer action timed out on going active.
[ERROR] [1626285663.010712617, 13.368000000] : (ros.Astrobee.actionlib) BUG: Got a second transition to DONE

I tested the perching, cargo transport and reacquire position commands
The delay ended up being 0.1, same as poll, so I don't think it will influence the overall performance.
Let me know if there's anything we can improve to make this fix 'cleaner'