### PR TITLE
IMU Aug and Heartbeat fixes

### DIFF
--- a/localization/graph_localizer/include/graph_localizer/graph_localizer_nodelet.h
+++ b/localization/graph_localizer/include/graph_localizer/graph_localizer_nodelet.h
@@ -122,6 +122,7 @@ class GraphLocalizerNodelet : public ff_util::FreeFlyerNodelet {
 
   ros::Time last_time_tf_dock_;
   ros::Time last_time_tf_handrail_;
+  ros::Time last_heartbeat_time_;
 
   // Timers
   localization_common::RosTimer vl_timer_ = localization_common::RosTimer("VL msg");

--- a/localization/imu_augmentor/include/imu_augmentor/imu_augmentor_nodelet.h
+++ b/localization/imu_augmentor/include/imu_augmentor/imu_augmentor_nodelet.h
@@ -69,6 +69,7 @@ class ImuAugmentorNodelet : public ff_util::FreeFlyerNodelet {
   tf2_ros::TransformBroadcaster transform_pub_;
   ros::Time last_time_;
   ros::Time last_heartbeat_time_;
+  boost::optional<ros::Time> last_state_msg_time_;
 };
 }  // namespace imu_augmentor
 

--- a/localization/imu_augmentor/include/imu_augmentor/imu_augmentor_nodelet.h
+++ b/localization/imu_augmentor/include/imu_augmentor/imu_augmentor_nodelet.h
@@ -68,6 +68,7 @@ class ImuAugmentorNodelet : public ff_util::FreeFlyerNodelet {
   ff_msgs::Heartbeat heartbeat_;
   tf2_ros::TransformBroadcaster transform_pub_;
   ros::Time last_time_;
+  ros::Time last_heartbeat_time_;
 };
 }  // namespace imu_augmentor
 

--- a/localization/imu_augmentor/src/imu_augmentor_nodelet.cc
+++ b/localization/imu_augmentor/src/imu_augmentor_nodelet.cc
@@ -77,7 +77,10 @@ boost::optional<ff_msgs::EkfState> ImuAugmentorNodelet::PublishLatestImuAugmente
     LogDebugEveryN(100, "PublishLatestImuAugmentedLocalizationState: Failed to get latest imu augmented loc msg.");
     return boost::none;
   }
+  // Avoid sending repeat messages
+  if (last_state_msg_time_ && (latest_imu_augmented_loc_msg->header.stamp == *last_state_msg_time_)) return boost::none;
   state_pub_.publish(*latest_imu_augmented_loc_msg);
+  last_state_msg_time_ = latest_imu_augmented_loc_msg->header.stamp;
   return latest_imu_augmented_loc_msg;
 }
 

--- a/localization/imu_augmentor/src/imu_augmentor_nodelet.cc
+++ b/localization/imu_augmentor/src/imu_augmentor_nodelet.cc
@@ -33,6 +33,7 @@ ImuAugmentorNodelet::ImuAugmentorNodelet() : ff_util::FreeFlyerNodelet(NODE_IMU_
   heartbeat_.node = GetName();
   heartbeat_.nodelet_manager = ros::this_node::getName();
   last_time_ = ros::Time::now();
+  last_heartbeat_time_ = ros::Time::now();
 }
 
 void ImuAugmentorNodelet::Initialize(ros::NodeHandle* nh) {
@@ -112,7 +113,9 @@ void ImuAugmentorNodelet::PublishPoseAndTwistAndTransform(const ff_msgs::EkfStat
 
 void ImuAugmentorNodelet::PublishHeartbeat() {
   heartbeat_.header.stamp = ros::Time::now();
+  if ((heartbeat_.header.stamp - last_heartbeat_time_).toSec() < 1.0) return;
   heartbeat_pub_.publish(heartbeat_);
+  last_heartbeat_time_ = heartbeat_.header.stamp;
 }
 
 void ImuAugmentorNodelet::Run() {

--- a/localization/imu_augmentor/src/imu_augmentor_wrapper.cc
+++ b/localization/imu_augmentor/src/imu_augmentor_wrapper.cc
@@ -91,7 +91,14 @@ ImuAugmentorWrapper::LatestImuAugmentedCombinedNavStateAndCovariances() {
 
   if (standstill()) {
     LogDebugEveryN(100, "LatestImuAugmentedCombinedNavStateAndCovariances: Standstill.");
-    return std::pair<lc::CombinedNavState, lc::CombinedNavStateCovariances>{*latest_combined_nav_state_,
+    const auto latest_timestamp = imu_augmentor_->LatestTime();
+    if (!latest_timestamp) {
+      LogError("LatestImuAugmentedCombinedNavStateAndCovariances: Failed to get latest timestamp.");
+      return boost::none;
+    }
+    const lc::CombinedNavState latest_timestamp_combined_nav_state(
+      latest_combined_nav_state_->nav_state(), latest_combined_nav_state_->bias(), *latest_timestamp);
+    return std::pair<lc::CombinedNavState, lc::CombinedNavStateCovariances>{latest_timestamp_combined_nav_state,
                                                                             *latest_covariances_};
   }
 


### PR DESCRIPTION
Fixed IMU augmentor to use latest timestamp from latest IMU msg when at standstill, also added logic to prevent IMU Augmentor from sending any repeat msgs with the same timestamp.  Finally, throttled the heartbeat msgs for the IMU augmentor and graph_localizer to publish at max 1 second frequency.  Tested and verified each fix in simulation