### PR TITLE
Remove collision distance from flight modes in the world configs

### DIFF
--- a/astrobee/config/worlds/granite.config
+++ b/astrobee/config/worlds/granite.config
@@ -93,9 +93,6 @@ world_flight_modes = {
     -- Control enabled
     control_enabled = false;
 
-    -- Collision radius
-    collision_radius = 0;
-
     -- Attitude Parameters
     att_kp = vec3(0.0, 0.0, 4.0);
     att_ki = vec3(0.0, 0.0, 0.002);
@@ -133,9 +130,6 @@ world_flight_modes = {
 
     -- Control enabled
     control_enabled = true;
-
-    -- Collision radius
-    collision_radius = 0.25;
 
     -- Attitude Parameters
     att_kp = vec3(0.0, 0.0, 4.0);
@@ -176,9 +170,6 @@ world_flight_modes = {
     -- Control enabled
     control_enabled = true;
 
-    -- Collision radius
-    collision_radius = 0.25;
-
     -- Attitude Parameters
     att_kp = vec3(0.0, 0.0, 4.0);
     att_ki = vec3(0.0, 0.0, 0.002);
@@ -218,9 +209,6 @@ world_flight_modes = {
     -- Control enabled
     control_enabled = true;
 
-    -- Collision radius
-    collision_radius = 0.25;
-
     -- Attitude Parameters
     att_kp = vec3(0.0, 0.0, 4.0);
     att_ki = vec3(0.0, 0.0, 0.002);
@@ -259,9 +247,6 @@ world_flight_modes = {
 
     -- Control enabled
     control_enabled = true;
-
-    -- Collision radius
-    collision_radius = 0.25;
 
     -- Attitude Parameters
     att_kp = vec3(0.0, 0.0, 4.0);

--- a/astrobee/config/worlds/iss.config
+++ b/astrobee/config/worlds/iss.config
@@ -103,9 +103,6 @@ world_flight_modes = {
     -- Control enabled
     control_enabled = false;
 
-    -- Collision radius
-    collision_radius = 0;
-
     -- Attitude Parameters
     att_kp = vec3(4.0, 4.0, 4.0); -- .4
     att_ki = vec3(0.002, 0.002, 0.002);
@@ -143,9 +140,6 @@ world_flight_modes = {
 
     -- Control enabled
     control_enabled = true;
-
-    -- Collision radius
-    collision_radius = 0.25;
 
     -- Attitude Parameters
     att_kp = vec3(4.0, 4.0, 4.0); -- .4
@@ -185,9 +179,6 @@ world_flight_modes = {
     -- Control enabled
     control_enabled = true;
 
-    -- Collision radius
-    collision_radius = 0.25;
-
     -- Attitude Parameters
     att_kp = vec3(4.0, 4.0, 4.0); -- .4
     att_ki = vec3(0.002, 0.002, 0.002);
@@ -226,9 +217,6 @@ world_flight_modes = {
     -- Control enabled
     control_enabled = true;
 
-    -- Collision radius
-    collision_radius = 0.25;
-
     -- Attitude Parameters
     att_kp = vec3(4.0, 4.0, 4.0); -- .4
     att_ki = vec3(0.002, 0.002, 0.002);
@@ -266,9 +254,6 @@ world_flight_modes = {
 
     -- Control enabled
     control_enabled = true;
-
-    -- Collision radius
-    collision_radius = 0.25;
 
     -- Attitude Parameters
     att_kp = vec3(4.0, 4.0, 4.0); -- .4

--- a/astrobee/config/worlds/mgtf.config
+++ b/astrobee/config/worlds/mgtf.config
@@ -86,9 +86,6 @@ world_flight_modes = {
     -- Control enabled
     control_enabled = false;
 
-    -- Collision radius
-    collision_radius = 0;
-
     -- Attitude Parameters
     att_kp = vec3(2.0, 2.0, 2.0); -- .4
     att_ki = vec3(0.001, 0.001, 0.001);
@@ -126,9 +123,6 @@ world_flight_modes = {
 
     -- Control enabled
     control_enabled = true;
-
-    -- Collision radius
-    collision_radius = 0.25;
 
     -- Attitude Parameters
     att_kp = vec3(2.0, 2.0, 2.0); -- .4
@@ -168,9 +162,6 @@ world_flight_modes = {
     -- Control enabled
     control_enabled = true;
 
-    -- Collision radius
-    collision_radius = 0.25;
-
     -- Attitude Parameters
     att_kp = vec3(2.0, 2.0, 2.0); -- .4
     att_ki = vec3(0.001, 0.001, 0.001);
@@ -209,9 +200,6 @@ world_flight_modes = {
     -- Control enabled
     control_enabled = true;
 
-    -- Collision radius
-    collision_radius = 0.25;
-
     -- Attitude Parameters
     att_kp = vec3(2.0, 2.0, 2.0); -- .4
     att_ki = vec3(0.001, 0.001, 0.001);
@@ -249,9 +237,6 @@ world_flight_modes = {
 
     -- Control enabled
     control_enabled = true;
-
-    -- Collision radius
-    collision_radius = 0.25;
 
     -- Attitude Parameters
     att_kp = vec3(2.0, 2.0, 2.0); -- .4

--- a/communications/ff_msgs/msg/FlightMode.msg
+++ b/communications/ff_msgs/msg/FlightMode.msg
@@ -23,8 +23,6 @@ string name                       # Name of the flight mode
 
 bool control_enabled              # Is control enabled?
 
-float32 collision_radius          # Collision radius in meters
-
 # Tolerances (all in SI units)
 float32 tolerance_pos_endpoint    # Endpoint position tolerance in m
 float32 tolerance_pos             # Position tolerance in m

--- a/management/executive/include/executive/executive.h
+++ b/management/executive/include/executive/executive.h
@@ -252,6 +252,7 @@ class Executive : public ff_util::FreeFlyerNodelet {
  protected:
   virtual void Initialize(ros::NodeHandle *nh);
   bool ReadParams();
+  bool ReadMapperParams();
   bool ReadCommand(config_reader::ConfigReader::Table *response,
                    ff_msgs::CommandStampedPtr cmd);
   void PublishAgentState();
@@ -263,7 +264,7 @@ class Executive : public ff_util::FreeFlyerNodelet {
   ExecutiveActionClient<ff_msgs::MotionAction> motion_ac_;
   ExecutiveActionClient<ff_msgs::PerchAction> perch_ac_;
 
-  config_reader::ConfigReader config_params_;
+  config_reader::ConfigReader config_params_, mapper_config_params_;
 
   ff_msgs::AgentStateStamped agent_state_;
 

--- a/shared/ff_util/src/ff_flight/ff_flight.cc
+++ b/shared/ff_util/src/ff_flight/ff_flight.cc
@@ -171,7 +171,6 @@ namespace ff_util {
         if (   !flight_modes.GetTable(j + 1, &mode)
             || !mode.GetStr("name", &info.name)
             || !mode.GetBool("control_enabled", &control_enabled)
-            || !mode.GetReal("collision_radius", &info.collision_radius)
             || !mode.GetReal("hard_limit_omega", &info.hard_limit_omega)
             || !mode.GetReal("hard_limit_vel", &info.hard_limit_vel)
             || !mode.GetReal("hard_limit_alpha", &info.hard_limit_alpha)


### PR DESCRIPTION
Removed the collision distance from the flight modes in the world
config files. This distance is also in the mapper config so it was
confusing as to which collision distance was being used. Also the
executive was changed to read this distance out of the mapper config.