### PR TITLE
explicitly specify python3 while running for ubuntu 16 machines

### DIFF
--- a/scripts/git/pre-commit.linter_cpp
+++ b/scripts/git/pre-commit.linter_cpp
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import datetime
 import importlib


### PR DESCRIPTION
While running the hook on my ubuntu 16 machine I got an import error, seems like the library we had to upgrade because of python3/ubuntu 20 requirements is not back compatible. Therefore I made it use python3 instead of the default.