### PR TITLE
Adding data share documentation

### DIFF
--- a/astrobee/readme.md
+++ b/astrobee/readme.md
@@ -1,4 +1,4 @@
-\page astrobee Astrobee
+\page astrobee General Considerations
 
 # Folder description
 

--- a/doc/general_documentation/astrobee_usage.md
+++ b/doc/general_documentation/astrobee_usage.md
@@ -1,21 +1,25 @@
 
-# Astrobee Usage
+# Tutorials
 
 \subpage astrobee
 
-\subpage astrobee-code-style
+\subpage running-the-sim
+
+\subpage advanced-sim-info
 
 \subpage teleop
 
-\subpage release
+\subpage astrobee-code-style
 
-\subpage managing_debians
+\subpage conventions
 
 \subpage new_robot
 
 \subpage doc
 
-\subpage conventions
+\subpage release
+
+\subpage managing_debians
 
 \subpage adding_a_command
 

--- a/doc/general_documentation/documentation.md
+++ b/doc/general_documentation/documentation.md
@@ -1,6 +1,4 @@
-\page doc Documentation
-
-# Tools used for FSW documentation
+\page doc Tools used for FSW documentation
 
 ## Code documentation
 

--- a/doc/general_documentation/public_data.md
+++ b/doc/general_documentation/public_data.md
@@ -1,0 +1,6 @@
+
+# Publicly Available Data
+
+Data from Astrobee collected during some ISS activities can be found [here](https://nasagov.box.com/s/4ign43svk39guhy9ev8t5xkzui6tqjm1)
+
+The data is available in bagfile format, you can learn more about bagfiles [here](http://wiki.ros.org/rosbag). If you didn't already install Astrobee \ref install-nonNASA, to play and extract the data you will have to import the custom Astrobee message types.

--- a/simulation/readme.md
+++ b/simulation/readme.md
@@ -14,13 +14,13 @@ If you you are not cross-compiling, then the build process started with "make" w
 
 ## Running the Simulator
 
-Please see the \subpage running-the-sim documentation.
+Please see the \ref running-the-sim documentation.
 
 
 ## Advanced Simulator Information
 
 If you would like more information on running localization only mode,
 collisions, performance, frame consistency, debugging, changing properties, or
-the Astrobee specific plugins, please see the \subpage advanced-sim-info.
+the Astrobee specific plugins, please see the \ref advanced-sim-info.
 
 For common simulation issues and workarounds, check \subpage sim-issues

--- a/simulation/scripts/start_server
+++ b/simulation/scripts/start_server
@@ -50,4 +50,4 @@ fi
 
 final=$(relocate_remappings "${final}")
 
-GAZEBO_MASTER_URI="$desired_master_uri" gzserver $final
+GAZEBO_MASTER_URI="$desired_master_uri" gzserver $final --verbose


### PR DESCRIPTION
Didn't elaborate on the documentation because use cases are not clear yet.
Possibly we can add instructions on how to view the data with rqt_bag (http://wiki.ros.org/rqt_bag) -- ROS centric; or instructions on how to convert the data to other formats like .cvs.