### PR TITLE
adding service to perching arm to try and reconnect the arm

### DIFF
--- a/hardware/perching_arm/readme.md
+++ b/hardware/perching_arm/readme.md
@@ -1,3 +1,8 @@
 \page perching_arm Perching arm
 
-To be written...
+## Re-initialize service
+
+In case we forget to power on the arm bay before starting fsw, it is
+possible to re-initialize the perching arm, trying to re-connect with:
+
+    rosservice call /hw/arm/enable_arm "enabled: true"

--- a/hardware/perching_arm/src/perching_arm_node.cc
+++ b/hardware/perching_arm/src/perching_arm_node.cc
@@ -358,7 +358,8 @@ class PerchingArmNode : public ff_util::FreeFlyerNodelet {
     }
   }
 
-  // Enable arm
+  // This service re-initializes the perching arm if the arm was
+  // not powered on during startup
   bool EnableArmCallback(ff_hw_msgs::SetEnabled::Request &req,
                          ff_hw_msgs::SetEnabled::Response &res) {
     if (req.enabled && !arm_connected_) {

--- a/hardware/perching_arm/src/perching_arm_node.cc
+++ b/hardware/perching_arm/src/perching_arm_node.cc
@@ -61,6 +61,15 @@ class PerchingArmNode : public ff_util::FreeFlyerNodelet {
     if (!config_params.GetTable("perching_arm", &devices))
       NODELET_FATAL("Could get perching_arm item in config file");
 
+    // Reconnect to the arm service
+    if (!initialized_) {
+      srv_a_ =
+          nh->advertiseService(SERVICE_HARDWARE_PERCHING_ARM_ENABLE,
+                               &PerchingArmNode::EnableArmCallback,
+                               this);
+          initialized_ = true;
+    }
+
     // Iterate over all devices
     for (int i = 0; i < devices.GetSize(); i++) {
       config_reader::ConfigReader::Table device_info;
@@ -137,12 +146,6 @@ class PerchingArmNode : public ff_util::FreeFlyerNodelet {
         // Call back with joint state goals from the high-level driver
         sub_ = nh->subscribe(TOPIC_JOINT_GOALS, 1,
                              &PerchingArmNode::GoalCallback, this);
-
-        // Enable the arm
-        srv_a_ =
-            nh->advertiseService(SERVICE_HARDWARE_PERCHING_ARM_ENABLE,
-                                 &PerchingArmNode::EnableArmCallback,
-                                 this);
 
         // Set the distal velocity
         srv_p_ =
@@ -440,6 +443,7 @@ class PerchingArmNode : public ff_util::FreeFlyerNodelet {
 
  private:
   ros::NodeHandle nh_;
+  bool initialized_ = false;
   bool arm_connected_ = false;
   PerchingArm arm_;              // Arm interface library
   ros::Subscriber sub_;          // Joint state subscriber

--- a/shared/ff_util/include/ff_util/ff_names.h
+++ b/shared/ff_util/include/ff_util/ff_names.h
@@ -429,6 +429,7 @@
 #define SERVICE_HARDWARE_EPS_GET_BOARD_INFO         "hw/eps/get_board_info"
 #define SERVICE_HARDWARE_EPS_CLEAR_TERMINATE        "hw/eps/clear_terminate"
 
+#define SERVICE_HARDWARE_PERCHING_ARM_ENABLE        "hw/arm/enable_arm"
 #define SERVICE_HARDWARE_PERCHING_ARM_DIST_VEL      "hw/arm/set_dist_vel"
 #define SERVICE_HARDWARE_PERCHING_ARM_PROX_VEL      "hw/arm/set_prox_vel"
 #define SERVICE_HARDWARE_PERCHING_ARM_PROX_SERVO    "hw/arm/enable_proximal_servo"


### PR DESCRIPTION
To reread the arm after fsw has started, one can run:
rosservice call /hw/arm/enable_arm "enabled: true"

This has been tested in the lab