### PR TITLE
Fix: configure.sh correctly appends cmake env var to ./bashrc

### DIFF
--- a/scripts/configure.sh
+++ b/scripts/configure.sh
@@ -309,8 +309,10 @@ if [ $native_build == 1 ] ; then
     # Add our cmake to paths and bashrc
     grep -qF 'source /opt/ros/'$ros_version'/setup.bash' ~/.bashrc || echo 'source /opt/ros/'$ros_version'/setup.bash' >> ~/.bashrc
     cmake_astrobee_path=`catkin locate -s`/cmake
-    grep -qF ${cmake_astrobee_path} ~/.bashrc \
-      || echo 'if [[ ":$CMAKE_PREFIX_PATH:" != *":'${cmake_astrobee_path}':"* ]]; then CMAKE_PREFIX_PATH="${CMAKE_PREFIX_PATH:+"$CMAKE_PREFIX_PATH:"}'${cmake_astrobee_path}'"; fi' >> ~/.bashrc
+    grep -qF ${cmake_astrobee_path} ~/.bashrc || {
+      echo -e '\n' >> ~/.bashrc \ 
+      echo 'if [[ ":$CMAKE_PREFIX_PATH:" != *":'${cmake_astrobee_path}':"* ]]; then CMAKE_PREFIX_PATH="${CMAKE_PREFIX_PATH:+"$CMAKE_PREFIX_PATH:"}'${cmake_astrobee_path}'"; fi' >> ~/.bashrc
+    }
     source ~/.bashrc
 
     catkin profile add native


### PR DESCRIPTION
Add: newline before cmake append in configure.sh. configure.sh did not correctly append if ./bashrc did not end in a newline (i.e., command was appended to existing line in ./bashrc, even if it was commented, had a command, etc.)