### PR TITLE
Added gs topics to the default recording.

### DIFF
--- a/astrobee/config/management/data_bagger.config
+++ b/astrobee/config/management/data_bagger.config
@@ -51,6 +51,9 @@ default_topics = {{topic="gnc/ctl/traj", downlink="immediate", frequency=-1},
                   {topic="command", downlink="immediate", frequency=-1},
                   {topic="mgt/ack", downlink="immediate", frequency=-1},
                   {topic="mgt/sys_monitor/time_diff", downlink="immediate", frequency=-1},
+                  {topic="gs/gs_manager/ack", downlink="immediate", frequency=-1},
+                  {topic="gs/gs_manager/config", downlink="immediate", frequency=-1},
+                  {topic="gs/gs_manager/state", downlink="immediate", frequency=-1},
                   {topic="rosout", downlink="immediate", frequency=-1},
                   {topic="robot_name", downlink="immediate", frequency=-1}}
 


### PR DESCRIPTION
The dds ros bridge died during an activity and it looks like it may have
been due to a mismatch in the guest science state and config messages.
Since these topics weren't recorded, it is hard to piece together what
happened. Thus these topics were added to the default topics that get
recorded all the time.