### PR TITLE
Documentation failed to compile

### DIFF
--- a/astrobee.doxyfile
+++ b/astrobee.doxyfile
@@ -789,7 +789,7 @@ INPUT                  =  README.md \
                           astrobee \
                           simulation \
                           tools \
-                          description \
+                          description/description \
                           licenses.csv
 
 

--- a/doc/general_documentation/astrobee_usage.md
+++ b/doc/general_documentation/astrobee_usage.md
@@ -3,6 +3,8 @@
 
 \subpage astrobee
 
+\subpage astrobee-code-style
+
 \subpage teleop
 
 \subpage release

--- a/localization/sparse_mapping/build_map.md
+++ b/localization/sparse_mapping/build_map.md
@@ -56,7 +56,7 @@ temporarily modify the above files to reflect your camera's parameters
 (without checking in your changes).
 
 More details on these and other environmental variables can be found
-in the \subpage astrobee configuration documentation.
+in the \ref astrobee configuration documentation.
 
 ## Reduce the number of images
 
@@ -77,7 +77,7 @@ should inspect the images in the ``eog`` viewer, and delete redundant
 ones from it manually, using the Delete key.
 
 The images can also be inspected and deleted with ``nvm_visualize``, a
-tool included with this software. See \subpage sparsemapping for
+tool included with this software. See \ref sparsemapping for
 details.  This tool, unlike ``eog``, echoes each image name as it is
 displayed, which can be useful with image manipulation tasks.
 
@@ -123,7 +123,7 @@ before doing feature detection. It was shown to create maps that are
 more robust to illumination changes.
 
 In practice, the map is build in pieces, and then merged. Then the
-above process needs to be modified. See \subpage sparsemapping for the
+above process needs to be modified. See \ref sparsemapping for the
 procedure.
 
 ### Map building pipeline
@@ -212,7 +212,7 @@ would drift from each other.
 
 If it is desired to take out images from the map, it should happen at
 this stage, before the vocabulary database and pruning happens at the
-next step. See \subpage sparsemapping when it comes to such
+next step. See \ref sparsemapping when it comes to such
 operations, where the script grow_map.py is used.
 
 #### Vocabulary database
@@ -304,8 +304,8 @@ The xyz locations of the control points for the granite lab, the
 ISS and MGTF are mentioned below.
 
 If a set of world coordinates needs to be acquired, one can use the
-\subpage total_station. (Alternatively one can can try the 
-\subpage faro instrument but that is more technically involved.)
+\ref total_station. (Alternatively one can can try the
+\ref faro instrument but that is more technically involved.)
 
 Register the map with the command:
     
@@ -366,7 +366,7 @@ new image set.
 ### Registration in the granite lab
 
 See the xyz coordinates of the control points used for registration in
-the \subpage granite_lab_registration section.
+the \ref granite_lab_registration section.
 
 ### Registration on the ISS
 
@@ -427,7 +427,7 @@ Python command will refresh them.
 ### Registration in the MGTF
 
 A set of 10 registration points were measured in the MGTF with the
-\subpage total_station. They are in the file:
+\ref total_station. They are in the file:
 
     $ASTROBEE_SOURCE_PATH/localization/sparse_mapping/mgtf_registration.txt
 
@@ -590,7 +590,7 @@ and compared to the old ones via:
 
 ## Evaluating the map without running the localization node
 
-See the \subpage ekfbag page for how to run the ``sparse_map_eval``
+See the \ref ekfbag page for how to run the ``sparse_map_eval``
 tool that takes as inputs a bag and a BRISK map and prints the number
 of detected features.
 

--- a/localization/sparse_mapping/readme.md
+++ b/localization/sparse_mapping/readme.md
@@ -19,7 +19,7 @@ features detected in the image and their 3D coordinates.
 
 ### Inputs
 
-* `/hw/cam_nav`: Camera images The map file. See the \subpage
+* `/hw/cam_nav`: Camera images The map file. See the \ref
   map_building section (towards the bottom) for its assumed location
   on the robot.
 
@@ -106,7 +106,7 @@ name can change.
 
 ### Building a map
 
-The ``build_map`` tools is used to construct a map. See \subpage
+The ``build_map`` tools is used to construct a map. See \ref
 map_building for further details.
 
 ### Visualization
@@ -162,7 +162,7 @@ built. It can also delete images in this mode, with the 'Delete' and
 ### Localize a single frame
 
 All the commands below assume that the environment was set up, 
-as specified in the \subpage map_building section.
+as specified in the \ref map_building section.
 
 To test localization of a single frame, use the command:
 
@@ -212,7 +212,7 @@ for speed and here we want more accuracy.
 
 ### Testing localization using a bag 
 
-See the \subpage ekfbag page for how to study how well a BRISK map
+See the \ref ekfbag page for how to study how well a BRISK map
 with a vocabulary database does when localizing images from a bag.
 
 ### Extract sub-maps
@@ -260,7 +260,7 @@ Given a set of SURF maps, they can be merged using the command:
       -num_image_overlaps_at_endpoints 50
 
 It is very important to note that only maps with SURF features (see
-\subpage map_building) can be merged. If a map has BRISK features, it
+\ref map_building) can be merged. If a map has BRISK features, it
 needs to be rebuilt with SURF features, as follows:
 
       build_map -rebuild -histogram_equalization       \
@@ -337,7 +337,7 @@ maps using the command:
      images/*jpg -output_map <map file>
 
 examine them individually, merging them as appropriate, then
-performing bundle adjustment and registration as per the \subpage
+performing bundle adjustment and registration as per the \ref
 map_building section. Only when a good enough map is obtained, a
 renamed copy of it should be rebuilt with BRISK features and a
 vocabulary database to be used on the robot.
@@ -492,3 +492,9 @@ Instead of taking images out of the map randomly, one can start with a
 reduced map with a small list of desired images which can be set with
 -image_list, and then all images for which localization fails will be
 added back to it.
+
+\subpage map_building
+\subpage total_station
+\subpage granite_lab_registration
+\subpage faro
+\subpage theia_map

--- a/tools/readme.md
+++ b/tools/readme.md
@@ -3,6 +3,8 @@
 This directory contains tools that are useful for debugging,
 but are not run on the robot.
 
+\subpage calibration
+
 \subpage ekfbag
 
 \subpage ekfvideo


### PR DESCRIPTION
I fixed the documentation replacing \subpage with \ref such that it could compile.
\subpage can only be used one for establishing a tree; \ref is used to reference a page

@oleg-alexandrov please re-arrange the tree in this PR if you don't like this configuration :)

@rsoussan reminder to put new documentation (calibration) inside a tree or else it will appear in the first page of the documentation and not under tools. If it was intended, please revert my changes