### PR TITLE
Docker remote run

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -2,16 +2,17 @@
 
 ## Quick Start using the Astrobee docker image
 
-If you just want to try out the astrobee simulator, you can use one of the docker images in the [Docker Hub](https://hub.docker.com/r/astrobee/astrobee). 
+If you just want to try out the astrobee simulator, you can use one of the docker images in the [Github Container Registry](https://github.com/nasa/astrobee/pkgs/container/astrobee).
 
-Given that Docker (see note) is installed:
+Make sure you have docker installed in your ubuntu system following the [installation instructions](https://docs.docker.com/engine/install/ubuntu/) and [post-installation steps for Linux](https://docs.docker.com/engine/install/linux-postinstall/).
 
-	git clone https://github.com/nasa/astrobee.git
-	cd astrobee
-	./scripts/docker/run.sh
+For some systems (with discrete graphics cards), you may need to install additional software. For Nvidia graphics cards, [see here](https://github.com/NVIDIA/nvidia-docker).
 
-*Note: Be aware that this only works on a native ubuntu install.*
-*Note: Make sure you have docker installed in your ubuntu system following the [installation instructions](https://docs.docker.com/engine/install/ubuntu/) and [post-installation steps for Linux](https://docs.docker.com/engine/install/linux-postinstall/).*
+``` bash
+git clone https://github.com/nasa/astrobee.git
+cd astrobee
+./scripts/docker/run.sh --remote
+```
 
 ## Building the code natively
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -2,11 +2,13 @@
 
 ## Quick Start using the Astrobee docker image
 
+*The following has been tested on Ubuntu systems using X11 (the default). Please see [these ROS pages](http://wiki.ros.org/docker/Tutorials#Tooling_with_Docker) for more resources.*
+
 If you just want to try out the astrobee simulator, you can use one of the docker images in the [Github Container Registry](https://github.com/nasa/astrobee/pkgs/container/astrobee).
 
 Make sure you have docker installed in your ubuntu system following the [installation instructions](https://docs.docker.com/engine/install/ubuntu/) and [post-installation steps for Linux](https://docs.docker.com/engine/install/linux-postinstall/).
 
-For some systems (with discrete graphics cards), you may need to install additional software. For Nvidia graphics cards, [see here](https://github.com/NVIDIA/nvidia-docker).
+For some systems (with discrete graphics cards), you may need to install [additional software](http://wiki.ros.org/docker/Tutorials/Hardware%20Acceleration).
 
 ``` bash
 git clone https://github.com/nasa/astrobee.git

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -2,7 +2,7 @@
 
 ## Quick Start using the Astrobee docker image
 
-*The following has been tested on Ubuntu systems using X11 (the default). Please see [these ROS pages](http://wiki.ros.org/docker/Tutorials#Tooling_with_Docker) for more resources.*
+*The following has been tested on native (non-VM) Ubuntu systems using X11 (the default). Please see [these ROS pages](http://wiki.ros.org/docker/Tutorials#Tooling_with_Docker) for more resources.*
 
 If you just want to try out the astrobee simulator, you can use one of the docker images in the [Github Container Registry](https://github.com/nasa/astrobee/pkgs/container/astrobee).
 

--- a/scripts/docker/run.sh
+++ b/scripts/docker/run.sh
@@ -18,13 +18,16 @@
 # under the License.
 
 # short help
-usage_string="$scriptname [-h] [-x <use ubuntu 16.04 image>]\
- [-b <use ubuntu 18.04 image>] [-f <use ubuntu 20.04 image>]"
+usage_string="$0 usage:  [-h] [-x <use ubuntu 16.04 image>]\
+ [-b <use ubuntu 18.04 image>] [-f <use ubuntu 20.04 image>]\
+ [-r <download remote image>]"
 #[-t make_target]
+docs_url="https://nasa.github.io/astrobee/html/install-docker.html"
 
 usage()
 {
-    echo "usage: sysinfo_page [[[-a file ] [-i]] | [-h]]"
+    echo "$usage_string"
+    echo "see: $docs_url"
 }
 os=`cat /etc/os-release | grep -oP "(?<=VERSION_CODENAME=).*"`
 args="dds:=false robot:=sim_pub"

--- a/scripts/docker/run.sh
+++ b/scripts/docker/run.sh
@@ -55,15 +55,6 @@ while [ "$1" != "" ]; do
     shift
 done
 
-
-rootdir=$(dirname "$(readlink -f "$0")")
-cd $rootdir
-
-XSOCK=/tmp/.X11-unix
-XAUTH=/tmp/.docker.xauth
-touch $XAUTH
-xauth nlist $DISPLAY | sed -e 's/^..../ffff/' | xauth -f $XAUTH nmerge -
-
 if [ "$os" = "xenial" ]; then
 tag=astrobee:latest-ubuntu16.04
 elif [ "$os" = "bionic" ]; then
@@ -78,6 +69,15 @@ if [ "$tagrepo" = "astrobee" ] && [[ "$(docker images -q $tagrepo/$tag 2> /dev/n
   usage
   exit 1
 fi
+
+rootdir=$(dirname "$(readlink -f "$0")")
+cd $rootdir
+
+# setup XServer for Docker
+XSOCK=/tmp/.X11-unix
+XAUTH=/tmp/.docker.xauth
+touch $XAUTH
+xauth nlist $DISPLAY | sed -e 's/^..../ffff/' | xauth -f $XAUTH nmerge -
 
 docker run -it --rm --name astrobee \
         --volume=$XSOCK:$XSOCK:rw \

--- a/scripts/docker/run.sh
+++ b/scripts/docker/run.sh
@@ -41,7 +41,7 @@ while [ "$1" != "" ]; do
                                         ;;
         -f | --focal )                  os="focal"
                                         ;;
-        -r | --remote )                 tagrepo=ghcr.io
+        -r | --remote )                 tagrepo=ghcr.io/nasa
                                         ;;
         --args )                        args+=" $2"
                                         shift


### PR DESCRIPTION
This adds an option to the run.sh script to use the remote image from github (and downloading it if it doesn't exist) rather than using a locally built one. This could save some hassle from having to build the image locally.

TODO
- [x] add a few sentences to the docs
~- [ ] add a quickstart section to the base readme~ already there under usage