### PR TITLE
Add the option --fix-first-map to merge_maps

### DIFF
--- a/localization/sparse_mapping/include/sparse_mapping/reprojection.h
+++ b/localization/sparse_mapping/include/sparse_mapping/reprojection.h
@@ -26,6 +26,7 @@
 #include <vector>
 #include <limits>
 #include <string>
+#include <set>
 
 namespace camera {
   class CameraModel;
@@ -69,8 +70,8 @@ void BundleAdjust(std::vector<std::map<int, int> > const& pid_to_cid_fid,
                   ceres::Solver::Options const& options,
                   ceres::Solver::Summary* summary,
                   int first = 0, int last = std::numeric_limits<int>::max(),
-                  bool fix_cameras = false, bool fix_all_xyz = false);
-
+                  bool fix_cameras = false,
+                  std::set<int> const& fixed_cameras = std::set<int>());
 
 /**
  * Perform bundle adjustment.
@@ -79,15 +80,14 @@ void BundleAdjust(std::vector<std::map<int, int> > const& pid_to_cid_fid,
  * meant to be used to do 2 or 3 camera refinements however it can do
  * N cameras just fine.
  *
-
  **/
-void BundleAdjust(std::vector<Eigen::Matrix2Xd> const& features_n,
-                  double focal_length,
-                  std::vector<Eigen::Affine3d> * cam_t_global_n,
-                  Eigen::Matrix3Xd * pid_to_xyz,
-                  ceres::LossFunction * loss,
-                  ceres::Solver::Options const& options,
-                  ceres::Solver::Summary * summary);
+void BundleAdjustSmallSet(std::vector<Eigen::Matrix2Xd> const& features_n,
+                          double focal_length,
+                          std::vector<Eigen::Affine3d> * cam_t_global_n,
+                          Eigen::Matrix3Xd * pid_to_xyz,
+                          ceres::LossFunction * loss,
+                          ceres::Solver::Options const& options,
+                          ceres::Solver::Summary * summary);
 
 // Random integer between min (inclusive) and max (exclusive)
 int RandomInt(int min, int max);

