### PR TITLE
Use data acquisition timestamps for Pico sensor data per #412

### DIFF
--- a/hardware/pico_driver/src/pico_proxy.cc
+++ b/hardware/pico_driver/src/pico_proxy.cc
@@ -182,8 +182,7 @@ class PicoProxyNodelet : public ff_util::FreeFlyerNodelet  {
   // Called when depth image data arrives
   void DepthImageCallback(const sensor_msgs::ImageConstPtr& msg) {
     // Prepare distance image
-    // TODO(oalexan1): keep same timestamp as the input?
-    distance_.header.stamp = ros::Time::now();
+    distance_.header.stamp = msg->header.stamp;
     distance_.header.frame_id = msg->header.frame_id;
     distance_.height = msg->height;
     distance_.width = msg->width;
@@ -192,8 +191,7 @@ class PicoProxyNodelet : public ff_util::FreeFlyerNodelet  {
     distance_.step = distance_.width * sizeof(uint16_t);
     distance_.data.resize(distance_.height * distance_.step);
     // Prepare confidence image
-    // TODO(oalexan1): keep same timestamp as the input?
-    confidence_.header.stamp = ros::Time::now();
+    confidence_.header.stamp = msg->header.stamp;
     confidence_.header.frame_id = msg->header.frame_id;
     confidence_.height = msg->height;
     confidence_.width = msg->width;


### PR DESCRIPTION
This hasn't been tested yet. The modifications should improve the Pico Flexx sensor data message timestamp accuracy a little.

One case that has some extra uncertainty is the DepthImage timestamp units, since it's not documented. I assumed it uses usecs like DepthData, but if not, it will return bizarre garbage timestamps, so it should be obvious. I think this message is not usually published, at least during ISAAC surveys.