### PR TITLE
README update for "A Brief Guide to Astrobee's Flight Software"

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ due to NASA legal requirements. Thank you for your understanding.
 
 [Extensive documentation is auto-generated from the contents of this repository.](https://nasa.github.io/astrobee/documentation.html)
 
-["A Brief Guide to Astrobee’s Flight Software"](https://github.com/albee/a-brief-guide-to-astrobee/raw/master/a_brief_guide_to_astrobee_v1.0.pdf) is a good tutorial, with a particular emphasis on the advanced topic of modifying Astrobee's flight software to enable Guidance, Navigation, & Control (GN&C) research. (Note that most guest science can be implemented as an app that uses the [Astrobee Command API](https://nasa.github.io/astrobee/html/command_dictionary.html) without modifying the flight software.)
+["A Brief Guide to Astrobee’s Flight Software"](https://github.com/albee/a-brief-guide-to-astrobee/raw/master/a_brief_guide_to_astrobee_latest.pdf) is a good tutorial, with a particular emphasis on the advanced topic of modifying Astrobee's flight software to enable Guidance, Navigation, & Control (GN&C) research. (Note that most guest science can be implemented as an app that uses the [Astrobee Command API](https://nasa.github.io/astrobee/html/command_dictionary.html) without modifying the flight software.)
 
 For more information, read [Astrobee-related publications](https://www.nasa.gov/content/research-publications-0).
 Learning about the Astrobee [platform](https://www.nasa.gov/sites/default/files/atoms/files/bualat_spaceops_2018_paper.pdf),


### PR DESCRIPTION
Updated README to point to latest version of "A Brief Guide to Astrobee's Flight Software." Guide repo will now use a static pdf name for the latest version so no more README changes are required.