### PR TITLE
Fix in declared undistorted bounds

### DIFF
--- a/astrobee/config/cameras.config
+++ b/astrobee/config/cameras.config
@@ -61,8 +61,8 @@ dock_cam = {
 haz_cam = {
   width                = 224,
   height               = 171,
-  undistorted_width    = 600,
-  undistorted_height   = 500,
+  undistorted_width    = 250,
+  undistorted_height   = 200,
   distortion_coeff     = robot_camera_calibrations.haz_cam.distortion_coeff,
   intrinsic_matrix     = robot_camera_calibrations.haz_cam.intrinsic_matrix,
   device               = "/dev/haz_cam",
@@ -73,10 +73,10 @@ haz_cam = {
 };
 
 perch_cam = {
-  width=224,
-  height=171,
-  undistorted_width=600,
-  undistorted_height=500,
+  width                = 224,
+  height               = 171,
+  undistorted_width    = 250,
+  undistorted_height   = 200,
   distortion_coeff=robot_camera_calibrations.perch_cam.distortion_coeff,
   intrinsic_matrix=robot_camera_calibrations.perch_cam.intrinsic_matrix,
   device="/dev/perch_cam",


### PR DESCRIPTION
For haz_cam and perch cam the image dimensions are 224 and 171. Yet, the undistorted dimensions are declared to be 600 and 500. There's no way this is possible, since the distortion of these narrow-field-of-view cameras is small.

Such overestimation actually causes problems. Since the distortion model is given by a polynomial, when it is applied to pixels way outside its calibrated range, weird values can result. Hence, when creating a textured 3D model with the haz_cam image I get a plausible texture, but around it there is an empty ring corresponding to no pixels, followed by a halo of junk, corresponding to 3D points not normally seen in the camera yet which had the bad luck that after being put in camera's coordinate system, normalized, and passed through the distortion polynomial, managed to receive values that actually project into the camera. 

After adjusting the undistorted dimensions these problems go away.

No such problems are seen for the nav or sci camera which have more sensible choices.  But even for those however the undistorted bounds are too liberal. When undistorting it is preferable to err towards cutting off valid peripheral pixels than to keep all possible pixels with extra areas where no valid pixel values exist. I won't touch those as those undistorted dimensions are not so grossly off to cause issues.