### PR TITLE
Separate multi-robot bridge configuration from main DDS files

### DIFF
--- a/astrobee/config/communications/dds_intercomms/NDDS_DISCOVERY_PEERS
+++ b/astrobee/config/communications/dds_intercomms/NDDS_DISCOVERY_PEERS
@@ -1,0 +1,17 @@
+;; NDDS_DISCOVERY_PEERS - Default Discovery Configuration File
+;;Multicast builtin.udpv4://239.255.0.1 ; default discovery multicast addr
+; EVERY LINE IN THIS FILE MUST END IN A COMMENT. Even blank lines.
+;
+;; Shared Memory
+;shmem://                ; All 'shmem' transport plugin(s)
+;builtin.shmem://        ; The builtin builtin 'shmem' transport plugin
+                         ;  at network address FCC0::0
+;
+;; Unicast
+;
+;; Localhost
+127.0.0.1              ; A comma can be used a separator
+;
+;; Granite Lab - P4
+;
+;; Custom entries below this line (Vagrant, etc)

--- a/astrobee/config/communications/dds_intercomms/RAPID_QOS_PROFILES.xml
+++ b/astrobee/config/communications/dds_intercomms/RAPID_QOS_PROFILES.xml
@@ -1,0 +1,989 @@
+<?xml version="1.0"?>
+<dds xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="/usr/local/irg/apps/RTI/ndds.4.5e/resource/qos_profiles_4.5e/schema/rti_dds_qos_profiles.xsd">
+  <!-- ################################################################### -->
+  <!-- ## RapidQosLibrary -->
+  <!-- ################################################################### -->
+  <qos_library name="RapidQosLibrary">
+    <qos_profile name="RapidDefaultQos" is_default_qos="true">
+      <participant_qos>
+        <user_data>
+          <!--  version of Qos File MUST CONVERT TO UNICODE: -->
+          <!--  http://rishida.net/tools/conversion/ -->
+          <!--  On Mixed Input text box, enter: YYYYMMDD.HHMMSS.III-LOC  -->
+          <!--  where III = Initials (2 or 3 chars) LOC = 3 char location -->
+          <!--  Version: 20110629.094600.HU-ARC -->
+          <value>50, 48, 49, 49, 48, 54,0x32,0x39,0x2e,0x30,0x39,0x34,0x33,0x30,0x30,0x2e,0x48,0x55,0x2d,0x41,0x52,0x43</value>
+        </user_data>
+        <wire_protocol>
+          <!-- default DDS well known ports -->
+          <rtps_well_known_ports>
+            <port_base>7400</port_base>
+            <domain_id_gain>250</domain_id_gain>
+            <participant_id_gain>2</participant_id_gain>
+            <builtin_multicast_port_offset>0</builtin_multicast_port_offset>
+            <builtin_unicast_port_offset>10</builtin_unicast_port_offset>
+            <user_multicast_port_offset>1</user_multicast_port_offset>
+            <user_unicast_port_offset>11</user_unicast_port_offset>
+          </rtps_well_known_ports>
+          <rtps_reserved_port_mask>MASK_DEFAULT</rtps_reserved_port_mask>
+        </wire_protocol>
+        <transport_builtin>
+          <mask>UDPv4</mask>
+        </transport_builtin>
+        <discovery>
+          <!-- if false, we do an explicit configuration through the discovery-peers files. -->
+          <!-- This limits accidental traffic on the robot-networks. -->
+          <!-- For the ground-side router, allowing unknown peers might be preferred. -->
+          <accept_unknown_peers>true</accept_unknown_peers>
+        </discovery>
+        <resource_limits>
+          <!-- increase max property size to accommodate flow controllers -->
+          <participant_property_string_max_length>4096</participant_property_string_max_length>
+          <!-- Type-codes don't work with overly restricted buffer size, so we disable it. -->
+          <!-- disabling type-code support -->
+          <type_code_max_serialized_length>0</type_code_max_serialized_length>
+          <type_object_max_serialized_length>0</type_object_max_serialized_length>
+        </resource_limits>
+
+        <property>
+          <value>
+            <!-- === Flow Controllers ===================================================================== -->
+            <!-- === note that each flow controller will add about 600 characters to the cumulative size of -->
+            <!-- === the property string, so resource_limits.participant_property_string_max_length must be -->
+            <!-- === increased to accommodate the larger size -->
+            <!-- NavMapFlowController -->
+            <element>
+              <name>dds.flow_controller.token_bucket.MeshFlowController.scheduling_policy</name>
+              <value>DDS_EDF_FLOW_CONTROLLER_SCHED_POLICY</value>
+            </element>
+            <element>
+              <name>dds.flow_controller.token_bucket.MeshFlowController.token_bucket.max_tokens</name>
+              <value>12</value>
+            </element>
+            <element>
+              <name>dds.flow_controller.token_bucket.MeshFlowController.token_bucket.tokens_added_per_period</name>
+              <value>4</value>
+            </element>
+            <element>
+              <name>dds.flow_controller.token_bucket.MeshFlowController.token_bucket.tokens_leaked_per_period</name>
+              <value>0</value>
+            </element>
+            <element>
+              <name>dds.flow_controller.token_bucket.MeshFlowController.token_bucket.bytes_per_token</name>
+              <value>1250</value>
+            </element>
+            <element>
+              <name>dds.flow_controller.token_bucket.MeshFlowController.token_bucket.period.sec</name>
+              <value>0</value>
+            </element>
+            <element>
+              <name>dds.flow_controller.token_bucket.MeshFlowController.token_bucket.period.nanosec</name>
+              <value>5000000</value>
+            </element>
+
+            <!-- === Transport ============================================================================ -->
+            <!--
+            <element>
+              <name>dds.transport.UDPv4.builtin.public_address</name>
+              <value>GROUND_PROXY_IP</value>
+            </element>
+            -->
+            <!-- maximum message size -->
+            <element>
+              <name>dds.transport.UDPv4.builtin.parent.message_size_max</name>
+              <value>1250</value>
+            </element>
+            <element>
+              <name>dds.transport.UDPv4.builtin.send_socket_buffer_size</name>
+              <value>65535</value>
+            </element>
+            <element>
+              <name>dds.transport.UDPv4.builtin.recv_socket_buffer_size</name>
+              <value>65535</value>
+            </element>
+            <!-- === SHMEM Transport ====================================================================== -->
+            <!-- maximum message size -->
+            <element>
+              <name>dds.transport.shmem.builtin.received_message_count_max </name>
+              <value>512</value>
+            </element>
+            <element>
+              <name>dds.transport.shmem.builtin.receive_buffer_size </name>
+              <value>1048576</value>
+            </element>
+            <!-- allow/deny lists -->
+            <!-- we try to exclude all vmware virtual network interfaces -->
+            <element>
+              <name>dds.transport.UDPv4.builtin.parent.deny_interfaces</name>
+              <value>128.102.*,10.10.1.*,10.30.10.*,192.168.3.255,169.254.194.2,192.9.202.1,192.168.5.*,192.168.10.*,192.168.122.*</value>
+            </element>
+            <element>
+              <name>dds.transport.UDPv4.builtin.parent.deny_multicast_interfaces</name>
+              <value>128.102.*,10.10.1.*,10.30.10.*,192.168.3.255,169.254.194.2,192.9.202.1,192.168.5.*,192.168.10.*,192.168.122.*</value>
+            </element>
+          </value>
+        </property>
+      </participant_qos>
+      <publisher_qos>
+      </publisher_qos>
+      <subscriber_qos>
+      </subscriber_qos>
+      <datareader_qos>
+        <reader_resource_limits>
+          <!-- disabling dynamically allocated fragments because it is causing 4.5e to crash on large fragmented messages (e.g. point clouds) -->
+          <dynamically_allocate_fragmented_samples>0</dynamically_allocate_fragmented_samples>
+        </reader_resource_limits>
+      </datareader_qos>
+      <datawriter_qos>
+        <writer_resource_limits>
+          <!-- see http://community.rti.com/content/forum-topic/instance-resources-dispose-and-unregister -->
+          <instance_replacement>ALIVE_THEN_DISPOSED_INSTANCE_REPLACEMENT</instance_replacement>
+        </writer_resource_limits>
+        <publish_mode>
+          <kind>ASYNCHRONOUS_PUBLISH_MODE_QOS</kind>
+        </publish_mode>
+      </datawriter_qos>
+    </qos_profile>
+
+    <!-- Best Effort base configuration -->
+    <!-- ===================================================== -->
+    <qos_profile name="RapidBestEffortQos" base_name="RapidDefaultQos" >
+      <datareader_qos>
+        <reliability>
+          <kind>BEST_EFFORT_RELIABILITY_QOS</kind>
+        </reliability>
+        <history>
+          <kind>KEEP_LAST_HISTORY_QOS</kind>
+          <depth>5</depth>
+        </history>
+      </datareader_qos>
+      <datawriter_qos>
+        <reliability>
+          <kind>BEST_EFFORT_RELIABILITY_QOS</kind>
+        </reliability>
+        <history>
+          <kind>KEEP_LAST_HISTORY_QOS</kind>
+          <depth>5</depth>
+        </history>
+      </datawriter_qos>
+    </qos_profile>
+
+    <!-- Reliable base configuration -->
+    <!-- ===================================================== -->
+    <qos_profile name="RapidReliableQos" base_name="RapidDefaultQos">
+      <datareader_qos>
+        <reliability>
+          <kind>RELIABLE_RELIABILITY_QOS</kind>
+        </reliability>
+        <history>
+          <kind>KEEP_ALL_HISTORY_QOS</kind>
+        </history>
+      </datareader_qos>
+      <datawriter_qos>
+        <reliability>
+          <kind>RELIABLE_RELIABILITY_QOS</kind>
+        </reliability>
+        <history>
+          <!-- To implement strict reliability, we need to set the history to KEEP_ALL.
+          That way, undelivered samples will not be overwritten. -->
+          <kind>KEEP_ALL_HISTORY_QOS</kind>
+        </history>
+      </datawriter_qos>
+    </qos_profile>
+
+    <!-- Reliable, durable base configuration -->
+    <!-- ===================================================== -->
+    <qos_profile name="RapidReliableDurableQos" base_name="RapidDefaultQos">
+      <datareader_qos>
+        <reliability>
+          <kind>RELIABLE_RELIABILITY_QOS</kind>
+        </reliability>
+        <durability>
+          <kind>TRANSIENT_LOCAL_DURABILITY_QOS</kind>
+        </durability>
+        <history>
+          <kind>KEEP_LAST_HISTORY_QOS</kind>
+          <depth>1</depth>
+        </history>
+      </datareader_qos>
+      <datawriter_qos>
+        <reliability>
+          <kind>RELIABLE_RELIABILITY_QOS</kind>
+        </reliability>
+        <durability>
+          <kind>TRANSIENT_LOCAL_DURABILITY_QOS</kind>
+        </durability>
+        <history>
+          <kind>KEEP_LAST_HISTORY_QOS</kind>
+          <depth>1</depth>
+        </history>
+      </datawriter_qos>
+    </qos_profile>
+
+    <!-- ===================================================== -->
+    <!-- Generic per Topic Category Profiles -->
+    <!-- ===================================================== -->
+
+    <!-- Generic Config Profile -->
+    <!-- ===================================================== -->
+    <qos_profile name="RapidConfigQos" base_name="RapidReliableDurableQos" />
+    <!-- Generic State Profile -->
+    <!-- ===================================================== -->
+    <qos_profile name="RapidStateQos" base_name="RapidReliableDurableQos" />
+    <!-- Generic Sample Profile -->
+    <!-- ===================================================== -->
+    <qos_profile name="RapidSampleQos" base_name="RapidBestEffortQos" />
+
+
+    <!-- ===================================================== -->
+    <!-- Per Topic Profiles -->
+    <!-- ===================================================== -->
+
+    <!-- ===================================================== -->
+    <qos_profile name="RapidAckProfile" base_name="RapidReliableDurableQos" />
+    <!-- ===================================================== -->
+    <qos_profile name="RapidAgentConfigProfile" base_name="RapidConfigQos" />
+    <qos_profile name="RapidAgentStateProfile" base_name="RapidSampleQos" />
+    <!-- ===================================================== -->
+    <qos_profile name="RapidAssetConfigProfile" base_name="RapidConfigQos" />
+    <!-- ===================================================== -->
+    <qos_profile name="RapidAssetStateProfile" base_name="RapidStateQos" />
+
+    <!-- ===================================================== -->
+    <qos_profile name="RapidCommandProfile" base_name="RapidReliableQos" />
+    <!-- ===================================================== -->
+    <qos_profile name="RapidCommandConfigProfile" base_name="RapidConfigQos" />
+
+    <!-- ===================================================== -->
+    <qos_profile name="RapidFrameStoreConfigProfile" base_name="RapidConfigQos" />
+
+    <!-- ===================================================== -->
+    <qos_profile name="RapidImageSensorSampleProfile" base_name="RapidSampleQos" />
+    <!-- ===================================================== -->
+    <qos_profile name="RapidImageSensorScienceInstrumentProfile" base_name="RapidDefaultQos">
+      <datareader_qos>
+        <reliability>
+          <kind>RELIABLE_RELIABILITY_QOS</kind>
+        </reliability>
+      </datareader_qos>
+      <datawriter_qos>
+        <reliability>
+          <kind>RELIABLE_RELIABILITY_QOS</kind>
+        </reliability>
+      </datawriter_qos>
+    </qos_profile>
+    <!-- ===================================================== -->
+    <qos_profile name="RapidImageSensorPanoramaProfile" base_name="RapidImageSensorScienceInstrumentProfile">
+      <datareader_qos>
+        <durability>
+          <kind>TRANSIENT_LOCAL_DURABILITY_QOS</kind>
+        </durability>
+        <history>
+          <kind>KEEP_LAST_HISTORY_QOS</kind>
+          <depth>6</depth>
+        </history>
+      </datareader_qos>
+      <datawriter_qos>
+        <durability>
+          <kind>TRANSIENT_LOCAL_DURABILITY_QOS</kind>
+        </durability>
+        <history>
+          <kind>KEEP_LAST_HISTORY_QOS</kind>
+          <depth>6</depth>
+        </history>
+      </datawriter_qos>
+    </qos_profile>
+    <!-- ===================================================== -->
+    <qos_profile name="RapidImageSensorMiProfile" base_name="RapidImageSensorScienceInstrumentProfile">
+      <datareader_qos>
+        <durability>
+          <kind>TRANSIENT_LOCAL_DURABILITY_QOS</kind>
+        </durability>
+        <history>
+          <kind>KEEP_LAST_HISTORY_QOS</kind>
+          <depth>1</depth>
+        </history>
+      </datareader_qos>
+      <datawriter_qos>
+        <durability>
+          <kind>TRANSIENT_LOCAL_DURABILITY_QOS</kind>
+        </durability>
+        <history>
+          <kind>KEEP_LAST_HISTORY_QOS</kind>
+          <depth>1</depth>
+        </history>
+      </datawriter_qos>
+    </qos_profile>
+    <!-- ===================================================== -->
+    <qos_profile name="RapidImageSensorStateProfile" base_name="RapidStateQos" />
+
+    <!-- ===================================================== -->
+    <qos_profile name="RapidJointConfigProfile" base_name="RapidConfigQos" />
+    <!-- ===================================================== -->
+    <qos_profile name="RapidJointSampleProfile" base_name="RapidReliableDurableQos" />
+
+    <!-- Extension: Macro ==================================== -->
+    <qos_profile name="RapidMacroConfigProfile" base_name="RapidConfigQos" />
+    <qos_profile name="RapidMacroStateProfile" base_name="RapidStateQos" />
+
+    <!-- ===================================================== -->
+    <qos_profile name="RapidNavMapConfigProfile" base_name="RapidConfigQos" />
+    <!-- ===================================================== -->
+    <qos_profile name="RapidNavMapSampleProfile" base_name="RapidSampleQos" >
+      <datawriter_qos>
+        <publish_mode>
+<!--          <flow_controller_name>dds.flow_controller.token_bucket.NavMapFlowController</flow_controller_name> -->
+        </publish_mode>
+      </datawriter_qos>
+    </qos_profile>
+
+    <!-- ===================================================== -->
+    <qos_profile name="RapidNavMapTilesConfigProfile" base_name="RapidConfigQos" />
+    <!-- ===================================================== -->
+    <qos_profile name="RapidNavMapTilesSampleProfile" base_name="RapidReliableDurableQos" >
+      <datawriter_qos>
+        <publish_mode>
+<!--          <flow_controller_name>dds.flow_controller.token_bucket.NavMapFlowController</flow_controller_name> -->
+        </publish_mode>
+        <reliability>
+          <max_blocking_time>
+            <sec>0</sec>
+            <nanosec>0</nanosec>
+          </max_blocking_time>
+        </reliability>
+        <history>
+          <kind>KEEP_LAST_HISTORY_QOS</kind>
+          <depth>1</depth>
+        </history>
+        <resource_limits>
+          <max_samples>512</max_samples>
+          <max_samples_per_instance>4</max_samples_per_instance>
+          <max_instances>128</max_instances>
+          <initial_instances>128</initial_instances>
+          <initial_samples>512</initial_samples>
+          <instance_hash_buckets>380</instance_hash_buckets>
+        </resource_limits>
+        <protocol>
+          <rtps_reliable_writer>
+            <high_watermark>32</high_watermark>
+            <fast_heartbeat_period>
+              <sec>0</sec>
+              <nanosec>500000000</nanosec>
+            </fast_heartbeat_period>
+            <max_heartbeat_retries>8</max_heartbeat_retries>
+            <inactivate_nonprogressing_readers>true</inactivate_nonprogressing_readers>
+          </rtps_reliable_writer>
+        </protocol>
+      </datawriter_qos>
+    </qos_profile>
+
+    <!-- ===================================================== -->
+    <qos_profile name="RapidPointCloudConfigProfile" base_name="RapidConfigQos" />
+    <!-- ===================================================== -->
+    <qos_profile name="RapidPointCloudSampleProfile" base_name="RapidSampleQos">
+      <datawriter_qos>
+        <publish_mode>
+<!--          <flow_controller_name>dds.flow_controller.token_bucket.NavMapFlowController</flow_controller_name> -->
+        </publish_mode>
+        <history>
+          <kind>KEEP_LAST_HISTORY_QOS</kind>
+          <depth>10</depth>
+        </history>
+      </datawriter_qos>
+      <datareader_qos>
+        <history>
+          <kind>KEEP_LAST_HISTORY_QOS</kind>
+          <depth>100</depth>
+        </history>
+      </datareader_qos>
+    </qos_profile>
+
+    <!-- ===================================================== -->
+    <qos_profile name="RapidPositionConfigProfile" base_name="RapidConfigQos" />
+
+    <!-- ===================================================== -->
+    <qos_profile name="RapidPositionSampleProfile" base_name="RapidSampleQos" />
+
+    <!-- ===================================================== -->
+    <qos_profile name="RapidQueueStateProfile" base_name="RapidStateQos" />
+
+    <!-- ===================================================== -->
+    <qos_profile name="RapidRangeScanConfigProfile" base_name="RapidConfigQos" />
+    <qos_profile name="RapidRangeScanSampleProfile" base_name="RapidSampleQos">
+      <datareader_qos>
+        <history>
+          <kind>KEEP_LAST_HISTORY_QOS</kind>
+          <depth>1000</depth>
+        </history>
+      </datareader_qos>
+      <datawriter_qos>
+        <history>
+          <kind>KEEP_LAST_HISTORY_QOS</kind>
+          <depth>200</depth>
+        </history>
+      </datawriter_qos>
+    </qos_profile>
+
+    <!-- Extension: SystemInfo =============================== -->
+    <qos_profile name="RapidSystemInfoConfigProfile" base_name="RapidConfigQos" />
+    <qos_profile name="RapidSystemInfoSampleProfile" base_name="RapidSampleQos" />
+
+    <!-- Extension: Trajectory2D ============================= -->
+    <qos_profile name="RapidTrajectory2DConfigProfile" base_name="RapidConfigQos" />
+    <qos_profile name="RapidTrajectory2DSampleProfile" base_name="RapidSampleQos" />
+
+    <!-- Extension: Trajectory (Geometric) =================== -->
+    <qos_profile name="RapidTrajectoryConfigProfile" base_name="RapidConfigQos" />
+    <qos_profile name="RapidTrajectorySampleProfile" base_name="RapidSampleQos" />
+
+    <!-- Extension: Virtual E-Stop =========================== -->
+    <qos_profile name="RapidVEStopConfigProfile" base_name="RapidConfigQos" />
+    <qos_profile name="RapidVEStopStateProfile" base_name="RapidStateQos" />
+
+    <!-- ===================================================== -->
+    <qos_profile name="RapidTextMessageProfile" base_name="RapidReliableDurableQos" />
+    <!-- ===================================================== -->
+    <qos_profile name="RapidAccessControlStateProfile" base_name="RapidStateQos" />
+
+    <!-- ImageSamples -->
+    <!-- ===================================================== -->
+    <qos_profile name="RapidSensorImageProfile" base_name="RapidReliableQos" />
+
+    <!-- ===================================================== -->
+    <!-- RAFT File Queue Profiles -->
+    <!-- ===================================================== -->
+    <qos_profile name="RapidFileQueueStateProfile" base_name="RapidStateQos" />
+    <!-- ===================================================== -->
+    <qos_profile name="RapidFileQueueEntryStateProfile" base_name="RapidStateQos" />
+    <!-- ===================================================== -->
+    <qos_profile name="RapidFileQueueConfigProfile" base_name="RapidConfigQos" />
+
+    <!-- FileQueueSample -->
+    <!-- ===================================================== -->
+    <qos_profile name="RapidFileQueueSampleProfile" base_name="RapidReliableQos">
+    </qos_profile>
+
+    <!-- FileAnnounce -->
+    <!-- ===================================================== -->
+    <qos_profile name="RapidFileAnnounceProfile" base_name="RapidReliableDurableQos">
+      <datawriter_qos>
+        <ownership>
+          <kind>EXCLUSIVE_OWNERSHIP_QOS</kind>
+        </ownership>
+        <ownership_strength>
+          <value>100</value>
+        </ownership_strength>
+      </datawriter_qos>
+      <datareader_qos>
+        <ownership>
+          <kind>EXCLUSIVE_OWNERSHIP_QOS</kind>
+        </ownership>
+      </datareader_qos>
+    </qos_profile>
+    <!-- FileAnnounceRepeater -->
+    <!-- ===================================================== -->
+    <qos_profile name="RaftFileAnnounceRepeaterProfile" base_name="RapidFileAnnounceProfile">
+      <datawriter_qos>
+        <ownership_strength>
+          <value>50</value>
+        </ownership_strength>
+      </datawriter_qos>
+    </qos_profile>
+    <!-- FileQueueReceiver -->
+    <!-- ===================================================== -->
+    <qos_profile name="RapidFileQueueReceiverSampleProfile" base_name="RapidSampleQos" />
+    <qos_profile name="RapidFileQueueReceiverEntryStateProfile" base_name="RapidFileQueueEntryStateProfile" />
+
+    <!-- Process Manager -->
+    <!-- ===================================================== -->
+    <qos_profile name="RapidProcessManagerConfigProfile" base_name="RapidConfigQos" />
+    <qos_profile name="RapidProcessManagerStateProfile" base_name="RapidStateQos" />
+    <qos_profile name="RapidProcessIoSampleProfile" base_name="RapidReliableDurableQos" >
+      <datareader_qos>
+        <history>
+          <depth>1000</depth>
+        </history>
+      </datareader_qos>
+      <datawriter_qos>
+        <publish_mode>
+          <!-- flow_controller_name>dds.flow_controller.token_bucket.ProcessIoFlowController</flow_controller_name -->
+        </publish_mode>
+        <history>
+          <depth>1000</depth>
+        </history>
+      </datawriter_qos>
+    </qos_profile>
+
+    <!-- ARC Extension: BatteryPack ========================== -->
+    <qos_profile name="RapidBatteryPackConfigProfile" base_name="RapidConfigQos" />
+    <qos_profile name="RapidBatteryPackSampleProfile" base_name="RapidSampleQos" />
+
+    <!-- === ARC Extension: Float32 ================================================== -->
+    <qos_profile name="RapidFloat32ConfigProfile" base_name="RapidConfigQos" />
+    <qos_profile name="RapidFloat32SampleProfile" base_name="RapidSampleQos" />
+
+    <!-- === ARC Extension: Geometry ================================================== -->
+    <qos_profile name="RapidGeometryAppearanceStateProfile" base_name="RapidStateQos" />
+    <qos_profile name="RapidGeometryConfigProfile" base_name="RapidConfigQos" />
+    <qos_profile name="RapidGeometryMeshSampleProfile" base_name="RapidSampleQos" >
+      <datawriter_qos>
+        <publish_mode>
+          <flow_controller_name>dds.flow_controller.token_bucket.MeshFlowController</flow_controller_name>
+        </publish_mode>
+        <history>
+          <kind>KEEP_LAST_HISTORY_QOS</kind>
+          <depth>1</depth>
+        </history>
+        <resource_limits>
+          <max_samples>32</max_samples>
+          <max_samples_per_instance>32</max_samples_per_instance>
+          <max_instances>1</max_instances>
+          <initial_instances>1</initial_instances>
+          <initial_samples>32</initial_samples>
+        </resource_limits>
+      </datawriter_qos>
+      <datareader_qos>
+        <reader_resource_limits>
+          <max_fragments_per_sample>4096</max_fragments_per_sample>
+        </reader_resource_limits>
+        <history>
+          <depth>4</depth>
+        </history>
+      </datareader_qos>
+    </qos_profile>
+
+    <!-- ARC Extension: Gps ================================== -->
+    <qos_profile name="RapidGpsConfigProfile" base_name="RapidConfigQos" />
+    <qos_profile name="RapidGpsSampleProfile" base_name="RapidSampleQos" />
+
+    <!-- ARC Extension: Spectrum ================================== -->
+    <qos_profile name="RapidSpectrumConfigProfile" base_name="RapidConfigQos" />
+    <qos_profile name="RapidSpectrumSampleProfile" base_name="RapidSampleQos" />
+
+    <!-- ARC Extension: StateMachine ========================= -->
+    <qos_profile name="RapidStateMachineConfigProfile" base_name="RapidConfigQos" />
+    <qos_profile name="RapidStateMachineStateProfile" base_name="RapidStateQos" />
+
+    <!-- ARC Extension: Ephemeris ============================ -->
+    <qos_profile name="RapidEphemerisConfigProfile" base_name="RapidConfigQos"/>
+    <qos_profile name="RapidEphemerisSampleProfile" base_name="RapidSampleQos" />
+
+    <!-- ================================================================================== -->
+    <!-- Astrobee Extensions ============================================================== -->
+    <!-- ================================================================================== -->
+
+    <!-- ASTROBEE Extension: AgentState ================================== -->
+    <qos_profile name="AstrobeeAgentStateProfile" base_name="RapidStateQos">
+      <datareader_qos>
+        <liveliness>
+          <lease_duration>
+            <sec>10</sec>
+            <nanosec>0</nanosec>
+          </lease_duration>
+        </liveliness>
+      </datareader_qos>
+      <datawriter_qos>
+        <liveliness>
+          <lease_duration>
+            <sec>10</sec>
+            <nanosec>0</nanosec>
+          </lease_duration>
+        </liveliness>
+      </datawriter_qos>
+    </qos_profile>
+
+    <!-- ASTROBEE Extension: ArmState ================================== -->
+    <qos_profile name="AstrobeeArmStateProfile" base_name="RapidStateQos" />
+
+    <!-- ASTROBEE Extension: CommState ================================== -->
+    <qos_profile name="AstrobeeCommStateProfile" base_name="RapidStateQos" />
+
+    <!-- ASTROBEE Extension: Component ================================== -->
+    <qos_profile name="AstrobeeComponentConfigProfile" base_name="RapidConfigQos" />
+    <qos_profile name="AstrobeeComponentStateProfile" base_name="RapidStateQos" />
+
+    <!-- ASTROBEE Extension: CompressedFile ================================ -->
+    <qos_profile name="AstrobeeCompressedFileProfile" base_name="RapidReliableQos" />
+
+    <!-- ASTROBEE Extension: CompressedFileAck ============================= -->
+    <qos_profile name="AstrobeeCompressedFileAckProfile" base_name="RapidAckProfile" />
+
+    <!-- ASTROBEE Extension: Cpu ======================================= -->
+    <qos_profile name="AstrobeeCpuConfigProfile" base_name="RapidConfigQos" />
+    <qos_profile name="AstrobeeCpuStateProfile" base_name="RapidStateQos" />
+
+    <!-- ASTROBEE Extension: Current Plan CompressedFile =================== -->
+    <qos_profile name="AstrobeeCurrentCompressedPlanProfile" base_name="RapidReliableDurableQos" />
+
+    <!-- ASTROBEE Extension: DataToDisk ============================== -->
+    <qos_profile name="AstrobeeDataToDiskStateProfile" base_name="RapidStateQos" />
+    <qos_profile name="AstrobeeDataTopicsListProfile" base_name="RapidConfigQos" />
+
+    <!-- ASTROBEE Extension: Disk ================================== -->
+    <qos_profile name="AstrobeeDiskConfigProfile" base_name="RapidConfigQos" />
+    <qos_profile name="AstrobeeDiskStateProfile" base_name="RapidStateQos" />
+
+    <!-- ASTROBEE Extension: DockState ==================================== -->
+    <qos_profile name="AstrobeeDockStateProfile" base_name="RapidStateQos">
+      <datareader_qos>
+        <liveliness>
+          <lease_duration>
+            <sec>10</sec>
+            <nanosec>0</nanosec>
+          </lease_duration>
+        </liveliness>
+      </datareader_qos>
+      <datawriter_qos>
+        <liveliness>
+          <lease_duration>
+            <sec>10</sec>
+            <nanosec>0</nanosec>
+          </lease_duration>
+        </liveliness>
+      </datawriter_qos>
+    </qos_profile>
+
+    <!-- ASTROBEE Extension: EkfState ================================== -->
+    <qos_profile name="AstrobeeEkfStateProfile" base_name="RapidStateQos" />
+
+    <!-- ASTROBEE Extension: Eps ================================== -->
+    <qos_profile name="AstrobeeEpsConfigProfile" base_name="RapidConfigQos" />
+    <qos_profile name="AstrobeeEpsStateProfile" base_name="RapidStateQos" />
+
+    <!-- ASTROBEE Extension: Fault ================================== -->
+    <qos_profile name="AstrobeeFaultConfigProfile" base_name="RapidConfigQos" />
+    <qos_profile name="AstrobeeFaultStateProfile" base_name="RapidStateQos" />
+
+    <!-- ASTROBEE Extension: GNC Control ============================== -->
+    <qos_profile name="AstrobeeGncControlStateProfile" base_name="RapidStateQos" />
+
+    <!-- ASTROBEE Extension: GNC Fam Cmd ============================== -->
+    <qos_profile name="AstrobeeGncFamCmdStateProfile" base_name="RapidStateQos" />
+
+    <!-- ASTROBEE Extension: Guest Science =============================== -->
+    <qos_profile name="AstrobeeGuestScienceConfigProfile" base_name="RapidConfigQos" />
+    <qos_profile name="AstrobeeGuestScienceDataProfile" base_name="RapidSampleQos" />
+    <qos_profile name="AstrobeeGuestScienceStateProfile" base_name="RapidStateQos" />
+
+    <!-- ASTROBEE Extension: Inertia ==================================== -->
+    <qos_profile name="AstrobeeInertiaProfile" base_name="RapidConfigQos" />
+
+    <!-- ASTROBEE Extension: Log ======================================== -->
+    <qos_profile name="AstrobeeLogSampleProfile" base_name="RapidSampleQos" />
+
+    <!-- ASTROBEE Extension: Mobility =================================== -->
+    <qos_profile name="AstrobeeMobilitySettingsStateProfile" base_name="RapidStateQos" />
+
+    <!-- ASTROBEE Extension: Payload ==================================== -->
+    <qos_profile name="AstrobeePayloadConfigProfile" base_name="RapidConfigQos" />
+    <qos_profile name="AstrobeePayloadStateProfile" base_name="RapidStateQos" />
+
+    <!-- ASTROBEE Extension: PlanStatus ================================== -->
+    <qos_profile name="AstrobeePlanStatusProfile" base_name="RapidStateQos" />
+
+    <!-- ASTROBEE Extension: PMC Cmd =================================== -->
+    <qos_profile name="AstrobeePmcCmdStateProfile" base_name="RapidStateQos" />
+
+    <!-- ASTROBEE Extension: Telemetry ================================== -->
+    <qos_profile name="AstrobeeTelemetryConfigProfile" base_name="RapidConfigQos" />
+    <qos_profile name="AstrobeeTelemetryStateProfile" base_name="RapidStateQos" />
+  
+    <!-- ================================================================================== -->
+    <!-- Traclabs Extensions ============================================================== -->
+    <!-- ================================================================================== -->
+
+    <!-- Traclabs Extension: Notice  ========================= -->
+    <qos_profile name="TraclabsNoticeConfigProfile" base_name="RapidConfigQos" />
+    <qos_profile name="TraclabsNoticeAckProfile"    base_name="RapidAckProfile" />
+    <qos_profile name="TraclabsNoticeStateProfile"  base_name="RapidStateQos">
+      <datareader_qos>
+        <history>
+          <kind>KEEP_LAST_HISTORY_QOS</kind>
+          <depth>5</depth>
+        </history>
+      </datareader_qos>
+      <datawriter_qos>
+        <history>
+          <kind>KEEP_LAST_HISTORY_QOS</kind>
+          <depth>5</depth>
+        </history>
+      </datawriter_qos>
+    </qos_profile>
+
+  </qos_library>
+
+  <!-- ===================================================== -->
+  <!-- RTI Monitor Qos library -->
+  <!-- ===================================================== -->
+  <qos_library name="RtiMonitorQosLibrary">
+    <!-- RTI Monitor library publishes statistics data as regular DDS traffic. -->
+    <!-- To separate this traffic, we put it on a separate DDS domain. -->
+    <!-- RTI Monitor GUI frontend likes the default ports better, than the RAPID setup. -->
+    <!-- As the Monitor library uses it's own domain-participant, they can just as -->
+    <!-- well use default ports with it. -->
+    <!-- !!! NOTE: The parameters used below wont work on the KSC tunnel. -->
+    <!-- !!! NOTE: Any changes to the parameters below have to be mirrored in the -->
+    <!-- !!! RTI Montior Qos config xml -->
+    <qos_profile name="RtiMonitorQosProfile">
+      <participant_qos>
+        <wire_protocol>
+          <!-- restore default ports, as RAPID sets others as default -->
+          <rtps_well_known_ports>
+            <port_base>7400</port_base>
+            <domain_id_gain>250</domain_id_gain>
+            <participant_id_gain>2</participant_id_gain>
+            <builtin_multicast_port_offset>0</builtin_multicast_port_offset>
+            <builtin_unicast_port_offset>10</builtin_unicast_port_offset>
+            <user_multicast_port_offset>1</user_multicast_port_offset>
+            <user_unicast_port_offset>11</user_unicast_port_offset>
+          </rtps_well_known_ports>
+        </wire_protocol>
+        <resource_limits>
+          <!-- uncomment the following if your user data type has large type code. You will also need to uncomment the lines
+            in property to enable large data for UDPv4 and shared memory -->
+          <type_code_max_serialized_length>30000</type_code_max_serialized_length>
+          <participant_property_list_max_length>64</participant_property_list_max_length>
+          <participant_property_string_max_length>2048</participant_property_string_max_length>
+        </resource_limits>
+        <!-- change the mask to SHMEM if you have no network connection -->
+        <transport_builtin>
+          <mask>UDPv4 | SHMEM</mask>
+        </transport_builtin>
+        <participant_name>
+          <name>Monitoring UI Application</name>
+        </participant_name>
+        <receiver_pool>
+          <buffer_size>65530</buffer_size>
+        </receiver_pool>
+        <!-- these are the default values and are here for reference. <discovery> <initial_peers> <element>builtin.udpv4://239.255.0.1</element>
+        <element>builtin.udpv4://localhost</element> <element>builtin.shmem://</element> </initial_peers> <multicast_receive_addresses>
+        <element>239.255.0.1</element> </multicast_receive_addresses> </discovery -->
+        <discovery_config>
+          <participant_liveliness_lease_duration>
+            <sec>100</sec>
+            <nanosec>0</nanosec>
+          </participant_liveliness_lease_duration>
+          <participant_liveliness_assert_period>
+            <sec>10</sec>
+            <nanosec>0</nanosec>
+          </participant_liveliness_assert_period>
+          <remote_participant_purge_kind>LIVELINESS_BASED_REMOTE_PARTICIPANT_PURGE</remote_participant_purge_kind>
+          <max_liveliness_loss_detection_period>
+            <sec>10</sec>
+            <nanosec>0</nanosec>
+          </max_liveliness_loss_detection_period>
+          <initial_participant_announcements>1</initial_participant_announcements>
+          <min_initial_participant_announcement_period>
+            <sec>2</sec>
+            <nanosec>0</nanosec>
+          </min_initial_participant_announcement_period>
+          <max_initial_participant_announcement_period>
+            <sec>2</sec>
+            <nanosec>0</nanosec>
+          </max_initial_participant_announcement_period>
+          <publication_reader>
+            <min_heartbeat_response_delay>
+              <sec>0</sec>
+              <nanosec>0</nanosec>
+            </min_heartbeat_response_delay>
+            <max_heartbeat_response_delay>
+              <sec>0</sec>
+              <nanosec>0</nanosec>
+            </max_heartbeat_response_delay>
+            <heartbeat_suppression_duration>
+              <sec>0</sec>
+              <nanosec>0</nanosec>
+            </heartbeat_suppression_duration>
+            <nack_period>
+              <sec>0</sec>
+              <nanosec>100000000</nanosec>
+            </nack_period>
+          </publication_reader>
+          <subscription_reader>
+            <min_heartbeat_response_delay>
+              <sec>0</sec>
+              <nanosec>0</nanosec>
+            </min_heartbeat_response_delay>
+            <max_heartbeat_response_delay>
+              <sec>0</sec>
+              <nanosec>0</nanosec>
+            </max_heartbeat_response_delay>
+            <heartbeat_suppression_duration>
+              <sec>0</sec>
+              <nanosec>0</nanosec>
+            </heartbeat_suppression_duration>
+            <nack_period>
+              <sec>0</sec>
+              <nanosec>100000000</nanosec>
+            </nack_period>
+          </subscription_reader>
+          <publication_writer>
+            <low_watermark>0</low_watermark>
+            <high_watermark>1</high_watermark>
+            <heartbeat_period>
+              <sec>5</sec>
+              <nanosec>0</nanosec>
+            </heartbeat_period>
+            <fast_heartbeat_period>
+              <sec>0</sec>
+              <nanosec>200000000</nanosec>
+            </fast_heartbeat_period>
+            <late_joiner_heartbeat_period>
+              <sec>0</sec>
+              <nanosec>200000000</nanosec>
+            </late_joiner_heartbeat_period>
+            <max_heartbeat_retries>1000</max_heartbeat_retries>
+            <heartbeats_per_max_samples>8</heartbeats_per_max_samples>
+            <min_nack_response_delay>
+              <sec>0</sec>
+              <nanosec>0</nanosec>
+            </min_nack_response_delay>
+            <max_nack_response_delay>
+              <sec>0</sec>
+              <nanosec>0</nanosec>
+            </max_nack_response_delay>
+            <nack_suppression_duration>
+              <sec>0</sec>
+              <nanosec>0</nanosec>
+            </nack_suppression_duration>
+            <max_bytes_per_nack_response>65530</max_bytes_per_nack_response>
+          </publication_writer>
+          <subscription_writer>
+            <low_watermark>0</low_watermark>
+            <high_watermark>1</high_watermark>
+            <heartbeat_period>
+              <sec>5</sec>
+              <nanosec>0</nanosec>
+            </heartbeat_period>
+            <fast_heartbeat_period>
+              <sec>0</sec>
+              <nanosec>200000000</nanosec>
+            </fast_heartbeat_period>
+            <late_joiner_heartbeat_period>
+              <sec>0</sec>
+              <nanosec>200000000</nanosec>
+            </late_joiner_heartbeat_period>
+            <max_heartbeat_retries>1000</max_heartbeat_retries>
+            <heartbeats_per_max_samples>8</heartbeats_per_max_samples>
+            <min_nack_response_delay>
+              <sec>0</sec>
+              <nanosec>0</nanosec>
+            </min_nack_response_delay>
+            <max_nack_response_delay>
+              <sec>0</sec>
+              <nanosec>0</nanosec>
+            </max_nack_response_delay>
+            <nack_suppression_duration>
+              <sec>0</sec>
+              <nanosec>0</nanosec>
+            </nack_suppression_duration>
+            <max_bytes_per_nack_response>65530</max_bytes_per_nack_response>
+          </subscription_writer>
+        </discovery_config>
+        <property>
+          <value>
+            <!-- transport properties -->
+            <element>
+              <name>dds.transport.UDPv4.builtin.recv_socket_buffer_size</name>
+              <value>1048576</value>
+            </element>
+            <!-- uncomment the following to enable large data for UDPv4 transport -->
+            <element>
+              <name>dds.transport.UDPv4.builtin.parent.message_size_max</name>
+              <value>65530</value>
+            </element>
+            <element>
+              <name>dds.transport.UDPv4.builtin.send_socket_buffer_size</name>
+              <value>65530</value>
+            </element>
+            <!-- these are some common properties needing adjusting for UDP and are here for reference. <element> <name>dds.transport.UDPv4.builtin.parent.deny_interfaces</name> 
+              <value>10.50.*</value> </element> <element> <name>dds.transport.UDPv4.builtin.multicast_enabled</name> <value>0</value> </element> 
+              <element> <name>dds.transport.UDPv4.builtin.parent.multicast_ttl</name> <value>3</value> </element> <element> <name>dds.transport.UDPv4.builtin.parent.allow_interfaces</name> 
+              <value>192.*</value> </element> -->
+            <!-- uncomment the following to enable large data for shared memory transport -->
+            <element>
+              <name>dds.transport.shmem.builtin.parent.message_size_max</name>
+              <value>65530</value>
+            </element>
+            <element>
+              <name>dds.transport.shmem.builtin.receive_buffer_size</name>
+              <value>65530</value>
+            </element>
+            <element>
+              <name>dds.transport.shmem.builtin.received_message_count_max</name>
+              <value>32</value>
+            </element>
+          </value>
+        </property>
+      </participant_qos>
+
+      <datareader_qos name="BaseReaderProfile">
+        <protocol>
+          <!-- This property keeps the Monitor UI's readers from showing up in the counts of the monitored application's 
+            discovery metrics. -->
+          <!-- mallan 5/5/11 RTI BUG: this property causes rtireplay to choke -->
+          <!-- vendor_specific_entity>TRUE</vendor_specific_entity -->
+        </protocol>
+      </datareader_qos>
+
+      <datareader_qos name="KeepLast1DurableReader" base_name="RtiMonitorQosProfile::BaseReaderProfile">
+        <durability>
+          <kind>TRANSIENT_LOCAL_DURABILITY_QOS</kind>
+        </durability>
+
+        <reliability>
+          <kind>RELIABLE_RELIABILITY_QOS</kind>
+        </reliability>
+
+        <history>
+          <kind>KEEP_LAST_HISTORY_QOS</kind>
+          <depth>1</depth>
+        </history>
+        <!--multicast> <value> <element> <receive_address>239.255.0.2</receive_address> </element> </value> </multicast -->
+      </datareader_qos>
+
+      <datareader_qos base_name="KeepLast1DurableReader" topic_filter="rti/dds/monitoring/*Description" />
+
+      <datareader_qos topic_filter="rti/dds/monitoring/*Statistics" base_name="RtiMonitorQosProfile::BaseReaderProfile">
+        <reliability>
+          <kind>BEST_EFFORT_RELIABILITY_QOS</kind>
+        </reliability>
+        <history>
+          <kind>KEEP_LAST_HISTORY_QOS</kind>
+          <depth>2</depth>
+        </history>
+      </datareader_qos>
+
+      <datawriter_qos name="KeepLast1DurableWriter">
+        <durability>
+          <kind>TRANSIENT_LOCAL_DURABILITY_QOS</kind>
+        </durability>
+
+        <reliability>
+          <kind>RELIABLE_RELIABILITY_QOS</kind>
+        </reliability>
+
+        <history>
+          <kind>KEEP_LAST_HISTORY_QOS</kind>
+          <depth>1</depth>
+        </history>
+      </datawriter_qos>
+
+      <datareader_qos base_name="KeepLast1DurableReader" topic_filter="rti/dds/monitoring/*Status">
+        <!-- keep more history for this topic -->
+        <history>
+          <kind>KEEP_LAST_HISTORY_QOS</kind>
+          <depth>10</depth>
+        </history>
+      </datareader_qos>
+
+      <datawriter_qos base_name="KeepLast1DurableWriter" topic_filter="rti/dds/monitoring/*Status">
+        <!-- keep more history for this topic -->
+        <history>
+          <kind>KEEP_LAST_HISTORY_QOS</kind>
+          <depth>10</depth>
+        </history>
+      </datawriter_qos>
+    </qos_profile>
+  </qos_library>
+</dds>

--- a/communications/dds_ros_bridge/src/astrobee_astrobee_bridge.cc
+++ b/communications/dds_ros_bridge/src/astrobee_astrobee_bridge.cc
@@ -80,7 +80,7 @@ void AstrobeeAstrobeeBridge::Initialize(ros::NodeHandle *nh) {
 
   // Make path to QOS and NDDS files
   std::string config_path = ff_common::GetConfigDir();
-  config_path += "/communications/dds/";
+  config_path += "/communications/dds_intercomms/";
 
   // Create fake argv containing only the particaptant name
   // Participant name needs to uniue so combine robot name with timestamp


### PR DESCRIPTION
 * New folder containing a copy of the profiles and peers was added
 * Addition is to avoid conflict when public IP is inserted for Trek
   configuration