--- a/localization/sparse_mapping/include/sparse_mapping/tensor.h
+++ b/localization/sparse_mapping/include/sparse_mapping/tensor.h
@@ -85,14 +85,16 @@ namespace sparse_mapping {
    * Improve the map with bundle adjustment. Vary only the cameras
    * between given indices.
    **/
-  void BundleAdjust(bool fix_cameras, sparse_mapping::SparseMap * map);
+  void BundleAdjust(bool fix_all_cameras, sparse_mapping::SparseMap * map,
+                    std::set<int> const& fixed_cameras = std::set<int>());
 
   void BundleAdjustment(sparse_mapping::SparseMap * s,
                         ceres::LossFunction * loss,
                         const ceres::Solver::Options & options,
                         ceres::Solver::Summary * summary,
                         int first = 0, int last = std::numeric_limits<int>::max(),
-                        bool fix_cameras = false);
+                        bool fix_all_cameras = false,
+                        std::set<int> const& fixed_cameras = std::set<int>());
 
   /**
      Append map file.
@@ -100,7 +102,7 @@ namespace sparse_mapping {
   void AppendMapFile(std::string const& mapOut, std::string const& mapIn,
                      int num_image_overlaps_at_endpoints,
                      double outlier_factor,
-                     bool bundle_adjust);
+                     bool bundle_adjust, bool fix_first_map);
 
   /**
      Merge two maps.

--- a/localization/sparse_mapping/readme.md
+++ b/localization/sparse_mapping/readme.md
@@ -283,8 +283,8 @@ option until the final map is computed, as this step can be
 time-consuming.
 
 If the first of the two maps to merge is already registered, it may be
-desirable to keep that portion fixed during merging. That is
-accomplished with the flag -fix_first_map.
+desirable to keep that portion fixed during merging when bundle
+adjustment happens. That is accomplished with the flag -fix_first_map.
   
 #### How to build a map efficiently
 

--- a/localization/sparse_mapping/readme.md
+++ b/localization/sparse_mapping/readme.md
@@ -283,11 +283,8 @@ option until the final map is computed, as this step can be
 time-consuming.
 
 If the first of the two maps to merge is already registered, it may be
-desirable to keep that portion fixed during merging. To achieve that,
-the merging can be done without bundle adjustment, and then build_map
-can be invoked only to do bundle adjustment, while specifying the
-range of cameras to optimize (the ones from the second map). See
-build_map.md for details.
+desirable to keep that portion fixed during merging. That is
+accomplished with the flag -fix_first_map.
   
 #### How to build a map efficiently
 

--- a/localization/sparse_mapping/src/tensor.cc
+++ b/localization/sparse_mapping/src/tensor.cc
@@ -605,8 +605,8 @@ void CloseLoop(sparse_mapping::SparseMap * s) {
                               &(s->cid_fid_to_pid_));
 }
 
-void BundleAdjust(bool fix_cameras,
-                  sparse_mapping::SparseMap * map) {
+void BundleAdjust(bool fix_all_cameras, sparse_mapping::SparseMap * map,
+                  std::set<int> const& fixed_cameras) {
   for (int i = 0; i < FLAGS_num_ba_passes; i++) {
     LOG(INFO) << "Beginning bundle adjustment, pass: " << i << ".\n";
 
@@ -619,16 +619,17 @@ void BundleAdjust(bool fix_cameras,
     options.max_num_iterations = FLAGS_max_num_iterations;
     options.minimizer_progress_to_stdout = true;
     ceres::Solver::Summary summary;
-    sparse_mapping::BundleAdjustment(map,
-                                     sparse_mapping::GetLossFunction(FLAGS_cost_function,
-                                                                     FLAGS_cost_function_threshold),
-                                     options, &summary,
+    ceres::LossFunction* loss = sparse_mapping::GetLossFunction(FLAGS_cost_function,
+                                                                FLAGS_cost_function_threshold);
+    sparse_mapping::BundleAdjustment(map, loss, options, &summary,
                                      FLAGS_first_ba_index, FLAGS_last_ba_index,
-                                     fix_cameras);
+                                     fix_all_cameras, fixed_cameras);
 
     LOG(INFO) << summary.FullReport() << "\n";
-    LOG(INFO) << "Starting Average Reprojection Error: " << summary.initial_cost / map->GetNumObservations();
-    LOG(INFO) << "Final Average Reprojection Error:    " << summary.final_cost / map->GetNumObservations();
+    LOG(INFO) << "Starting average reprojection error: "
+              << summary.initial_cost / map->GetNumObservations();
+    LOG(INFO) << "Final average reprojection error:    "
+              << summary.final_cost / map->GetNumObservations();
   }
 }
 
@@ -636,13 +637,15 @@ void BundleAdjustment(sparse_mapping::SparseMap * s,
                       ceres::LossFunction* loss,
                       const ceres::Solver::Options & options,
                       ceres::Solver::Summary* summary,
-                      int first, int last, bool fix_cameras) {
+                      int first, int last, bool fix_all_cameras,
+                      std::set<int> const& fixed_cameras) {
   sparse_mapping::BundleAdjust(s->pid_to_cid_fid_, s->cid_to_keypoint_map_,
                                s->camera_params_.GetFocalLength(), &(s->cid_to_cam_t_global_),
                                &(s->pid_to_xyz_),
                                s->user_pid_to_cid_fid_, s->user_cid_to_keypoint_map_,
                                &(s->user_pid_to_xyz_),
-                               loss, options, summary, first, last, fix_cameras);
+                               loss, options, summary, first, last, fix_all_cameras,
+                               fixed_cameras);
 
   // First do BA, and only afterwards remove outliers.
   if (!FLAGS_skip_filtering) {
@@ -655,14 +658,33 @@ void BundleAdjustment(sparse_mapping::SparseMap * s,
   // PrintTrackStats(s->pid_to_cid_fid_, "bundle adjustment and filtering");
 }
 
+// Check if the two arrays share elements
+bool haveSharedElements(std::vector<std::string> const& A, std::vector<std::string> const& B) {
+  std::set<std::string> setA;
+  for (size_t it = 0; it < A.size(); it++) setA.insert(A[it]);
+
+  for (size_t it = 0; it < B.size(); it++)
+    if (setA.find(B[it]) != setA.end())
+      return true;
+
+  return false;
+}
+
 // Load two maps, merge the second one onto the first one, and save the result.
 void AppendMapFile(std::string const& mapOut, std::string const& mapIn,
                    int num_image_overlaps_at_endpoints,
-                   double outlier_factor, bool bundle_adjust) {
+                   double outlier_factor, bool bundle_adjust,
+                   bool fix_first_map) {
+  if (!bundle_adjust && fix_first_map) LOG(FATAL) << "Cannot fix first map if no bundle adjustment happens.";
+
   LOG(INFO) << "Appending " << mapIn << " to " << mapOut << std::endl;
 
   sparse_mapping::SparseMap A(mapOut);
   sparse_mapping::SparseMap B(mapIn);
+
+  // Sanity check before we do a lot of work
+  if (fix_first_map && haveSharedElements(A.cid_to_filename_, B.cid_to_filename_))
+    LOG(FATAL) << "Cannot fix the first map if it shares cameras with the second map.";
 
   // C starts as A, as SparseMap lacks an empty constructor
   sparse_mapping::SparseMap C(mapOut);
@@ -674,10 +696,23 @@ void AppendMapFile(std::string const& mapOut, std::string const& mapIn,
                             mapOut,
                             &C);
 
-  // Bundle adjust the merged map.
+  // Bundle-adjust the merged map
   if (bundle_adjust) {
-    bool fix_cameras = false;
-    sparse_mapping::BundleAdjust(fix_cameras, &C);
+    bool fix_all_cameras = false;
+
+    std::set<int> fixed_cameras;
+
+    // Find in the list of images of the merged map the ones from the first map
+    if (fix_first_map) {
+      std::set<std::string> setA;
+      for (size_t it = 0; it < A.cid_to_filename_.size(); it++) setA.insert(A.cid_to_filename_[it]);
+
+      for (size_t it = 0; it < C.cid_to_filename_.size(); it++) {
+        if (setA.find(C.cid_to_filename_[it]) != setA.end()) fixed_cameras.insert(it);
+      }
+    }
+
+    sparse_mapping::BundleAdjust(fix_all_cameras, &C, fixed_cameras);
   }
 
   C.Save(mapOut);
@@ -2027,9 +2062,9 @@ void BuildMapFindEssentialAndInliers(Eigen::Matrix2Xd const& keypoints1,
           << " (" << round((100.0*num_pts_behind_camera) / observations2[0].cols())
           << "%)";
 
-  sparse_mapping::BundleAdjust(observations2, camera_params.GetFocalLength(), &cameras,
-                               &pid_to_xyz, new ceres::CauchyLoss(0.5), options,
-                               &summary);
+  sparse_mapping::BundleAdjustSmallSet(observations2, camera_params.GetFocalLength(), &cameras,
+                                       &pid_to_xyz, new ceres::CauchyLoss(0.5), options,
+                                       &summary);
 
   if (!summary.IsSolutionUsable()) {
     LOG(ERROR) << cam_a_idx << " " << cam_b_idx << " | Failed to refine RT with bundle adjustment";

--- a/localization/sparse_mapping/test/test_sparse_map.cc
+++ b/localization/sparse_mapping/test/test_sparse_map.cc
@@ -282,9 +282,10 @@ TEST_P(SparseMapTest, MapExtractMerge) {
   bool skip_bundle_adjustment = false;
   int num_image_overlaps_at_endpoints = 10;
   double outlier_factor = 3;
+  bool fix_first_map = false;
   sparse_mapping::AppendMapFile(submap1_file, submap2_file,
                                 num_image_overlaps_at_endpoints, outlier_factor,
-                                !skip_bundle_adjustment);
+                                !skip_bundle_adjustment, fix_first_map);
 
   // Read the merged map, and check if we have 3 frames as expected
   LOG(INFO) << "Reading: " << submap1_file << std::endl;

--- a/localization/sparse_mapping/tools/merge_maps.cc
+++ b/localization/sparse_mapping/tools/merge_maps.cc
@@ -59,6 +59,10 @@ DEFINE_double(outlier_factor, 3.0,
 DEFINE_bool(skip_bundle_adjustment, false,
             "If true, do not bundle adjust the merged map.");
 
+DEFINE_bool(fix_first_map, false,
+            "If true and bundle adjustment is not skipped, keep the first map fixed "
+            "when bundle adjustment takes place.");
+
 int main(int argc, char** argv) {
   ff_common::InitFreeFlyerApplication(&argc, &argv);
   GOOGLE_PROTOBUF_VERIFY_VERSION;
@@ -80,6 +84,9 @@ int main(int argc, char** argv) {
   if (FLAGS_num_image_overlaps_at_endpoints <= 0)
     LOG(FATAL) << "Must have num_image_overlaps_at_endpoints > 0.";
 
+  if (FLAGS_fix_first_map && argc != 3)
+    LOG(FATAL) << "Keeping the first map fixed works only when there are two input maps.";
+
   // The merged map starts as the first map.
   {
     sparse_mapping::SparseMap A(argv[1]);
@@ -92,7 +99,8 @@ int main(int argc, char** argv) {
     sparse_mapping::AppendMapFile(FLAGS_output_map, argv[i],
                                   FLAGS_num_image_overlaps_at_endpoints,
                                   FLAGS_outlier_factor,
-                                  !FLAGS_skip_bundle_adjustment);
+                                  !FLAGS_skip_bundle_adjustment,
+                                  FLAGS_fix_first_map);
   }
 
   google::protobuf::ShutdownProtobufLibrary();


### PR DESCRIPTION
This option makes it easy to merge and register a second map to a first map. Bundle adjustment will happen only on the second map while seeing but keeping fixed the first map. Hence if the registration of the first map is trusted, there is no need to collect control points. 