### PR TITLE
github test with single job

### DIFF
--- a/scripts/docker/test_astrobee.Dockerfile
+++ b/scripts/docker/test_astrobee.Dockerfile
@@ -7,6 +7,6 @@ FROM ${REMOTE}/astrobee:latest-ubuntu${UBUNTU_VERSION}
 
 # Run tests
 RUN cd /src/astrobee && catkin build --make-args tests \
-	&& catkin build --make-args test \
+	&& catkin build --make-args test -j1\
 	&& { . devel/setup.sh || true; } \
 	&& catkin_test_results build


### PR DESCRIPTION
lately we've been having some tests fail because github uses multiple jobs on the $catkin make test. This assures that only one test runs at a time