### PR TITLE
ubuntu 16/18 linter changes

### DIFF
--- a/scripts/git/pre-commit.linter_cpp
+++ b/scripts/git/pre-commit.linter_cpp
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 import datetime
-import importlib
+import importlib.machinery
 import os
 import subprocess
 from itertools import groupby

--- a/scripts/git/pre-commit.linter_python
+++ b/scripts/git/pre-commit.linter_python
@@ -21,36 +21,37 @@ files=$(git diff --cached --name-only | grep '\.py$')
 
 # If files is empty exit success
 if [ -z "${files}" ]; then
-	echo "=================================================="
-	echo "  No Python files changed, no checks needed."
-	exit 0
+  echo "=================================================="
+  echo "  No Python files changed, no checks needed."
+  exit 0
 fi
 
 failed_lint=false
+os=`cat /etc/os-release | grep -oP "(?<=VERSION_CODENAME=).*"`
+if [ "$os" = "focal" ]; then
+  echo "=================================================="
+  echo "  Analysing with black"
+  # This check the files but they will not be commited
+  if `black . --include ${files} --check --quiet`; then
+    echo "Linter black checks passed"
+  else
+    echo "Errors detected, fixing ..."
+    black . --include ${files}
+    failed_lint=true
+  fi
 
-echo "=================================================="
-echo "  Analysing with black"
-# This check the files but they will not be commited
-if `black . --include ${files} --check --quiet`; then
-	echo "Linter black checks passed"
-else
-	echo "Errors detected, fixing ..."	
-	black . --include ${files}
-	failed_lint=true
+  echo "=================================================="
+  echo "  Analysing with isort"
+  if $(isort ${files} --extend-skip cmake --profile black --diff --check-only --quiet >/dev/null); then
+    echo "Linter isort checks passed"
+  else
+    echo "Errors detected, fixing ..."
+    isort ${files} --extend-skip cmake --profile black >/dev/null
+    failed_lint=true
+  fi
 fi
-
-echo "=================================================="
-echo "  Analysing with isort"
-if $(isort ${files} --extend-skip cmake --profile black --diff --check-only --quiet >/dev/null); then
-	echo "Linter isort checks passed"
-else
-	echo "Errors detected, fixing ..."	
-	isort ${files} --extend-skip cmake --profile black >/dev/null
-	failed_lint=true
-fi
-
 # Cancel commit if linter failed
 # The user should add manually the corrected files
 if ${failed_lint}; then
-	exit 1
+  exit 1
 fi

--- a/scripts/git/pre-commit.linter_python
+++ b/scripts/git/pre-commit.linter_python
@@ -27,29 +27,41 @@ if [ -z "${files}" ]; then
 fi
 
 failed_lint=false
-os=`cat /etc/os-release | grep -oP "(?<=VERSION_CODENAME=).*"`
-if [ "$os" = "focal" ]; then
-  echo "=================================================="
-  echo "  Analysing with black"
-  # This check the files but they will not be commited
-  if `black . --include ${files} --check --quiet`; then
-    echo "Linter black checks passed"
-  else
-    echo "Errors detected, fixing ..."
-    black . --include ${files}
-    failed_lint=true
-  fi
 
-  echo "=================================================="
-  echo "  Analysing with isort"
-  if $(isort ${files} --extend-skip cmake --profile black --diff --check-only --quiet >/dev/null); then
-    echo "Linter isort checks passed"
-  else
-    echo "Errors detected, fixing ..."
-    isort ${files} --extend-skip cmake --profile black >/dev/null
-    failed_lint=true
-  fi
+if ! command -v black &> /dev/null
+then
+    echo "Black was not found, to install check https://github.com/psf/black"
+    echo "Unfortunately black requires Python 3.6.2+ to run"
+    exit 0
 fi
+
+if ! command -v isort &> /dev/null
+then
+    echo "isort was not found, to install check https://github.com/PyCQA/isort"
+    exit 0
+fi
+
+echo "=================================================="
+echo "  Analysing with black"
+# This check the files but they will not be commited
+if `black . --include ${files} --check --quiet`; then
+  echo "Linter black checks passed"
+else
+  echo "Errors detected, fixing ..."
+  black . --include ${files}
+  failed_lint=true
+fi
+
+echo "=================================================="
+echo "  Analysing with isort"
+if $(isort ${files} --extend-skip cmake --profile black --diff --check-only --quiet >/dev/null); then
+  echo "Linter isort checks passed"
+else
+  echo "Errors detected, fixing ..."
+  isort ${files} --extend-skip cmake --profile black >/dev/null
+  failed_lint=true
+fi
+
 # Cancel commit if linter failed
 # The user should add manually the corrected files
 if ${failed_lint}; then


### PR DESCRIPTION
fixing header for ubuntu 16;
disabling python linter unless in ubuntu 20 - black doesn't work on older python versions