### PR TITLE
Add Python tools for processing Pico Flexx data, reducing redundant logging requirements

### DIFF
--- a/hardware/pico_driver/scripts/README.md
+++ b/hardware/pico_driver/scripts/README.md
@@ -5,7 +5,8 @@ These Python utilities enable us to process logged
 `/hw/depth_haz/extended` topic and split the data to regenerate both
 point cloud messages normally logged on the `/hw/depth_haz/points` topic
 and amplitude image messages logged on the
-`/hw/depth_haz/extended/amplitude_int` topic.
+`/hw/depth_haz/extended/amplitude_int` topic. (Those are the
+HazCam-specific topics; to use  PerchCam, specify `--cam=perch`.)
 
 As a result, once these tools are fully validated, we will no longer
 need to log the latter two topics, providing a major savings in data
@@ -24,14 +25,14 @@ experience shows can be significant.
 Using these tools is a two-step process:
 
 1. Prep once for each Pico Flexx serial number: Using a prior bag that
-   contains all three Pico message types, extract and save xyz
-   coefficients that are required to recover point clouds from extended
-   messages. Optionally, you can also use the prior bag to do a dry run
-   of the split operation and check the quality of the reconstructed
-   data.
+   contains point clouds, extract and save xyz coefficients that are
+   required to recover point clouds from extended messages. Optionally,
+   if the prior bag contains all three Pico message types, you can also
+   use it to do a dry run of the split operation and check the quality
+   of the reconstructed data.
 
-2. Production: A single command performs the split operation, writing a new bag
-   with the recovered point clouds and amplitude images.
+2. Production: A single command performs the split operation, writing a
+   new bag with the recovered point clouds and amplitude images.
 
 This usage example shows how to do the prep:
 
@@ -56,8 +57,10 @@ Using the pico_write_xyz_coeff.py script, the xyz coefficients are
 effectively derived from the camera intrinsic parameters stored in the
 camera firmware. These parameters are unique to each Pico Flexx serial
 number and calibrated at the factory. By convention, when saving the
-coefficients, the output file name should document which robot and
-which camera (haz or perch) the coefficients are for.
+coefficients, the output file name should document which robot and which
+camera (haz or perch) the coefficients are for. During reconstruction,
+be careful to use the correct coefficients file for your robot and
+camera.
 
 The method we are using to recover the coefficients requires a bag of
 sample data recorded from the sensor, and it can only produce

--- a/hardware/pico_driver/scripts/README.md
+++ b/hardware/pico_driver/scripts/README.md
@@ -20,6 +20,18 @@ save up to 6.9 GB (33%). These savings impact not just storage space on
 the Astrobee MLP but also CPU load required to log the data, which
 experience shows can be significant.
 
+## System requirements and installation
+
+So far, these tools were tested only under Ubuntu 18.04 and Python 2.7
+on the host astrobeast.ndc.nasa.gov. This host already had the necessary
+dependencies pre-installed by the admins in the ARC-TI Systems Group,
+so no installation steps were needed, other than checking out the scripts
+from the repository.
+
+Some minor changes would probably be needed to support Python 3.x. If
+the tools will be used on other hosts that aren't pre-configured, this
+section should be expanded to document how to install the dependencies.
+
 ## Usage
 
 Using these tools is a two-step process:

--- a/hardware/pico_driver/scripts/README.md
+++ b/hardware/pico_driver/scripts/README.md
@@ -1,0 +1,94 @@
+# Pico Flexx Python utilities
+
+These Python utilities enable us to process logged
+`ff_msgs/PicoflexxIntermediateData` messages on the
+`/hw/depth_haz/extended` topic and split the data to regenerate both
+point cloud messages normally logged on the `/hw/depth_haz/points` topic
+and amplitude image messages logged on the
+`/hw/depth_haz/extended/amplitude_int` topic.
+
+As a result, once these tools are fully validated, we will no longer
+need to log the latter two topics, providing a major savings in data
+volume. To quantify the impact, we studied the longest `delayed` bag
+from the SoundSee-Data-3 Astrobee ISS activity, running an ISAAC-style
+survey. Out of a total bag size of 20.9 GB, the top four messages by
+data volume were NavCam images (8.6 GB), HazCam point clouds (6.3 GB),
+HazCam extended messages (5.0 GB), and HazCam amplitude images (0.6
+GB). By no longer logging point clouds and amplitude images, we could
+save up to 6.9 GB (33%). These savings impact not just storage space on
+the Astrobee MLP but also CPU load required to log the data, which
+experience shows can be significant.
+
+## Usage
+
+Using these tools is a two-step process:
+
+1. Prep once for each Pico Flexx serial number: Using a prior bag that
+   contains all three Pico message types, extract and save xyz
+   coefficients that are required to recover point clouds from extended
+   messages. Optionally, you can also use the prior bag to do a dry run
+   of the split operation and check the quality of the reconstructed
+   data.
+
+2. Production: A single command performs the split operation, writing a new bag
+   with the recovered point clouds and amplitude images.
+
+This usage example shows how to do the prep:
+
+    scripts=$HOME/astrobee/src/hardware/pico_driver/scripts
+    # example bag archived at hivemind.ndc.nasa.gov:/home/data-processing/freeflyer/2022-01-03_100/robot_data/SN003/bags
+    inbag=20220103_1429_soundsee_isaac_isaac_survey15mins.bag
+    $scripts/pico_write_xyz_coeff.py $inbag bumble_haz_xyz_coeff.npy
+    # optional: dry run and check data quality
+    $scripts/pico_split_extended.py $inbag bumble_haz_xyz_coeff.npy haz_split.bag
+    $scripts/pico_check_split_extended.py $inbag haz_split.bag
+
+And this example excerpts the one step needed in production:
+
+    $scripts/pico_split_extended.py $inbag bumble_xyz_coeff.npy haz_split.bag
+
+## Getting valid xyz coefficients
+
+A file of xyz coefficients is required to recover point clouds from
+extended messages.
+
+Using the pico_write_xyz_coeff.py script, the xyz coefficients are
+effectively derived from the camera intrinsic parameters stored in the
+camera firmware. These parameters are unique to each Pico Flexx serial
+number and calibrated at the factory. By convention, when saving the
+coefficients, the output file name should document which robot and
+which camera (haz or perch) the coefficients are for.
+
+The method we are using to recover the coefficients requires a bag of
+sample data recorded from the sensor, and it can only produce
+coefficients for a given sensor pixel if at least one frame of the
+input bag has valid depth data for that pixel. This means that:
+
+- The bag needs to be recorded with a scene that is suitable for the
+  Pico Flexx (objects within the right distance range, objects not too
+  dark or specular, etc.).
+
+- If the bag is recorded during a normal Astrobee activity in the
+  complicated ISS environment, you will effectively never see a static
+  scene that has all valid pixels. Therefore, it's better to process a
+  bag that contains lots of Pico Flexx frames with varying scenery, in
+  order to have the best chance of filling in the occasional dropout
+  pixels.
+
+- We've seen in practice that even if the guidelines above are followed,
+  there may be many pixels (~3%) near the corners of the image that
+  never get any valid depth returns. This doesn't cause anything to
+  crash and isn't a big deal *except* that if we use the resulting
+  coefficients, then even if future Pico Flexx sensor frames have valid
+  depth returns for those pixels, we won't be able to reconstruct the
+  corresponding xyz points due to the missing coefficients. The relevant
+  entries in the reconstructed xyz output will be set to the no-data
+  value, as if there was not a valid depth return. Note that for dense
+  3D mapping purposes, the pixels near the corners were already being
+  ignored anyway, because they were considered suspect due to
+  limitations of the camera calibration and other issues.
+
+- In a controlled lab setting, the ideal bag to collect to maximize
+  valid depth returns for calibrating the coefficients would probably
+  have the camera staring at a blank white surface just a bit farther
+  away than the minimum depth range of the camera (e.g., 20 cm).

