### PR TITLE
making it better for forks to do PRs without having the docker images

### DIFF
--- a/.github/workflows/ci_pr.yml
+++ b/.github/workflows/ci_pr.yml
@@ -21,7 +21,7 @@ jobs:
                           --build-arg UBUNTU_VERSION=16.04
                           --build-arg ROS_VERSION=kinetic
                           --build-arg PYTHON=''
-                          --build-arg REMOTE=ghcr.io/${{ github.repository_owner }}
+                          --build-arg REMOTE=ghcr.io/nasa
                           -t astrobee/astrobee:latest-ubuntu16.04
 
     - name: Test code
@@ -44,7 +44,7 @@ jobs:
                           --build-arg UBUNTU_VERSION=18.04
                           --build-arg ROS_VERSION=melodic
                           --build-arg PYTHON=3
-                          --build-arg REMOTE=ghcr.io/${{ github.repository_owner }}
+                          --build-arg REMOTE=ghcr.io/nasa
                           -t astrobee/astrobee:latest-ubuntu18.04
 
     - name: Test code
@@ -67,7 +67,7 @@ jobs:
                           --build-arg UBUNTU_VERSION=20.04
                           --build-arg ROS_VERSION=noetic
                           --build-arg PYTHON=3
-                          --build-arg REMOTE=ghcr.io/${{ github.repository_owner }}
+                          --build-arg REMOTE=ghcr.io/nasa
                           -t astrobee/astrobee:latest-ubuntu20.04
 
     - name: Test code

--- a/.github/workflows/ci_push.yml
+++ b/.github/workflows/ci_push.yml
@@ -21,7 +21,7 @@ jobs:
                           --build-arg UBUNTU_VERSION=16.04
                           --build-arg ROS_VERSION=kinetic
                           --build-arg PYTHON=''
-                          --build-arg REMOTE=ghcr.io/${{ github.repository_owner }}
+                          --build-arg REMOTE=ghcr.io/nasa
                           -t ghcr.io/${{ github.repository_owner }}/astrobee:latest-ubuntu16.04
 
     - name: Test code
@@ -35,7 +35,7 @@ jobs:
 
     - name: Push Docker image
       run: |
-        docker push ghcr.io/${{ github.repository_owner }}/astrobee:latest-ubuntu16.04
+        if [ ${{ github.repository_owner }}="nasa" ]; then docker push ghcr.io/${{ github.repository_owner }}/astrobee:latest-ubuntu16.04; fi;
 
   build-bionic:
 
@@ -52,7 +52,7 @@ jobs:
                           --build-arg UBUNTU_VERSION=18.04
                           --build-arg ROS_VERSION=melodic
                           --build-arg PYTHON=3
-                          --build-arg REMOTE=ghcr.io/${{ github.repository_owner }}
+                          --build-arg REMOTE=ghcr.io/nasa
                           -t ghcr.io/${{ github.repository_owner }}/astrobee:latest-ubuntu18.04
 
     - name: Test code
@@ -66,7 +66,7 @@ jobs:
 
     - name: Push Docker image
       run: |
-        docker push ghcr.io/${{ github.repository_owner }}/astrobee:latest-ubuntu18.04
+        if [ ${{ github.repository_owner }}="nasa" ]; then docker push ghcr.io/${{ github.repository_owner }}/astrobee:latest-ubuntu18.04; fi;
 
   build-focal:
 
@@ -83,7 +83,7 @@ jobs:
                           --build-arg UBUNTU_VERSION=20.04
                           --build-arg ROS_VERSION=noetic
                           --build-arg PYTHON=3
-                          --build-arg REMOTE=ghcr.io/${{ github.repository_owner }}
+                          --build-arg REMOTE=ghcr.io/nasa
                           -t ghcr.io/${{ github.repository_owner }}/astrobee:latest-ubuntu20.04
 
     - name: Test code
@@ -97,4 +97,4 @@ jobs:
 
     - name: Push Docker image
       run: |
-        docker push ghcr.io/${{ github.repository_owner }}/astrobee:latest-ubuntu20.04
+        if [ ${{ github.repository_owner }}="nasa" ]; then docker push ghcr.io/${{ github.repository_owner }}/astrobee:latest-ubuntu20.04; fi;


### PR DESCRIPTION
 * Forks don't have to have the astrobee packages in their own fork, it will use the nasa packages instead
 * It will not push the images when merging into develop unless doing it to nasa/develop