### PR TITLE
INSTALL.md: Use spaces for indented blocks to gen correct markup

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,17 +1,17 @@
 # Install
 
-## Quick Start using the Astrobee docker image
+## Quick start using the Astrobee Docker image
 
-If you just want to try out the astrobee simulator, you can use one of the docker images in the [Docker Hub](https://hub.docker.com/r/astrobee/astrobee). 
+If you just want to try out the astrobee simulator, you can use one of the Docker images in the [Docker Hub](https://hub.docker.com/r/astrobee/astrobee).
 
 Given that Docker (see note) is installed:
 
-	git clone https://github.com/nasa/astrobee.git
-	cd astrobee
-	./scripts/docker/run.sh
+    git clone https://github.com/nasa/astrobee.git
+    cd astrobee
+    ./scripts/docker/run.sh
 
-*Note: Be aware that this only works on a native ubuntu install.*
-*Note: Make sure you have docker installed in your ubuntu system following the [installation instructions](https://docs.docker.com/engine/install/ubuntu/) and [post-installation steps for Linux](https://docs.docker.com/engine/install/linux-postinstall/).*
+*Note: Be aware that this only works on a native Ubuntu install.*
+*Note: Make sure you have Docker installed in your Ubuntu system following the [installation instructions](https://docs.docker.com/engine/install/ubuntu/) and [post-installation steps for Linux](https://docs.docker.com/engine/install/linux-postinstall/).*
 
 ## Building the code natively
 
@@ -32,7 +32,7 @@ If you are a NASA user and want to install the cross-compiler for robot testing 
 
 ## Using Docker
 
-Docker build is also available for Ubuntu 16 and Ubuntu 18, 
+Docker builds are also available for Ubuntu 16 and Ubuntu 18.
 
 Instructions on how to build the images natively and run the containers are in:
 


### PR DESCRIPTION
The html currently in https://nasa.github.io/astrobee/html/md_INSTALL.html does not display correctly the "git clone ..." block on top. 

Based on how indented blocks are supposed to be written, per https://github.github.com/gfm/#indented-code-block, I replaced tabs with four spaces. Some other minor fixes were made for consistency of capitalization and punctuation. 