--- a/hardware/pico_driver/scripts/debug_pico_utils.py
+++ b/hardware/pico_driver/scripts/debug_pico_utils.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python
+# Copyright (c) 2017, United States Government, as represented by the
+# Administrator of the National Aeronautics and Space Administration.
+#
+# All rights reserved.
+#
+# The Astrobee platform is licensed under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with the
+# License. You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+"""
+Generate various plots that may help with debugging pico_utils issues.
+"""
+
+from __future__ import print_function
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import argparse
+import itertools
+import logging
+
+import numpy as np
+import pico_utils as pico
+import rosbag
+from matplotlib import collections as mc
+from matplotlib import pyplot as plt
+
+
+def plot_xy_grid_many(inbag_path, verbose=False, fast=False, cam=pico.DEFAULT_CAM):
+    """
+    Verify that over multiple point cloud frames, the xy values for z =
+    1 remain consistent.
+
+    Different frames will be plotted in different colors; you should
+    generally see only the last plotted color, except for a few
+    scattered points where one frame or another is missing data. And all
+    points should fall on a "warped grid" pattern based on the camera
+    intrinsics.
+    """
+    print()
+    print("=== plot_xy_grid_many ===")
+
+    fig = plt.figure()
+    fig, ax = plt.subplots()
+    ax.axis("equal")
+
+    for pts in pico.get_msgs(inbag_path, pico.get_pts_topic(cam), fast):
+        xyz = pico.xyz_from_points(pts)
+        x, y, z = xyz[:, 0], xyz[:, 1], xyz[:, 2]
+        xp = x / z
+        yp = y / z
+        plt.plot(xp, yp, ".")
+
+    plt.tight_layout()
+    fig_path = "xy_grid_many.png"
+    fig.set_size_inches((40, 40))
+    plt.savefig(fig_path)
+    logging.info("wrote to %s", fig_path)
+    plt.close()
+
+
+def iterate_pixels(img):
+    """
+    Given @img an N-channel image with dimensions (H, W, N), returns a
+    generator that iterates through the pixels, where the value of each
+    pixel is a length-N array.
+    """
+    w, h, _ = img.shape
+    for ix in range(w):
+        for iy in range(h):
+            yield img[ix, iy, :]
+
+
+def debug_plot_grid_lines(igrid):
+    """
+    Given @igrid a 2-channel "grid" image with dimensions (H, W, 2)
+    where channels 0 and 1 are interpreted as x and y coordinates, plot
+    the edges that connect Manhattan neighbor (x, y) points in order to
+    visually verify that the grid is sensible.
+    """
+    lines = []
+
+    # logging.debug("grid shapes %s %s", g.igrid[:, :-1, :].shape, g.igrid[:, 1:, :].shape)
+    grid_pairs = (
+        # horizontal neighbor pairs
+        (igrid[:, :-1, :], igrid[:, 1:, :]),
+        # vertical neighbor pairs
+        (igrid[:-1, :, :], igrid[1:, :, :]),
+    )
+    for from_grid, to_grid in grid_pairs:
+        for from_pt, to_pt in itertools.izip(
+            iterate_pixels(from_grid), iterate_pixels(to_grid)
+        ):
+            # logging.debug("from_pt %s to_pt %s", from_pt, to_pt)
+            if not (np.isnan(from_pt[0]) or np.isnan(to_pt[0])):
+                lines.append((from_pt, to_pt))
+                # logging.debug("lines d/d0 %f", np.linalg.norm(to_pt - from_pt) / 0.005)
+
+    lc = mc.LineCollection(lines, linewidths=[0.1] * len(lines))
+    fig, ax = plt.subplots()
+    ax.add_collection(lc)
+    ax.autoscale()
+
+
+def debug_plot_grid_points(igrid):
+    """
+    Given @igrid a 2-channel "grid" image with dimensions (H, W, 2)
+    where channels 0 and 1 are interpreted as x and y coordinates, plot
+    the (x, y) points.
+    """
+    plt.plot(igrid[:, :, 0], igrid[:, :, 1], "r.", markersize=0.1)
+
+
+def xy_from_xyz(xyz):
+    x, y, z = xyz[:, 0], xyz[:, 1], xyz[:, 2]
+    xp = x / z
+    yp = y / z
+    xy = np.column_stack([xp, yp])
+    return xy
+
+
+def igrid_from_xyz(xyz):
+    xy = xy_from_xyz(xyz)
+    return xy.reshape((pico.SENSOR_HEIGHT_PIXELS, pico.SENSOR_WIDTH_PIXELS, 2))
+
+
+def get_igrid(inbag_path, fast=False, cam=pico.DEFAULT_CAM):
+    xyz = pico.merge_point_clouds(
+        pico.get_msgs(inbag_path, pico.get_pts_topic(cam), fast=fast)
+    )
+    return igrid_from_xyz(xyz)
+
+
+def plot_xy_grid_merge(inbag_path, verbose=False, fast=False, cam=pico.DEFAULT_CAM):
+    """
+    Verify the sanity of the x/y grid after merging all xyz frames.
+    It should follow a "warped grid" pattern.
+    """
+    print()
+    print("=== plot_xy_grid_merge ===")
+    igrid = get_igrid(inbag_path, fast=fast, cam=cam)
+
+    fig = plt.figure()
+    fig, ax = plt.subplots()
+    ax.axis("equal")
+
+    debug_plot_grid_lines(igrid)
+    debug_plot_grid_points(igrid)
+
+    plt.tight_layout()
+    fig_path = "xy_grid_merge.pdf"
+    fig.set_size_inches((40, 40))
+    plt.savefig(fig_path)
+    logging.info("wrote to %s", fig_path)
+    plt.close()
+
+
+def plot_msg_sync(inbag_path, verbose=False, cam=pico.DEFAULT_CAM):
+    """
+    Figure out how to match extended messages to points messages from
+    the same frame.
+
+    From the resulting plots, it looks like generally when a new frame
+    arrives from the sensor, its "points" message will be published
+    first and its "extended" message will be published < 100 ms
+    later. (Going by the msg.header.stamp publish timestamp.)
+    """
+    print()
+    print("=== plot_msg_sync ===")
+
+    with rosbag.Bag(inbag_path, "r") as inbag:
+        topics = [pico.get_ext_topic(cam), pico.get_pts_topic(cam)]
+        topic_times = {}
+        for topic, msg, t in inbag.read_messages(topics):
+            times = topic_times.setdefault(topic, [])
+            times.append(msg.header.stamp)
+            if len(times) >= 1000:
+                break
+
+    t0 = topic_times[pico.get_pts_topic(cam)][0].to_sec()
+    for topic in topics:
+        topic_times[topic] = np.array([t.to_sec() for t in topic_times[topic]]) - t0
+
+    topic_data = {}
+    WIN_RADIUS = 10
+    DT_MIN = -2
+    DT_MAX = 2
+
+    pts_times = topic_times[pico.get_pts_topic(cam)]
+    for topic in topics:
+        data = []
+        times = topic_times[topic]
+        for i, pts_t in enumerate(pts_times):
+            dt = times[(i - WIN_RADIUS) : (i + WIN_RADIUS)] - pts_t
+            in_bounds = (dt >= DT_MIN) & (dt <= DT_MAX)
+            dt = dt[in_bounds]
+            for dt_val in dt:
+                data.append((pts_t, dt_val))
+        topic_data[topic] = np.array(data)
+
+    fig = plt.figure()
+    for topic in topics:
+        data = topic_data[topic]
+        plt.plot(data[:, 0], data[:, 1], ",", markersize=0.2)
+    plt.legend(topics)
+    plt.xlabel("elapsed time msg.header.stamp (s)")
+    plt.ylabel("dt (s)")
+    plt.yticks(np.arange(DT_MIN, DT_MAX + 0.1, 0.1))
+    plt.grid()
+
+    fig_path = "message_sync_all.pdf"
+    fig.set_size_inches((50, 10))
+    plt.savefig(fig_path)
+    logging.info("wrote to %s", fig_path)
+    plt.close()
+
+
+def plot_first_distance_image(inbag_path, verbose=False, cam=pico.DEFAULT_CAM):
+    """
+    Save the distance image extracted from the first extended message in
+    @inbag_path as an imshow() plot.
+    """
+    print()
+    print("=== plot_first_distance_image ===")
+    ext_msgs = pico.get_msgs(inbag_path, pico.get_ext_topic(cam))
+    distance, amplitude, intensity, noise = pico.split_extended(next(ext_msgs))
+
+    plt.figure()
+    plt.imshow(distance)
+    plt.tight_layout()
+    fig_path = "distance_image.png"
+    plt.savefig(fig_path)
+    logging.info("wrote to %s", fig_path)
+    plt.close()
+
+
+def debug_xyz_agreement(inbag_path, verbose=False, fast=False, cam=pico.DEFAULT_CAM):
+    print()
+    print("=== debug_xyz_agreement ===")
+    xyz_coeff = pico.get_xyz_coeff(inbag_path, fast)
+    pair_stream = pico.get_ext_pts_pairs(inbag_path, fast=fast, cam=cam)
+
+    err_max_log = []
+    err_rms_log = []
+    for i, (ext_msg, pts_msg) in enumerate(pair_stream):
+        distance, amplitude, intensity, noise = pico.split_extended(ext_msg)
+        distance = distance.reshape(
+            (pico.SENSOR_HEIGHT_PIXELS * pico.SENSOR_WIDTH_PIXELS,)
+        )
+        xyz_ext = xyz_coeff * distance[:, np.newaxis]
+        xyz_pts = pico.xyz_from_points(pts_msg)
+        success, err_max, err_rms = pico.check_xyz_error(xyz_pts, xyz_ext, i)
+        err_max_log.append(err_max)
+        err_rms_log.append(err_rms)
+
+    logging.info("Summary over all messages:")
+    logging.info(" Error max (um): %.3f", np.max(err_max_log) * 1e6)
+    logging.info(" Mean error RMS (um): %.3f", np.mean(err_rms_log) * 1e6)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        help="print more verbose debug info",
+        default=False,
+        action="store_true",
+    )
+    parser.add_argument(
+        "-f",
+        "--fast",
+        help="speed up testing by only processing part of the bag",
+        default=False,
+        action="store_true",
+    )
+    parser.add_argument(
+        "-c",
+        "--cam",
+        help="specify camera for rosbag topic filtering [%(default)s]",
+        nargs="?",
+        choices=pico.CAM_CHOICES,
+        default=pico.DEFAULT_CAM,
+    )
+    parser.add_argument("inbag", help="input bag")
+
+    args = parser.parse_args()
+    level = logging.DEBUG if args.verbose else logging.INFO
+    logging.basicConfig(level=level, format="%(message)s")
+
+    plot_xy_grid_many(args.inbag, verbose=args.verbose, fast=args.fast, cam=args.cam)
+    plot_xy_grid_merge(args.inbag, verbose=args.verbose, fast=args.fast, cam=args.cam)
+    plot_msg_sync(args.inbag, verbose=args.verbose, cam=args.cam)
+    plot_first_distance_image(args.inbag, verbose=args.verbose, cam=args.cam)
+    debug_xyz_agreement(args.inbag, verbose=args.verbose, fast=args.fast, cam=args.cam)
+
+    # suppress confusing ROS message at exit
+    logging.getLogger().setLevel(logging.WARN)

--- a/hardware/pico_driver/scripts/pico_check_split_extended.py
+++ b/hardware/pico_driver/scripts/pico_check_split_extended.py
@@ -67,7 +67,7 @@ def check_points_msgs(
 
         k_logger.info("checked %5d points messages", k_logger.count + 1)
 
-    logging.info("Summary over all %d points messages:", k_logger.count + 1)
+    logging.info("Summary over all %d points messages:", k_logger.count)
     logging.info(" Error max (um): %.3f", np.max(err_max_log) * 1e6)
     logging.info(" Mean error RMS (um): %.3f", np.mean(err_rms_log) * 1e6)
 

--- a/hardware/pico_driver/scripts/pico_check_split_extended.py
+++ b/hardware/pico_driver/scripts/pico_check_split_extended.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python
+# Copyright (c) 2017, United States Government, as represented by the
+# Administrator of the National Aeronautics and Space Administration.
+#
+# All rights reserved.
+#
+# The Astrobee platform is licensed under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with the
+# License. You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+"""
+Given two bags containing the message topics output by
+pico_split_extended.py, aligns matching messages by publish timestamp
+and checks their contents are the same. For "points" messages, the check
+includes a (very strict) error tolerance to accommodate round-off
+error. For "amplitude" messages, the check is for exact integer
+equality.
+"""
+
+import argparse
+import logging
+
+import numpy as np
+import pico_utils as pico
+
+
+def check_points_msgs(
+    orig_bag_path, test_bag_path, fast=False, verbose=False, cam=pico.DEFAULT_CAM
+):
+    pts_topic = pico.get_pts_topic(cam)
+    orig_msgs = pico.get_msg_tuples(orig_bag_path, pts_topic)
+    test_msgs = pico.get_msg_tuples(test_bag_path, pts_topic)
+
+    # In raw robot bags studied so far, the extended message is reliably
+    # published <100 ms after the points message. The points messages in
+    # orig_bag are timestamped like points messages.  The points messages in
+    # test_bag will have timestamps the same as the extended messages they are
+    # derived from.  We set dt_limit to reflect this.
+    pair_stream = pico.get_matched_msg_pairs(
+        orig_msgs,
+        test_msgs,
+        dt_limit=pico.EXT_MINUS_PTS_DT_LIMIT,
+    )
+    if fast:
+        pair_stream = pico.fast_filter(pair_stream)
+
+    success = True
+    err_max_log = []
+    err_rms_log = []
+
+    k_logger = pico.PrintEveryK(100)
+    for i, (orig_msg, test_msg) in enumerate(pair_stream):
+        msg_success, err_max, err_rms = pico.check_points_msg_pair(
+            orig_msg, test_msg, i, verbose
+        )
+        success &= msg_success
+        err_max_log.append(err_max)
+        err_rms_log.append(err_rms)
+
+        k_logger.info("checked %5d points messages", k_logger.count + 1)
+
+    logging.info("Summary over all %d points messages:", k_logger.count + 1)
+    logging.info(" Error max (um): %.3f", np.max(err_max_log) * 1e6)
+    logging.info(" Mean error RMS (um): %.3f", np.mean(err_rms_log) * 1e6)
+
+    return success
+
+
+def check_amp_msgs(
+    orig_bag_path, test_bag_path, fast=False, verbose=False, cam=pico.DEFAULT_CAM
+):
+    amp_topic = pico.get_amp_topic(cam)
+    orig_msgs = pico.get_msg_tuples(orig_bag_path, amp_topic)
+    test_msgs = pico.get_msg_tuples(test_bag_path, amp_topic)
+
+    # In the original bag, we should be guaranteed that the amp message comes
+    # after the extended message, because it is derived from the extended
+    # message by the pico_proxy nodelet. The amp messages in orig_bag should be
+    # timestamped like amp messages, but the timestamps in test_bag inherit
+    # their timestamps from the extended messages. Therefore dt should be negative.
+    pair_stream = pico.get_matched_msg_pairs(
+        orig_msgs,
+        test_msgs,
+        dt_limit=(-0.2, 0),
+    )
+    if fast:
+        pair_stream = pico.fast_filter(pair_stream)
+
+    success = True
+
+    k_logger = pico.PrintEveryK(100)
+    for i, (orig_msg, test_msg) in enumerate(pair_stream):
+        success &= pico.check_amp_msg_pair(orig_msg, test_msg, i, verbose)
+
+        k_logger.info("checked %5d amplitude_int messages", k_logger.count + 1)
+
+    return success
+
+
+def pico_check_split_extended(
+    orig_bag_path, test_bag_path, fast=False, verbose=False, cam=pico.DEFAULT_CAM
+):
+    success = True
+    success &= check_points_msgs(
+        orig_bag_path, test_bag_path, fast=fast, verbose=verbose, cam=cam
+    )
+    success &= check_amp_msgs(
+        orig_bag_path, test_bag_path, fast=fast, verbose=verbose, cam=cam
+    )
+
+    if success:
+        print("OK - All checks passed.")
+    else:
+        print("FAILED - Some checks failed. See previous messages.")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        help="Print debug info",
+        default=False,
+        action="store_true",
+    )
+    parser.add_argument(
+        "-f",
+        "--fast",
+        help="speed testing up by only processing part of the bags",
+        default=False,
+        action="store_true",
+    )
+    parser.add_argument(
+        "-c",
+        "--cam",
+        help="specify camera for rosbag topic filtering [%(default)s]",
+        nargs="?",
+        choices=pico.CAM_CHOICES,
+        default=pico.DEFAULT_CAM,
+    )
+    parser.add_argument(
+        "orig_bag", help="input bag containing original points messages"
+    )
+    parser.add_argument(
+        "test_bag",
+        help="input bag containing points messages to check against original messages",
+    )
+
+    args = parser.parse_args()
+    level = logging.DEBUG if args.verbose else logging.INFO
+    logging.basicConfig(level=level, format="%(message)s")
+
+    pico_check_split_extended(
+        args.orig_bag,
+        args.test_bag,
+        fast=args.fast,
+        verbose=args.verbose,
+        cam=args.cam,
+    )
+
+    # suppress confusing ROS message at exit
+    logging.getLogger().setLevel(logging.WARN)
+
+
+if __name__ == "__main__":
+    main()

--- a/hardware/pico_driver/scripts/pico_split_extended.py
+++ b/hardware/pico_driver/scripts/pico_split_extended.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python
+# Copyright (c) 2017, United States Government, as represented by the
+# Administrator of the National Aeronautics and Space Administration.
+#
+# All rights reserved.
+#
+# The Astrobee platform is licensed under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with the
+# License. You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+"""
+Given a bag containing /hw/depth_*/extended messages and an xyz coefficients
+file output by pico_write_xyz_coeff.py, output a bag of /hw/depth_*/points
+messages.
+"""
+
+import argparse
+import logging
+import os
+
+import numpy as np
+import pico_utils as pico
+import rosbag
+
+
+class PrintEveryK:
+    def __init__(self, k):
+        self.k = k
+        self.count = 0
+
+    def debug(self, *args, **kwargs):
+        self.count += 1
+        if (self.count % self.k) == 0:
+            logging.debug(*args, **kwargs)
+
+
+def pico_xyz_from_extended(
+    in_bag_path,
+    in_npy_path,
+    out_bag_path,
+    fast=False,
+    verbose=False,
+    cam=pico.DEFAULT_CAM,
+):
+    with open(in_npy_path, "rb") as in_npy:
+        xyz_coeff = np.load(in_npy)
+
+    k_logger = pico.PrintEveryK(100)
+    ext_topic = pico.get_ext_topic(cam)
+    pts_topic = pico.get_pts_topic(cam)
+    amp_topic = pico.get_amp_topic(cam)
+    with rosbag.Bag(out_bag_path, "w") as out_bag:
+        for ext_msg in pico.get_msgs(in_bag_path, ext_topic, fast):
+            distance, amplitude, intensity, noise = pico.split_extended(ext_msg)
+
+            xyz = pico.xyz_from_distance(distance, xyz_coeff)
+            pts_msg = pico.make_points_msg(ext_msg.header, xyz)
+            out_bag.write(pts_topic, pts_msg, pts_msg.header.stamp)
+
+            amp_msg = pico.make_amp_msg(ext_msg.header, amplitude)
+            out_bag.write(amp_topic, amp_msg, amp_msg.header.stamp)
+
+            k_logger.info("split %5d extended messages", k_logger.count + 1)
+    logging.info("wrote split messages to %s", out_bag_path)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        help="print more verbose debug info",
+        default=False,
+        action="store_true",
+    )
+    parser.add_argument(
+        "-f",
+        "--fast",
+        help="speed testing up by only processing part of the bag",
+        default=False,
+        action="store_true",
+    )
+    parser.add_argument(
+        "-c",
+        "--cam",
+        help="specify camera for rosbag topic filtering [%(default)s]",
+        nargs="?",
+        choices=pico.CAM_CHOICES,
+        default=pico.DEFAULT_CAM,
+    )
+    parser.add_argument("in_bag", help="input bag containing extended messages")
+    parser.add_argument("in_npy", help="input xyz coefficients file")
+    parser.add_argument("out_bag", help="output bag of points messages")
+
+    args = parser.parse_args()
+    if os.path.exists(args.out_bag):
+        parser.error("not replacing existing file %s" % args.out_bag)
+
+    level = logging.DEBUG if args.verbose else logging.INFO
+    logging.basicConfig(level=level, format="%(message)s")
+
+    pico_xyz_from_extended(
+        args.in_bag,
+        args.in_npy,
+        args.out_bag,
+        fast=args.fast,
+        verbose=args.verbose,
+        cam=args.cam,
+    )
+
+    # suppress confusing ROS message at exit
+    logging.getLogger().setLevel(logging.WARN)
+
+
+if __name__ == "__main__":
+    main()

--- a/hardware/pico_driver/scripts/pico_utils.py
+++ b/hardware/pico_driver/scripts/pico_utils.py
@@ -1,0 +1,473 @@
+#!/usr/bin/env python
+# Copyright (c) 2017, United States Government, as represented by the
+# Administrator of the National Aeronautics and Space Administration.
+#
+# All rights reserved.
+#
+# The Astrobee platform is licensed under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with the
+# License. You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+"""
+Utilities for working with Pico Flexx data in Python.
+"""
+
+from __future__ import print_function
+
+import collections
+import io
+import itertools
+import logging
+import struct
+
+import cv2
+import numpy as np
+import rosbag
+import sensor_msgs.point_cloud2 as pc2
+from cv_bridge import CvBridge
+from sensor_msgs.msg import Image, PointCloud2, PointField
+
+PTS_TOPIC_TMPL = "/hw/depth_{cam}/points"
+EXT_TOPIC_TMPL = "/hw/depth_{cam}/extended"
+AMP_TOPIC_TMPL = "/hw/depth_{cam}/extended/amplitude_int"
+CAM_CHOICES = ("haz", "perch")
+DEFAULT_CAM = "haz"
+SENSOR_WIDTH_PIXELS = 224
+SENSOR_HEIGHT_PIXELS = 171
+
+# We've observed that in the raw bags from Astrobee, the depth "extended"
+# message is reliably published < 100 ms after the "points" message, when
+# comparing the msg.header.stamp values. We can use this to robustly identify
+# matched message pairs, even if they are occasionally out of order in the
+# rosbag.
+EXT_MINUS_PTS_DT_LIMIT = (0, 0.1)
+PTS_MINUS_EXT_DT_LIMIT = (-EXT_MINUS_PTS_DT_LIMIT[1], -EXT_MINUS_PTS_DT_LIMIT[0])
+
+# This tolerance is much stricter than what we really need from the application
+# side, and about double the maximum error we've seen so far with
+# reconstructing points messages from extended messages. If we start to see
+# tolerance violations at this level, we could consider increasing it.
+ERROR_TOLERANCE_METERS = 250e-6
+
+# The amplitude portion of the extended message is encoded as a floating point
+# value that needs to be scaled before converting to an integer type for Kalibr
+# compatibility. The scaling factor is somewhat arbitrary, and Oleg verified
+# this value works empirically, although it may not be optimal.
+AMPLITUDE_SCALE = 100
+
+
+def get_ext_topic(cam):
+    return EXT_TOPIC_TMPL.format(cam=cam)
+
+
+def get_pts_topic(cam):
+    return PTS_TOPIC_TMPL.format(cam=cam)
+
+
+def get_amp_topic(cam):
+    return AMP_TOPIC_TMPL.format(cam=cam)
+
+
+class PrintEveryK:
+    """
+    Acts a bit like a logger, but prints the message only one out of
+    every k times you call it. Convenient to use with large k for
+    occasionally indicating progress.
+    """
+
+    def __init__(self, k):
+        self.k = k
+        self.count = 0
+
+    def debug(self, *args, **kwargs):
+        self.count += 1
+        if (self.count % self.k) == 0:
+            logging.debug(*args, **kwargs)
+
+    def info(self, *args, **kwargs):
+        self.count += 1
+        if (self.count % self.k) == 0:
+            logging.info(*args, **kwargs)
+
+
+def fast_filter(msgs):
+    """
+    Grabs an arbitrary subset of 100 messages from the stream.
+    Convenient for fast testing.
+    """
+    return itertools.islice(msgs, 100, 1100, 10)
+
+
+def get_msg_tuples_internal(inbag_path, topic):
+    with rosbag.Bag(inbag_path, "r") as inbag:
+        for msg_tuple in inbag.read_messages([topic]):
+            yield msg_tuple
+
+
+def get_msg_tuples(inbag_path, topic, fast=False):
+    """
+    A generator that iterates through message tuples (topic, msg, t)
+    in the ROS bag @inbag_path on topic @topic. If @fast is True,
+    only returns a subset of the bag for fast testing.
+    """
+    msg_tuples = get_msg_tuples_internal(inbag_path, topic)
+    if fast:
+        return fast_filter(msg_tuples)
+    return msg_tuples
+
+
+def get_msgs(inbag_path, topic, fast=False):
+    """
+    A generator that iterates through messages in the ROS bag
+    @inbag_path on topic @topic. If @fast is True, only returns a subset
+    of the bag for fast testing.
+    """
+    return (msg_tuple[1] for msg_tuple in get_msg_tuples(inbag_path, topic, fast))
+
+
+def dt64(t):
+    """
+    Convert rospy.Time to np.datetime64.
+    """
+    return np.datetime64(t.to_nsec(), "ns")
+
+
+def peek(iterable):
+    """
+    Python generators don't provide a peek() method to examine the first
+    item in the sequence without actually popping it off. This function
+    provides similar functionality if you call it like this:
+
+    first, it = peek(it)
+
+    After the call, @first will still be the first item in @it.
+    """
+    try:
+        first = next(iterable)
+    except StopIteration:
+        return None, None
+    return first, itertools.chain([first], iterable)
+
+
+def split_msg_stream_by_topic(in_stream, topics):
+    """
+    Given @in_stream a message tuple generator and @topics a sequence of
+    topics [topic_1, .., topic_n], returns a sequence of message tuple
+    generators [stream_1, .., stream_n] such that stream_i generates
+    the message tuples from @in_stream that match topic_i.
+    """
+    it = iter(in_stream)
+    deques = [collections.deque() for i in range(len(topics))]
+    deque_by_topic = dict(zip(topics, deques))
+
+    def gen(deq):
+        while 1:
+            while not deq:
+                try:
+                    newval = next(it)
+                except StopIteration:
+                    return
+                msg_topic, msg, t = newval
+                # logging.debug("got message topic %s", msg_topic)
+                deque_by_topic[msg_topic].append(newval)
+            # logging.debug("propagated message topic %s", topic)
+            yield deq.popleft()
+
+    return tuple(gen(deq) for deq in deques)
+
+
+def get_matched_msg_pairs(stream1, stream2, dt_limit=None):
+    """
+    Given @stream1 and @stream2 message tuple generators, returns
+    matched pairs of messages from the two streams. The behavior is very
+    similar to itertools.izip() followed by selecting just the message
+    part of the (topic, message, t) tuple.
+
+    However, if @dt_limit is specified, instead of simply matching
+    message pairs that have the same index in their respective
+    sequences, it also calculates their publish timestamp differential:
+
+    dt = msg2.header.stamp - msg1.header.stamp
+
+    Two messages are potential matches if dt falls within the specified
+    interval @dt_limit = (dt_min, dt_max). Subject to that constraint,
+    the pairing is greedy, and each message can be used at most once.
+    If a particular message has no valid match based on dt, it will be
+    dropped with a debug message.
+
+    Using @dt_limit can make the matching more robust to occasional out
+    of order rosbag logging.
+    """
+    while 1:
+        val1, stream1 = peek(stream1)
+        val2, stream2 = peek(stream2)
+        if val1 is None or val2 is None:
+            logging.debug(
+                "get_matched_msg_pairs: ran out of pairs, stream1 %s, stream2 %s",
+                "done" if val1 is None else "not done",
+                "done" if val2 is None else "not done",
+            )
+            return
+        topic1, msg1, t1 = val1
+        topic2, msg2, t2 = val2
+        if dt_limit is not None:
+            dt_min, dt_max = dt_limit
+            dt = (msg2.header.stamp - msg1.header.stamp).to_sec()
+            if not (dt_min <= dt):
+                # need a newer t2 to make dt large enough: drop t2
+                logging.debug(
+                    "get_matched_msg_pairs: dropping unmatched message from stream1, dt = %.3f, at %s",
+                    dt,
+                    dt64(t1),
+                )
+                next(stream2)
+                continue
+            if not (dt <= dt_max):
+                # need a newer t1 to make dt small enough: drop t1
+                logging.debug(
+                    "get_matched_msg_pairs: dropping unmatched message from stream2, dt = %.3f, at %s",
+                    dt,
+                    dt64(t2),
+                )
+                next(stream1)
+                continue
+        yield msg1, msg2
+        next(stream1)
+        next(stream2)
+
+
+def get_ext_pts_pairs_internal(inbag_path, cam):
+    topics = [get_ext_topic(cam), get_pts_topic(cam)]
+    with rosbag.Bag(inbag_path, "r") as inbag:
+        msg_stream = inbag.read_messages(topics)
+        ext_stream, pts_stream = split_msg_stream_by_topic(msg_stream, topics)
+        # note: we can't just return the generator here because returning from this
+        # function would close the bag and render the generator invalid.
+        for pair in get_matched_msg_pairs(
+            ext_stream, pts_stream, dt_limit=PTS_MINUS_EXT_DT_LIMIT
+        ):
+            yield pair
+
+
+def get_ext_pts_pairs(inbag_path, fast=False, cam=DEFAULT_CAM):
+    """
+    Given @inbag_path a path to an input bag, returns a generator that
+    will produce matched message pairs (ext_msg, pts_msg) from the bag
+    on the "extended" and "points" topics, respectively.
+
+    The message matching attempts to guarantee the matched messages are
+    from the same sensor frame by comparing their publish timestamps,
+    which is empirically more robust than relying on the sequence
+    ordering in the bag.
+    """
+    pairs = get_ext_pts_pairs_internal(inbag_path, cam=cam)
+    if fast:
+        return fast_filter(pairs)
+    return pairs
+
+
+def xyz_from_points(pts):
+    """
+    Extract xyz points from a "points" message. Replaces zero entries
+    with np.nan to explicitly mark them as invalid.
+    """
+    pc = pc2.read_points(pts, field_names=("x", "y", "z"))
+    xyz = np.array(list(pc))
+
+    # mark rows that have z == 0 as nan
+    xyz[xyz[:, 2] == 0, :] = np.nan
+
+    return xyz
+
+
+def merge_point_clouds(pts_stream):
+    """
+    Given @pts_stream a stream of points messages, merges the xyz points
+    from all messages into a single xyz frame.
+
+    All points messages have the same length of xyz array, and each
+    index within the array consistently corresponds to the same pixel of
+    the sensor.
+
+    The merge semantics produces an output xyz array where the value at
+    each pixel is the mean value over all of the messages that have a
+    valid value for that pixel (not nan).
+    """
+    xyz_sum = np.zeros(
+        (SENSOR_HEIGHT_PIXELS * SENSOR_WIDTH_PIXELS, 3), dtype=np.float64
+    )
+    xyz_count = np.zeros((SENSOR_HEIGHT_PIXELS * SENSOR_WIDTH_PIXELS,), dtype=np.uint32)
+    for i, pts in enumerate(pts_stream):
+        xyz = xyz_from_points(pts)
+        valid = ~np.isnan(xyz[:, 0])
+        xyz_sum[valid] += xyz[valid]
+        xyz_count[valid] += 1
+
+    merged = np.empty((SENSOR_HEIGHT_PIXELS * SENSOR_WIDTH_PIXELS, 3), dtype=np.float64)
+    merged.fill(np.nan)
+    valid = xyz_count != 0
+    merged[valid] = xyz_sum[valid] / xyz_count[valid, np.newaxis]
+
+    logging.info("merge_point_clouds: processed %s point clouds", i + 1)
+    num_invalid_pixels = np.count_nonzero(xyz_count == 0)
+    logging.info(
+        "merge_point_clouds: invalid pixels: %d (%.1f%%)",
+        num_invalid_pixels,
+        float(num_invalid_pixels) / (SENSOR_HEIGHT_PIXELS * SENSOR_WIDTH_PIXELS) * 100,
+    )
+    return merged
+
+
+def split_extended(ext_msg):
+    bridge = CvBridge()
+    cv_image = bridge.imgmsg_to_cv2(ext_msg.raw, desired_encoding="32FC4")
+    distance, amplitude, intensity, noise = cv2.split(cv_image)
+
+    # explicitly mark no-data value of 0 as nan
+    distance[distance == 0] = [np.nan]
+
+    return distance, amplitude, intensity, noise
+
+
+def get_xyz_coeff(inbag_path, fast=False, cam=DEFAULT_CAM):
+    xyz = merge_point_clouds(get_msgs(inbag_path, get_pts_topic(cam), fast=fast))
+    xyz = xyz / np.linalg.norm(xyz, axis=1)[:, np.newaxis]
+    return xyz
+
+
+def xyz_from_distance(distance, xyz_coeff):
+    return (
+        xyz_coeff
+        * distance.reshape((SENSOR_HEIGHT_PIXELS * SENSOR_WIDTH_PIXELS,))[:, np.newaxis]
+    )
+
+
+def xyz_from_extended(ext_msg, xyz_coeff):
+    distance, amplitude, intensity, noise = split_extended(ext_msg)
+    return xyz_from_distance(distance, xyz_coeff)
+
+
+def make_amp_msg(header, amplitude):
+    msg = Image()
+    msg.header = header
+    msg.height = SENSOR_HEIGHT_PIXELS
+    msg.width = SENSOR_WIDTH_PIXELS
+    msg.encoding = "mono16"
+    msg.is_bigendian = False
+    msg.step = SENSOR_WIDTH_PIXELS * 2
+
+    # simulate OpenCV convertTo() operation used in pico_proxy
+    max16 = (1 << 16) - 1
+    amp16 = np.clip(np.rint(amplitude * AMPLITUDE_SCALE), 0, max16).astype(np.uint16)
+
+    msg.data = amp16.tobytes()
+
+    return msg
+
+
+def make_points_msg(header, xyz):
+    pts = PointCloud2()
+    pts.header = header
+    pts.height = SENSOR_HEIGHT_PIXELS
+    pts.width = SENSOR_WIDTH_PIXELS
+    pts.fields = [
+        PointField(name="x", offset=0, datatype=PointField.FLOAT32, count=1),
+        PointField(name="y", offset=4, datatype=PointField.FLOAT32, count=1),
+        PointField(name="z", offset=8, datatype=PointField.FLOAT32, count=1),
+    ]
+    pts.is_bigendian = False
+    pts.point_step = 20
+    pts.row_step = 4480
+
+    xyz32 = xyz.astype(np.float32)
+    xyz32[np.isnan(xyz32)] = 0.0
+    buf = io.BytesIO()
+    for row in xyz32:
+        # write xyz values (12 bytes)
+        buf.write(struct.pack("<fff", *row))
+        # pad with 8 bytes of 0 to replicate original point_step of 20
+        buf.write(struct.pack("<q", 0))
+    pts.data = buf.getvalue()
+
+    pts.is_dense = True
+
+    return pts
+
+
+def check_equal(a, b, i, field_name):
+    if a == b:
+        return True
+    else:
+        if max(len(str(a)), len(str(b))) > 100:
+            logging.info("FAILED at index %d: %s values differ", i, field_name)
+        else:
+            logging.info("FAILED at index %d: %s %s != %s", i, field_name, a, b)
+        return False
+
+
+def check_xyz_error(xyz1, xyz2, i):
+    success = True
+
+    # the same entries should be valid in both point clouds
+    valid_diff = np.isnan(xyz1) ^ np.isnan(xyz2)
+    if np.count_nonzero(valid_diff):
+        logging.info("FAILED at index %d: messages have different valid pixels", i)
+        success = False
+
+    # check accuracy in valid areas
+    valid = ~np.isnan(xyz1)
+    err = xyz2[valid] - xyz1[valid]
+    err_max = np.max(np.abs(err))
+    err_rms = np.std(err)
+
+    logging.debug("%5d Error max (um): %.3f", i, err_max * 1e6)
+    logging.debug("%5d Error RMS (um): %.3f", i, err_rms * 1e6)
+    if err_max > ERROR_TOLERANCE_METERS:
+        logging.info("FAILED at index %d: Error max (um) = %.3f", i, err_max * 1e6)
+        success = False
+
+    return success, err_max, err_rms
+
+
+def check_points_msg_pair(orig_msg, test_msg, i, verbose=False):
+    success = True
+
+    success &= check_equal(orig_msg.height, test_msg.height, i, "height")
+    success &= check_equal(orig_msg.width, test_msg.width, i, "width")
+    success &= check_equal(orig_msg.fields, test_msg.fields, i, "fields")
+    success &= check_equal(
+        orig_msg.is_bigendian, test_msg.is_bigendian, i, "is_bigendian"
+    )
+    success &= check_equal(orig_msg.point_step, test_msg.point_step, i, "point_step")
+    success &= check_equal(orig_msg.row_step, test_msg.row_step, i, "row_step")
+    success &= check_equal(orig_msg.is_dense, test_msg.is_dense, i, "is_dense")
+
+    orig_xyz = xyz_from_points(orig_msg)
+    test_xyz = xyz_from_points(test_msg)
+
+    xyz_success, err_max, err_rms = check_xyz_error(orig_xyz, test_xyz, i)
+    success &= xyz_success
+
+    return success, err_max, err_rms
+
+
+def check_amp_msg_pair(orig_msg, test_msg, i, verbose=False):
+    success = True
+
+    success &= check_equal(orig_msg.height, test_msg.height, i, "height")
+    success &= check_equal(orig_msg.width, test_msg.width, i, "width")
+    success &= check_equal(
+        orig_msg.is_bigendian, test_msg.is_bigendian, i, "is_bigendian"
+    )
+    success &= check_equal(orig_msg.step, test_msg.step, i, "step")
+    success &= check_equal(orig_msg.data, test_msg.data, i, "data")
+
+    return success

--- a/hardware/pico_driver/scripts/pico_utils.py
+++ b/hardware/pico_driver/scripts/pico_utils.py
@@ -76,6 +76,10 @@ def get_amp_topic(cam):
     return AMP_TOPIC_TMPL.format(cam=cam)
 
 
+def rms(v):
+    return np.sqrt(np.mean(v * v))
+
+
 class PrintEveryK:
     """
     Acts a bit like a logger, but prints the message only one out of
