### PR TITLE
Add fix for enabling localization from launch file

### DIFF
--- a/astrobee/launch/offline_localization/enable_localization
+++ b/astrobee/launch/offline_localization/enable_localization
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Run the command to enable localization. If it fails, try again after a short time.
+
+while [ 1 ]; do 
+  rosservice call --wait /loc/ml/enable true
+  ans=$?
+  if [ "$ans" -eq 0 ]; then 
+    break 
+  fi 
+  sleep 0.25 
+done
+
+
+

--- a/astrobee/launch/offline_localization/sparse_mapping_matching_from_bag.launch
+++ b/astrobee/launch/offline_localization/sparse_mapping_matching_from_bag.launch
@@ -63,6 +63,5 @@
   </include>
 
   <!-- Service calls -->
-  <!-- Add 'wait' here so nodes are running before the service calls are made -->
-  <node pkg="rosservice" type="rosservice" name="enable_sparse_mapping" args="call --wait /loc/ml/enable true" />
+  <node pkg="rosservice" type="rosservice" name="enable_localization" launch-prefix="$(find astrobee)/launch/offline_localization/enable_localization" args="" />
 </launch>


### PR DESCRIPTION
This is a continuation of https://github.com/nasa/astrobee/pull/374.

In ROS Melodic, launching a node to start a rosservice enabling localization fails, unless the node which starts in parallel playing the bag is already fully running. The error in that case is: "rospy.exceptions.ROSInitException: time is not initialized. Have you called init_node()?"

As I see it, playing the bag sets up a ROS node which then rosservice can talk to, and until that is done rosservice won't work, even when '--wait' is used with that rosservice. And playing a bag can take quite some time, if the bag is big. 

The fix I came up with is to put the call to the rosservice in a shell script, and within that script try this repeatedly till it succeeds.  I tested this very thoroughly and it works. There could be more elegant approaches out there, but for now maybe this may do. 