### PR TITLE
Increased plan name size and reject plans if the plan name is too long.

### DIFF
--- a/communications/dds_msgs/idl/PlanStatus.idl
+++ b/communications/dds_msgs/idl/PlanStatus.idl
@@ -43,7 +43,7 @@ module rapid {
         //@copy-c-declaration typedef PlanStatus Type;
 
         //@copy-declaration /**  the name of the currently executing/paused plan */
-        public String32 planName;
+        public String128 planName;
 
         //@copy-declaration /**  The current station or segment */
         public long currentPoint;

--- a/communications/dds_ros_bridge/src/ros_plan_status_rapid_plan_status.cc
+++ b/communications/dds_ros_bridge/src/ros_plan_status_rapid_plan_status.cc
@@ -44,8 +44,8 @@ ff::RosPlanStatusRapidPlanStatus::Callback(
 
   msg.hdr.timeStamp = util::RosTime2RapidTime(status->header.stamp);
 
-  std::strncpy(msg.planName, status->name.data(), 32);
-  msg.planName[31] = '\0';  // ensure null-terminated
+  std::strncpy(msg.planName, status->name.data(), 128);
+  msg.planName[127] = '\0';  // ensure null-terminated
 
   msg.currentPoint = status->point;
   msg.currentCommand = status->command;

--- a/management/executive/src/executive.cc
+++ b/management/executive/src/executive.cc
@@ -2711,7 +2711,6 @@ bool Executive::SetPlan(ff_msgs::CommandStampedPtr const& cmd) {
   std::string err_msg;
   if (plan_) {
     if (sequencer::LoadPlan(plan_, &sequencer_)) {
-      NODELET_ERROR_STREAM("Plan name is " << sequencer_.plan_status().name << " size of the plan name is: " << std::to_string(sequencer_.plan_status().name.size()));
       if (sequencer_.plan_status().name.size() < 128) {
         // Set plan execution state to paused, apparently this was the way
         // spheres worked

--- a/management/executive/src/executive.cc
+++ b/management/executive/src/executive.cc
@@ -2711,20 +2711,33 @@ bool Executive::SetPlan(ff_msgs::CommandStampedPtr const& cmd) {
   std::string err_msg;
   if (plan_) {
     if (sequencer::LoadPlan(plan_, &sequencer_)) {
-      // Set plan execution state to paused, apparently this was the way
-      // spheres worked
-      SetPlanExecState(ff_msgs::ExecState::PAUSED);
-      // Publish plan stuff for ground
-      PublishPlan();
-      PublishPlanStatus(ff_msgs::AckStatus::QUEUED);
-      // Clear plan so that the operator has to upload a new plan after this
-      // plan is done running
-      plan_.reset();
-      state_->AckCmd(cmd->cmd_id);
-      return true;
+      NODELET_ERROR_STREAM("Plan name is " << sequencer_.plan_status().name << " size of the plan name is: " << std::to_string(sequencer_.plan_status().name.size()));
+      if (sequencer_.plan_status().name.size() < 128) {
+        // Set plan execution state to paused, apparently this was the way
+        // spheres worked
+        SetPlanExecState(ff_msgs::ExecState::PAUSED);
+        // Publish plan stuff for ground
+        PublishPlan();
+        PublishPlanStatus(ff_msgs::AckStatus::QUEUED);
+        // Clear plan so that the operator has to upload a new plan after this
+        // plan is done running
+        plan_.reset();
+        state_->AckCmd(cmd->cmd_id);
+        return true;
+      } else {
+        // If the plan name is greater than 127 characters, ack it as bad syntax
+        // The plan status rapid message only supports plan names that are
+        // no more than 128 characters where the last character is the null
+        // character.
+        err_msg = "Plan name is too long. Size needs to be less than 128 ";
+        err_msg += "characters instead of ";
+        err_msg += std::to_string(sequencer_.plan_status().name.size());
+        err_msg += " characters.";
+      }
+    } else {
+      err_msg = "Invalid syntax in uploaded plan!";
     }
     plan_.reset();
-    err_msg = "Invalid syntax in uploaded plan!";
   } else {
     err_msg = "No plan found! Plan must have failed to upload.";
   }


### PR DESCRIPTION
GDS requires the full plan name for some error checking. Thus, we have decided to make plans with names longer than 128 characters invalid.