@@ -426,7 +430,7 @@ def check_xyz_error(xyz1, xyz2, i):
     valid = ~np.isnan(xyz1)
     err = xyz2[valid] - xyz1[valid]
     err_max = np.max(np.abs(err))
-    err_rms = np.std(err)
+    err_rms = rms(err)
 
     logging.debug("%5d Error max (um): %.3f", i, err_max * 1e6)
     logging.debug("%5d Error RMS (um): %.3f", i, err_rms * 1e6)

--- a/hardware/pico_driver/scripts/pico_write_xyz_coeff.py
+++ b/hardware/pico_driver/scripts/pico_write_xyz_coeff.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+# Copyright (c) 2017, United States Government, as represented by the
+# Administrator of the National Aeronautics and Space Administration.
+#
+# All rights reserved.
+#
+# The Astrobee platform is licensed under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with the
+# License. You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+"""
+Given a bag containing Pico Flexx points messages, output a *.npy file
+containing array xyz coefficients that can subsequently be used to
+reconstruct point clouds from Pico Flexx extended messages.
+"""
+
+import argparse
+import logging
+
+import numpy as np
+import pico_utils as pico
+
+
+def pico_write_xyz_coeff(
+    in_bag_path, out_npy_path, fast=False, verbose=False, cam=pico.DEFAULT_CAM
+):
+    xyz_coeff = pico.get_xyz_coeff(in_bag_path, fast=fast, cam=cam)
+    with open(out_npy_path, "wb") as out_npy:
+        np.save(out_npy, xyz_coeff, allow_pickle=False)
+    logging.info("wrote pico xyz coefficients to %s", out_npy_path)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        help="print more verbose debug info",
+        default=False,
+        action="store_true",
+    )
+    parser.add_argument(
+        "-f",
+        "--fast",
+        help="speed up testing by only processing part of the bag",
+        default=False,
+        action="store_true",
+    )
+    parser.add_argument(
+        "-c",
+        "--cam",
+        help="specify camera for rosbag topic filtering [%(default)s]",
+        nargs="?",
+        choices=pico.CAM_CHOICES,
+        default=pico.DEFAULT_CAM,
+    )
+    parser.add_argument("in_bag", help="input bag containing points messages")
+    parser.add_argument("out_npy", help="output npy file of xyz coefficients")
+
+    args = parser.parse_args()
+    level = logging.DEBUG if args.verbose else logging.INFO
+    logging.basicConfig(level=level, format="%(message)s")
+
+    pico_write_xyz_coeff(
+        args.in_bag, args.out_npy, fast=args.fast, verbose=args.verbose, cam=args.cam
+    )
+
+    # suppress confusing ROS message at exit
+    logging.getLogger().setLevel(logging.WARN)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
These tools allow us to process Pico Flexx "extended" messages to reconstruct "points" point clouds and "amplitude_int" amplitude images.

The intent is to eventually stop logging the latter message topics because they are redundant and take a lot of data volume, but before we can move forward with that, we should double-check that the reconstructed output messages are compatible with existing uses, including ISAAC dense mapping and depth-based localization.