### PR TITLE
Fix comparison logic when pushing docker images

### DIFF
--- a/.github/workflows/ci_push.yml
+++ b/.github/workflows/ci_push.yml
@@ -35,7 +35,7 @@ jobs:
 
     - name: Push Docker image
       run: |
-        if [ ${{ github.repository_owner }}="nasa" ]; then docker push ghcr.io/${{ github.repository_owner }}/astrobee:latest-ubuntu16.04; fi;
+        if [ "${{ github.repository_owner }}" = "nasa" ]; then docker push ghcr.io/${{ github.repository_owner }}/astrobee:latest-ubuntu16.04; fi;
 
   build-bionic:
 
@@ -66,7 +66,7 @@ jobs:
 
     - name: Push Docker image
       run: |
-        if [ ${{ github.repository_owner }}="nasa" ]; then docker push ghcr.io/${{ github.repository_owner }}/astrobee:latest-ubuntu18.04; fi;
+        if [ "${{ github.repository_owner }}" = "nasa" ]; then docker push ghcr.io/${{ github.repository_owner }}/astrobee:latest-ubuntu18.04; fi;
 
   build-focal:
 
@@ -97,4 +97,4 @@ jobs:
 
     - name: Push Docker image
       run: |
-        if [ ${{ github.repository_owner }}="nasa" ]; then docker push ghcr.io/${{ github.repository_owner }}/astrobee:latest-ubuntu20.04; fi;
+        if [ "${{ github.repository_owner }}" = "nasa" ]; then docker push ghcr.io/${{ github.repository_owner }}/astrobee:latest-ubuntu20.04; fi;


### PR DESCRIPTION
A blank space is needed between the operator and the operands.
Otherwise, it always returns true.