### PR TITLE
Print note that the number of errors may have changed.

### DIFF
--- a/scripts/git/cpplint_repo.py
+++ b/scripts/git/cpplint_repo.py
@@ -36,6 +36,7 @@ def print_objection():
     print("Code formatting errors were found.")
     print("==================================")
 
+
 def main():
     num_errors = 0
 

--- a/scripts/git/cpplint_repo.py
+++ b/scripts/git/cpplint_repo.py
@@ -33,13 +33,8 @@ def run_cpplint(filename, cpplint_path):
 
 
 def print_objection():
-    print("   ____  __      _           __  _             __")
-    print("  / __ \/ /_    (_)__  _____/ /_(_)___  ____  / /")
-    print(" / / / / __ \  / / _ \/ ___/ __/ / __ \/ __ \/ / ")
-    print("/ /_/ / /_/ / / /  __/ /__/ /_/ / /_/ / / / /_/  ")
-    print("\____/_.___/_/ /\___/\___/\__/_/\____/_/ /_(_)   ")
-    print("          /___/                                  ")
-
+    print("Code formatting errors were found.")
+    print("==================================")
 
 def main():
     num_errors = 0
@@ -98,9 +93,9 @@ def main():
 
     print(("=" * 50))
     if num_errors > 0:
-        print(("  You have %d lint errors" % num_errors))
+        print(("  You have %d lint errors." % num_errors))
     elif num_errors == 0:
-        print("  Code adheres to style guide lines")
+        print("  Code adheres to style guidelines.")
 
     exit(num_errors)
 

--- a/scripts/git/pre-commit.linter_cpp
+++ b/scripts/git/pre-commit.linter_cpp
@@ -58,13 +58,8 @@ def run_cpplint(filename, cpplint_path):
 
 
 def print_objection():
-    print("   ____  __      _           __  _             __")
-    print("  / __ \/ /_    (_)__  _____/ /_(_)___  ____  / /")
-    print(" / / / / __ \  / / _ \/ ___/ __/ / __ \/ __ \/ / ")
-    print("/ /_/ / /_/ / / /  __/ /__/ /_/ / /_/ / / / /_/  ")
-    print("\____/_.___/_/ /\___/\___/\__/_/\____/_/ /_(_)   ")
-    print("          /___/                                  ")
-
+    print("Code formatting errors were found.")
+    print("==================================")
 
 def main():
     num_errors = 0
@@ -144,10 +139,11 @@ def main():
 
     print("=" * 50)
     if num_errors > 0:
-        print("  You have %d lint errors, commit failed" % num_errors)
-        print("  The errors were automatically piped through clang-format-8")
+        print("  You have %d lint errors, commit failed." % num_errors)
+        print("  Your code was modified with clang-format-8. " + \
+              "Try to add and commit your files again to get an updated error count.")
     elif num_errors == 0:
-        print("  Code adheres to style guide lines, committing ...")
+        print("  Code adheres to style guide lines. Committing.")
 
     exit(num_errors)
 


### PR DESCRIPTION
Once the linter flags the errors, clang-format-8 fixes them, but the old number of errors is printed, before the fix. 

Here I add a note to mention that the user should add and commit the files again to see the updated number of errors. Longer term, our hook needs to be modified to run cpplint second time, but for now this may do.

I also reword the "OBJECTION" notice. I always found it mildly insulting. Fixing thousands of format errors is unpleasant enough, without that ugly note in your face. 