### PR TITLE
Add clarification for .bashrc

### DIFF
--- a/doc/general_documentation/INSTALL.md
+++ b/doc/general_documentation/INSTALL.md
@@ -102,6 +102,10 @@ of turning on and off options. To see which options are supported, simply run
     source ~/.bashrc
     popd
 
+The configure script modifies your ``.bashrc`` to source ``setup.bash`` for 
+the current ROS distribution and to set CMAKE_PREFIX_PATH. It is suggested
+to examine it and see if all changes were made correctly.
+
 If you want to explicitly specify the workspace and install directories, use
 instead:
 

--- a/doc/general_documentation/NASA_INSTALL.md
+++ b/doc/general_documentation/NASA_INSTALL.md
@@ -173,6 +173,10 @@ of turning on and off options. To see which options are supported, simply run
     source ~/.bashrc
     popd
 
+The configure script modifies your ``.bashrc`` to source ``setup.bash`` for 
+the current ROS distribution and to set CMAKE_PREFIX_PATH. It is suggested
+to examine it and see if all changes were made correctly.
+
 If you want to explicitly specify the workspace and/or install directories, use
 instead:
 


### PR DESCRIPTION
The configure.sh script modifies user's .bashrc. In my case it did it incorrectly, as the logic using "grep" it has can't distinguish commented out lines.

This text makes it explicit that .bashrc is modified, and it suggests that the user examine the changes.