### PR TITLE
Bugfix in undistort_image

### DIFF
--- a/localization/sparse_mapping/readme.md
+++ b/localization/sparse_mapping/readme.md
@@ -157,8 +157,8 @@ disables the arrow keys, then one can navigate with the "Ins" and
 "Del" keys on the numpad.)
 
 This tool can be invoked to look at just images, without any map being
-built. It can also delete images in this mode, with the 'Delete' and
-'x' keys, if invoked as:
+built. It can also delete images in this mode, with the 'x' key, if
+invoked as:
 
     nvm_visualize -enable_image_deletion <image dir>/*jpg
 

--- a/localization/sparse_mapping/tools/build_map.cc
+++ b/localization/sparse_mapping/tools/build_map.cc
@@ -454,7 +454,10 @@ int main(int argc, char** argv) {
   GOOGLE_PROTOBUF_VERIFY_VERSION;
 
   // It is important to get the robot name right
-  std::cout << "ASTROBEE_ROBOT=" << getenv("ASTROBEE_ROBOT") << std::endl;
+  char * bot = getenv("ASTROBEE_ROBOT");
+  if (bot == NULL)
+    LOG(FATAL) << "ASTROBEE_ROBOT was not set.\n";
+  std::cout << "ASTROBEE_ROBOT=" << bot << std::endl;
 
   if (FLAGS_output_map == "")
     LOG(FATAL) << "Must specify the output map name.";

--- a/localization/sparse_mapping/tools/nvm_visualize.cc
+++ b/localization/sparse_mapping/tools/nvm_visualize.cc
@@ -617,7 +617,11 @@ int main(int argc, char** argv) {
       cid = num_images - 1;  // The 'End' key was pressed, go to the last image
     }
 
-    if ((ret =='x' || ret == 255) && FLAGS_enable_image_deletion) {
+    // Note that the 'Delete' key is not used, because in some
+    // situations, due to some quirk, certain window events can send a
+    // signal the viewer interprets as this key, and images are
+    // deleted then when not intended.
+    if (ret =='x' && FLAGS_enable_image_deletion) {
       deleteImageFromDiskAndMap(map, imfile);
       num_images = map.GetNumFrames();  // update the number of images
       if (num_images == 0) {


### PR DESCRIPTION
This commit fixes a couple of issues in undistort_image. When the distortion model has large inaccuracies at the boundary, or when the user would specify large crop dimensions for the undistorted images, it would crash. The solution is to do adjustments to keep things within bounds.

A second fix is to nvm_visualize. This has some functionality for deleting images, which only I use (it is useful though), and sometimes due to how getKey() works in OpenCV the tool thinks the 'Del' key is received when in fact another signal was sent.  The reason for that is obscure. This fix allow images to be deleted in nvm_visualize only with the 'x' key, and a comment about that was added.  