### PR TITLE
Fix flaky inverse depth tests

### DIFF
--- a/localization/graph_localizer/test/test_inverse_depth_projection_factor.cc
+++ b/localization/graph_localizer/test/test_inverse_depth_projection_factor.cc
@@ -91,7 +91,7 @@ TEST(InverseDepthProjectionFactorTester, InvalidError) {
 TEST(InverseDepthProjectionFactorTester, Jacobians) {
   constexpr double translation_stddev = 0.05;
   constexpr double rotation_stddev = 1;
-  for (int i = 0; i < 500; ++i) {
+  for (int i = 0; i < 5000; ++i) {
     const gtsam::Point3 source_cam_t_measurement = lc::RandomFrontFacingPoint();
     const gtsam::Pose3 body_T_cam = lc::RandomPose();
     const Eigen::Matrix3d intrinsics = lc::RandomIntrinsics();
@@ -118,7 +118,7 @@ TEST(InverseDepthProjectionFactorTester, Jacobians) {
         boost::function<Eigen::Vector2d(const gtsam::Pose3&, const vc::InverseDepthMeasurement&, const gtsam::Pose3&)>(
           boost::bind(&gtsam::InverseDepthProjectionFactor::evaluateError, factor, _1, _2, _3, boost::none, boost::none,
                       boost::none)),
-        world_T_source_body, inverse_depth_measurement, world_T_target_body);
+        world_T_source_body, inverse_depth_measurement, world_T_target_body, 1e-6);
     EXPECT_MATRIX_NEAR(numerical_d_error_d_world_T_source_body, d_error_d_world_T_source_body, 1e-6);
     const auto numerical_d_error_d_inverse_depth =
       gtsam::numericalDerivative32<Eigen::Vector2d, gtsam::Pose3, vc::InverseDepthMeasurement, gtsam::Pose3>(
@@ -132,7 +132,7 @@ TEST(InverseDepthProjectionFactorTester, Jacobians) {
         boost::function<Eigen::Vector2d(const gtsam::Pose3&, const vc::InverseDepthMeasurement&, const gtsam::Pose3&)>(
           boost::bind(&gtsam::InverseDepthProjectionFactor::evaluateError, factor, _1, _2, _3, boost::none, boost::none,
                       boost::none)),
-        world_T_source_body, inverse_depth_measurement, world_T_target_body);
+        world_T_source_body, inverse_depth_measurement, world_T_target_body, 1e-6);
     EXPECT_MATRIX_NEAR(numerical_d_error_d_world_T_target_body, d_error_d_world_T_target_body, 1e-6);
   }
 }

--- a/localization/vision_common/src/utilities.cc
+++ b/localization/vision_common/src/utilities.cc
@@ -49,8 +49,8 @@ Eigen::Vector2d Project(const Eigen::Vector3d& cam_t_point, const Eigen::Matrix3
     const double z_inv = 1.0 / cam_t_point.z();
     const double z_inv_2 = z_inv * z_inv;
     *d_projected_point_d_cam_t_point << intrinsics(0, 0) * z_inv, intrinsics(0, 1) * z_inv,
-      intrinsics(0, 2) * z_inv - p.x() * z_inv_2, 0, intrinsics(1, 1) * z_inv,
-      intrinsics(1, 2) * z_inv - p.y() * z_inv_2;
+      -intrinsics(0, 0) * cam_t_point.x() * z_inv_2 - intrinsics(0, 1) * cam_t_point.y() * z_inv_2, 0,
+      intrinsics(1, 1) * z_inv, -intrinsics(1, 1) * cam_t_point.y() * z_inv_2;
   }
   return (intrinsics * cam_t_point).hnormalized();
 }

--- a/localization/vision_common/test/test_inverse_depth_measurement.cc
+++ b/localization/vision_common/test/test_inverse_depth_measurement.cc
@@ -127,7 +127,7 @@ TEST(InverseDepthMeasurementTester, InvalidProject) {
 TEST(InverseDepthMeasurementTester, ProjectJacobians) {
   constexpr double translation_stddev = 0.05;
   constexpr double rotation_stddev = 1;
-  for (int i = 0; i < 500; ++i) {
+  for (int i = 0; i < 5000; ++i) {
     const gtsam::Point3 source_cam_t_measurement = lc::RandomFrontFacingPoint();
     const gtsam::Pose3 body_T_cam = lc::RandomPose();
     const Eigen::Matrix3d intrinsics = lc::RandomIntrinsics();
@@ -163,7 +163,7 @@ TEST(InverseDepthMeasurementTester, ProjectJacobians) {
         gtsam::numericalDerivative11<Eigen::Vector2d, gtsam::Pose3>(
           boost::function<Eigen::Vector2d(const gtsam::Pose3&)>(
             boost::bind(&ProjectPoseJacobianHelper, inverse_depth_measurement, _1, world_T_target_body)),
-          world_T_source_body);
+          world_T_source_body, 1e-6);
       EXPECT_MATRIX_NEAR(numerical_d_projected_point_d_world_T_source_body, d_projected_point_d_world_T_source_body,
                          1e-6);
     }
@@ -173,7 +173,7 @@ TEST(InverseDepthMeasurementTester, ProjectJacobians) {
         gtsam::numericalDerivative11<Eigen::Vector2d, gtsam::Pose3>(
           boost::function<Eigen::Vector2d(const gtsam::Pose3&)>(
             boost::bind(&ProjectPoseJacobianHelper, inverse_depth_measurement, world_T_source_body, _1)),
-          world_T_target_body);
+          world_T_target_body, 1e-6);
       EXPECT_MATRIX_NEAR(numerical_d_projected_point_d_world_T_target_body, d_projected_point_d_world_T_target_body,
                          1e-6);
     }


### PR DESCRIPTION
Reduced step size for numerical derivative to fix two previously flaky tests and cleaned up the projection jacobian.