### PR TITLE
Enable backward compatibility with archived telemetry bags

### DIFF
--- a/communications/ff_msgs/bmr/2021_08_05_FlightMode_add_field.bmr
+++ b/communications/ff_msgs/bmr/2021_08_05_FlightMode_add_field.bmr
@@ -1,0 +1,214 @@
+class update_ff_msgs_FlightMode_21af9f940eeb9407d4d58829e8cfc200(MessageUpdateRule):
+	old_type = "ff_msgs/FlightMode"
+	old_full_text = """
+# Copyright (c) 2017, United States Government, as represented by the
+# Administrator of the National Aeronautics and Space Administration.
+#
+# All rights reserved.
+#
+# The Astrobee platform is licensed under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with the
+# License. You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# This message captures all information in a flight mode
+
+Header header                     # Metadata
+
+string name                       # Name of the flight mode
+
+bool control_enabled              # Is control enabled?
+
+float32 collision_radius          # Collision radius in meters
+
+# Tolerances (all in SI units)
+float32 tolerance_pos             # Position tolerance in m
+float32 tolerance_vel             # Velocity tolerance in m/s
+float32 tolerance_att             # Attitude tolerance in rads
+float32 tolerance_omega           # Angular acceleration tolerance in rad/s
+float32 tolerance_time            # Acceptable lag betwee TX and RX of control
+
+# Controller gains
+geometry_msgs/Vector3 att_kp      # Positional proportional constant
+geometry_msgs/Vector3 att_ki      # Positional integrative constant
+geometry_msgs/Vector3 omega_kd    # Attidue derivative constant
+geometry_msgs/Vector3 pos_kp      # Positional proportional contant
+geometry_msgs/Vector3 pos_ki      # Positional integrative constant
+geometry_msgs/Vector3 vel_kd      # Positional derivative constant
+
+# Hard limit on planning
+float32 hard_limit_vel            # Position tolerance in m/s
+float32 hard_limit_accel          # Position tolerance in m/s^2
+float32 hard_limit_omega          # Position tolerance in rads/s
+float32 hard_limit_alpha          # Position tolerance in rads/s^2
+
+# Impeller speed
+uint8 speed                       # Current speed gain
+uint8 SPEED_MIN        = 0        # Min acceptable gain
+uint8 SPEED_OFF        = 0        # Blowers off
+uint8 SPEED_QUIET      = 1        # Quiet mode
+uint8 SPEED_NOMINAL    = 2        # Nomainal mode
+uint8 SPEED_AGGRESSIVE = 3        # Aggressive mode
+uint8 SPEED_MAX        = 3        # Max acceptable gain
+
+================================================================================
+MSG: std_msgs/Header
+# Standard metadata for higher-level stamped data types.
+# This is generally used to communicate timestamped data 
+# in a particular coordinate frame.
+# 
+# sequence ID: consecutively increasing ID 
+uint32 seq
+#Two-integer timestamp that is expressed as:
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')
+# time-handling sugar is provided by the client library
+time stamp
+#Frame this data is associated with
+# 0: no frame
+# 1: global frame
+string frame_id
+
+================================================================================
+MSG: geometry_msgs/Vector3
+# This represents a vector in free space. 
+# It is only meant to represent a direction. Therefore, it does not
+# make sense to apply a translation to it (e.g., when applying a 
+# generic rigid transformation to a Vector3, tf2 will only apply the
+# rotation). If you want your data to be translatable too, use the
+# geometry_msgs/Point message instead.
+
+float64 x
+float64 y
+float64 z
+"""
+
+	new_type = "ff_msgs/FlightMode"
+	new_full_text = """
+# Copyright (c) 2017, United States Government, as represented by the
+# Administrator of the National Aeronautics and Space Administration.
+#
+# All rights reserved.
+#
+# The Astrobee platform is licensed under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with the
+# License. You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# This message captures all information in a flight mode
+
+Header header                     # Metadata
+
+string name                       # Name of the flight mode
+
+bool control_enabled              # Is control enabled?
+
+float32 collision_radius          # Collision radius in meters
+
+# Tolerances (all in SI units)
+float32 tolerance_pos_endpoint    # Endpoint position tolerance in m
+float32 tolerance_pos             # Position tolerance in m
+float32 tolerance_vel             # Velocity tolerance in m/s
+float32 tolerance_att             # Attitude tolerance in rads
+float32 tolerance_omega           # Angular acceleration tolerance in rad/s
+float32 tolerance_time            # Acceptable lag betwee TX and RX of control
+
+# Controller gains
+geometry_msgs/Vector3 att_kp      # Positional proportional constant
+geometry_msgs/Vector3 att_ki      # Positional integrative constant
+geometry_msgs/Vector3 omega_kd    # Attidue derivative constant
+geometry_msgs/Vector3 pos_kp      # Positional proportional contant
+geometry_msgs/Vector3 pos_ki      # Positional integrative constant
+geometry_msgs/Vector3 vel_kd      # Positional derivative constant
+
+# Hard limit on planning
+float32 hard_limit_vel            # Position tolerance in m/s
+float32 hard_limit_accel          # Position tolerance in m/s^2
+float32 hard_limit_omega          # Position tolerance in rads/s
+float32 hard_limit_alpha          # Position tolerance in rads/s^2
+
+# Impeller speed
+uint8 speed                       # Current speed gain
+uint8 SPEED_MIN        = 0        # Min acceptable gain
+uint8 SPEED_OFF        = 0        # Blowers off
+uint8 SPEED_QUIET      = 1        # Quiet mode
+uint8 SPEED_NOMINAL    = 2        # Nomainal mode
+uint8 SPEED_AGGRESSIVE = 3        # Aggressive mode
+uint8 SPEED_MAX        = 3        # Max acceptable gain
+
+================================================================================
+MSG: std_msgs/Header
+# Standard metadata for higher-level stamped data types.
+# This is generally used to communicate timestamped data 
+# in a particular coordinate frame.
+# 
+# sequence ID: consecutively increasing ID 
+uint32 seq
+#Two-integer timestamp that is expressed as:
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')
+# time-handling sugar is provided by the client library
+time stamp
+#Frame this data is associated with
+string frame_id
+
+================================================================================
+MSG: geometry_msgs/Vector3
+# This represents a vector in free space. 
+# It is only meant to represent a direction. Therefore, it does not
+# make sense to apply a translation to it (e.g., when applying a 
+# generic rigid transformation to a Vector3, tf2 will only apply the
+# rotation). If you want your data to be translatable too, use the
+# geometry_msgs/Point message instead.
+
+float64 x
+float64 y
+float64 z
+"""
+
+	order = 0
+	migrated_types = [
+		("Header","Header"),
+		("geometry_msgs/Vector3","geometry_msgs/Vector3"),]
+
+	valid = True
+
+	def update(self, old_msg, new_msg):
+		self.migrate(old_msg.header, new_msg.header)
+		new_msg.name = old_msg.name
+		new_msg.control_enabled = old_msg.control_enabled
+		new_msg.collision_radius = old_msg.collision_radius
+		new_msg.tolerance_pos = old_msg.tolerance_pos
+		new_msg.tolerance_vel = old_msg.tolerance_vel
+		new_msg.tolerance_att = old_msg.tolerance_att
+		new_msg.tolerance_omega = old_msg.tolerance_omega
+		new_msg.tolerance_time = old_msg.tolerance_time
+		self.migrate(old_msg.att_kp, new_msg.att_kp)
+		self.migrate(old_msg.att_ki, new_msg.att_ki)
+		self.migrate(old_msg.omega_kd, new_msg.omega_kd)
+		self.migrate(old_msg.pos_kp, new_msg.pos_kp)
+		self.migrate(old_msg.pos_ki, new_msg.pos_ki)
+		self.migrate(old_msg.vel_kd, new_msg.vel_kd)
+		new_msg.hard_limit_vel = old_msg.hard_limit_vel
+		new_msg.hard_limit_accel = old_msg.hard_limit_accel
+		new_msg.hard_limit_omega = old_msg.hard_limit_omega
+		new_msg.hard_limit_alpha = old_msg.hard_limit_alpha
+		new_msg.speed = old_msg.speed
+
+		# New field. Fill by coping the value of tolerance_pos, which
+		# accurately represents the old behavior.
+		new_msg.tolerance_pos_endpoint = old_msg.tolerance_pos

--- a/communications/ff_msgs/bmr/2022_01_11_CpuStateStamped_add_field.bmr
+++ b/communications/ff_msgs/bmr/2022_01_11_CpuStateStamped_add_field.bmr
@@ -1,0 +1,250 @@
+class update_ff_msgs_CpuStateStamped_40cac5670a1d8d81e75089cf6eaba744(MessageUpdateRule):
+	old_type = "ff_msgs/CpuStateStamped"
+	old_full_text = """
+# Copyright (c) 2017, United States Government, as represented by the
+# Administrator of the National Aeronautics and Space Administration.
+# 
+# All rights reserved.
+# 
+# The Astrobee platform is licensed under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with the
+# License. You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# Cpu state message with timestamp.
+
+# Header with timestamp
+std_msgs/Header header
+
+# Machine name (llp, hlp, mlp, etc)
+string name
+
+# Load constants
+string NICE=nice
+string USER=user
+string SYS=sys
+string VIRT=virt
+string TOTAL=total
+
+# The available fields within the load values, mostly uses the constants
+# defined above.
+string[] load_fields
+
+# Average loads for all processors combined
+float32[] avg_loads
+
+# Temperature for a cpu (average of all thermal zones)
+float32 temp
+
+# Information for each processor
+# Size of the array specifies how many processors are on the board, whether
+# or not all of them are enabled.
+ff_msgs/CpuState[] cpus
+
+
+================================================================================
+MSG: std_msgs/Header
+# Standard metadata for higher-level stamped data types.
+# This is generally used to communicate timestamped data 
+# in a particular coordinate frame.
+# 
+# sequence ID: consecutively increasing ID 
+uint32 seq
+#Two-integer timestamp that is expressed as:
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')
+# time-handling sugar is provided by the client library
+time stamp
+#Frame this data is associated with
+# 0: no frame
+# 1: global frame
+string frame_id
+
+================================================================================
+MSG: ff_msgs/CpuState
+# Copyright (c) 2017, United States Government, as represented by the
+# Administrator of the National Aeronautics and Space Administration.
+# 
+# All rights reserved.
+# 
+# The Astrobee platform is licensed under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with the
+# License. You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# State of a CPU.
+
+# Processor is on (enabled) or not
+bool enabled
+
+# The load (in percentages) of the cpu, for the fields given in
+# CpuStateStamped
+float32[] loads 
+
+# Current operating frequency in Hz
+uint32 frequency
+
+# Max frequency (may be less than theoretical limit of the processor)
+uint32 max_frequency
+"""
+
+	new_type = "ff_msgs/CpuStateStamped"
+	new_full_text = """
+# Copyright (c) 2017, United States Government, as represented by the
+# Administrator of the National Aeronautics and Space Administration.
+# 
+# All rights reserved.
+# 
+# The Astrobee platform is licensed under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with the
+# License. You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# Cpu state message with timestamp.
+
+# Header with timestamp
+std_msgs/Header header
+
+# Machine name (llp, hlp, mlp, etc)
+string name
+
+# Load constants
+string NICE=nice
+string USER=user
+string SYS=sys
+string VIRT=virt
+string TOTAL=total
+
+# The available fields within the load values, mostly uses the constants
+# defined above.
+string[] load_fields
+
+# Average loads for all processors combined
+float32[] avg_loads
+
+# Temperature for a cpu (average of all thermal zones)
+float32 temp
+
+# Information for each processor
+# Size of the array specifies how many processors are on the board, whether
+# or not all of them are enabled.
+ff_msgs/CpuState[] cpus
+
+# Load usage of individual ROS nodes
+ff_msgs/CpuNodeState[] load_nodes
+================================================================================
+MSG: std_msgs/Header
+# Standard metadata for higher-level stamped data types.
+# This is generally used to communicate timestamped data 
+# in a particular coordinate frame.
+# 
+# sequence ID: consecutively increasing ID 
+uint32 seq
+#Two-integer timestamp that is expressed as:
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')
+# time-handling sugar is provided by the client library
+time stamp
+#Frame this data is associated with
+string frame_id
+
+================================================================================
+MSG: ff_msgs/CpuState
+# Copyright (c) 2017, United States Government, as represented by the
+# Administrator of the National Aeronautics and Space Administration.
+# 
+# All rights reserved.
+# 
+# The Astrobee platform is licensed under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with the
+# License. You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# State of a CPU.
+
+# Processor is on (enabled) or not
+bool enabled
+
+# The load (in percentages) of the cpu, for the fields given in
+# CpuStateStamped
+float32[] loads 
+
+# Current operating frequency in Hz
+uint32 frequency
+
+# Max frequency (may be less than theoretical limit of the processor)
+uint32 max_frequency
+
+================================================================================
+MSG: ff_msgs/CpuNodeState
+# Copyright (c) 2017, United States Government, as represented by the
+# Administrator of the National Aeronautics and Space Administration.
+# 
+# All rights reserved.
+# 
+# The Astrobee platform is licensed under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with the
+# License. You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# State of a CPU load for a node.
+
+# Node name
+string name
+
+# The load (in percentages) of the cpu
+float32 load
+"""
+
+	order = 0
+	migrated_types = [
+		("Header","Header"),
+		("CpuState","CpuState"),]
+
+	valid = True
+
+	def update(self, old_msg, new_msg):
+		self.migrate(old_msg.header, new_msg.header)
+		new_msg.name = old_msg.name
+		new_msg.load_fields = old_msg.load_fields
+		new_msg.avg_loads = old_msg.avg_loads
+		new_msg.temp = old_msg.temp
+		self.migrate_array(old_msg.cpus, new_msg.cpus, "ff_msgs/CpuState")
+
+		# New field. Fill with no-data value.
+		new_msg.load_nodes = []

--- a/communications/ff_msgs/bmr/rosbag_rewrite_types_rules.json
+++ b/communications/ff_msgs/bmr/rosbag_rewrite_types_rules.json
@@ -1,0 +1,8 @@
+{
+    "rename_types": [
+    ],
+    "fix_message_definition_topic_patterns": [
+        "/gs/*",
+        "/hw/cam_sci/compressed"
+    ]
+}

--- a/doc/general_documentation/maintaining_telemetry.md
+++ b/doc/general_documentation/maintaining_telemetry.md
@@ -32,13 +32,16 @@ proposes a maintenance approach.
    our ISS imagery.)
 
 3. We also have a priority list of bad outcomes to avoid:
-   a. Misleading users. If the message semantics has changed such that
+
+    - Misleading users. If the message semantics has changed such that
       trying to interpret legacy messages with the new semantics is
       actively misleading, this is the worst case.
-   b. Breaking all messages. Some bag analysis tools are sensitive and
+
+    - Breaking all messages. Some bag analysis tools are sensitive and
       crash if the bag has even a single problematic message definition.
       We should strive hard to avoid this problem.
-   c. Loss of ability to analyze specific message types or specific
+
+    - Loss of ability to analyze specific message types or specific
       fields. This may be more acceptable, depending on the specific
       user needs.
 
@@ -70,11 +73,13 @@ proposes a maintenance approach.
    interpreted like the current type.
 
 5. ROS message types defined by guest scientists:
-   - If legacy bag compatibility is required for these messages, it
-     should be the responsibility of the guest science developers.
-   - As a fallback, the FSW team should provide a tool for filtering out
-     no-longer-compatible guest science messages, in case the other
-     messages in the bag are still valuable.
+
+    - If legacy bag compatibility is required for these messages, it
+      should be the responsibility of the guest science developers.
+
+    - As a fallback, the FSW team should provide a tool for filtering
+      out no-longer-compatible guest science messages, in case the other
+      messages in the bag are still valuable.
 
 6. Out of scope: The primary focus is on legacy messages recorded in ISS
    telemetry bags, or particularly important ground experiments.  We
@@ -103,8 +108,10 @@ avoid a crash.
 The other remaining problem arises when there are substantial changes in
 a message definition that make migration to the new definition
 problematic. For example:
+
 - If a field has been deleted, any attempt to migrate an old message
   instance to the new definition will necessarily involve data loss.
+
 - If the change is sufficiently complicated, it may not be worth the
   effort to figure out how to reliably remap old data into the new
   structure.
@@ -125,30 +132,34 @@ message type in legacy bags to use the frozen type name.
 
 - Try to avoid message definition changes that are problematic for
   backward compatibility.
-  - Adding a field is easy. However, if there is legacy data that needs
-    to be migrated, try to design the new field to accommodate a clear
-    no-data value that can be used to migrate old messages that didn't
-    contain the field.  (For example, rather than a `bool` field, you
-    might prefer to use an `int8` field with enumerated values that
-    include an explicit no-data value.)
-  - Deleting a field is problematic for migration, assuming the field
-    had any value when recorded in legacy messages. (Migrating to the
-    new message type could lose precious data.) This might or might not
-    be acceptable, depending on the situation.
-  - Try hard to avoid renumbering the label values for enumerated
-    types. If you do that, message migration will have to remap the
-    legacy values to the new values (which is complicated and
-    error-prone), or risk keeping values that are actively misleading
-    for data analysis. Instead, you should assign never-before-used
-    values as needed for new labels. If some old labels are no longer
-    used in new messages, you should still keep them in the message
-    definition as documentation for interpreting legacy
-    messages. However, it's encouraged to clarify their legacy status
-    (e.g., add a comment, or even prepend `OLD_` to the label text).
-  - If the message changes are so involved that you can't figure out how
-    you would migrate old message data to the new message type, consider
-    whether it might be better to simply define a brand-new message
-    type.
+
+   - Adding a field is easy. However, if there is legacy data that needs
+     to be migrated, try to design the new field to accommodate a clear
+     no-data value that can be used to migrate old messages that didn't
+     contain the field.  (For example, rather than a `bool` field, you
+     might prefer to use an `int8` field with enumerated values that
+     include an explicit no-data value.)
+
+   - Deleting a field is problematic for migration, assuming the field
+     had any value when recorded in legacy messages. (Migrating to the
+     new message type could lose precious data.) This might or might not
+     be acceptable, depending on the situation.
+
+   - Try hard to avoid renumbering the label values for enumerated
+     types. If you do that, message migration will have to remap the
+     legacy values to the new values (which is complicated and
+     error-prone), or risk keeping values that are actively misleading
+     for data analysis. Instead, you should assign never-before-used
+     values as needed for new labels. If some old labels are no longer
+     used in new messages, you should still keep them in the message
+     definition as documentation for interpreting legacy
+     messages. However, it's encouraged to clarify their legacy status
+     (e.g., add a comment, or even prepend `OLD_` to the label text).
+
+   - If the message changes are so involved that you can't figure out
+     how you would migrate old message data to the new message type,
+     consider whether it might be better to simply define a brand-new
+     message type.
 
 - Legacy message types that were recorded in precious (ISS) bags but are
   no longer published by the current software should not be deleted by
@@ -162,18 +173,22 @@ message type in legacy bags to use the frozen type name.
   the same time, following the [migration
   instructions](http://wiki.ros.org/rosbag/migration), ideally using
   section 3.1 "Preferred Approach".
-  - Place your `*.bmr` file in the `bmr` folder of the appropriate ROS
-    package. See
-    [`ff_msgs/bmr`](https://github.com/nasa/astrobee/tree/develop/communications/ff_msgs/bmr)
-    for an example of naming and styling conventions.
-  - It is not necessary to export your `*.bmr` file in `package.xml` as
-    documented in section 4. Unfortunately, that helps only if `rosdep`
-    is configured on your host, which we can't always count on.
-    Instead, our automated bag processing keeps a list of folders to
-    search for migration rules.
-  - Once your `*.bmr` file is added, `rosbag_fix_all.py` will apply your
-    migration rules as needed.
-  - Verify your new rule, as described below.
+
+   - Place your `*.bmr` file in the `bmr` folder of the appropriate ROS
+     package. See
+     [`ff_msgs/bmr`](https://github.com/nasa/astrobee/tree/develop/communications/ff_msgs/bmr)
+     for an example of naming and styling conventions.
+
+   - It is not necessary to export your `*.bmr` file in `package.xml` as
+     documented in section 4. Unfortunately, that helps only if `rosdep`
+     is configured on your host, which we can't always count on.
+     Instead, our automated bag processing keeps a list of folders to
+     search for migration rules.
+
+   - Once your `*.bmr` file is added, `rosbag_fix_all.py` will apply
+     your migration rules as needed.
+
+   - Verify your new rule, as described below.
 
 - If you are contemplating a new message definition change that is too
   involved for migration to be feasible, you should probably just define
@@ -181,50 +196,70 @@ message type in legacy bags to use the frozen type name.
   hassle. However, we already have past message changes of this flavor
   built up as technical debt. We deal with them by "freezing" a legacy
   copy of the old message definition. Follow these conventions:
-  - Messages are frozen by copying their definition files (e.g.,
-    `*.msg` or `*.action`).
-  - To avoid clutter, the frozen copies may be placed in their
-    own package, for example [`ff_legacy_msgs`] for messages from
-    [`ff_msgs`] or [`ff_hw_msgs`].
-  - Files defining frozen messages should be named by appending a
-    version number to the original filename. For example,
-    `Inspection.action` would become `InspectionV1.action`.
-  - When you freeze a parent type, you should also freeze any subtypes
-    contained in its fields, if there is any chance their definition
-    could change in the future.
-  - Add a rule for renaming the message type, as follows:
-    - Append your rule to the list in the `rename_types` field of the
-      file named `bmr/rewrite_types_rules.json` within the relevant ROS
-      package, such as `ff_msgs`.
-    - Your rule must specify these four fields:
-      - `old_type`: The old message type name in `some_pkg/SomeMsg`
-        format.
-      - `old_type_md5sum`: You can determine the MD5 sum for the old
-        type by examining the output of `rosbag info` run on a bag that
-        contains the legacy message, or by running `rosmsg md5
-        <old_type>` with the legacy version of FSW checked out.
-      - `new_type`: The new (frozen) message type name.
-      - `new_type_md5sum`: Determine with `rosmsg md5 <new_type>`.
-    - The rule is interpreted as follows: if a bag contains messages
-      that match both `type = old_type` and `type_md5sum =
-      old_type_md5sum`, those messages will have their type and MD5 sum
-      information rewritten to the new values.
-  - If you created a new rules file for the package, you may need to add
-    it to the list of rules files that `Makefile.rosbag_fix_all` looks
-    for.
-  - Once your renaming rule is added, `rosbag_fix_all.py` will apply it
-    as needed.
-  - TODO: Point to an example. (There is an example, but it will be
-    merged separately later.)
-  - Verify your new rule as described below.
+
+   - Messages are frozen by copying their definition files (e.g.,
+     `*.msg` or `*.action`).
+
+   - To avoid clutter, the frozen copies may be placed in their own
+     package, for example `ff_legacy_msgs` for messages from
+     `ff_msgs` or `ff_hw_msgs`.
+
+   - Files defining frozen messages should be named by appending a
+     version number to the original filename. For example,
+     `Inspection.action` would become `InspectionV1.action`.
+
+   - When you freeze a parent type, you should also freeze any subtypes
+     contained in its fields, if there is any chance their definition
+     could change in the future.
+
+   - Add a rule for renaming the message type, as follows:
+
+        - Append your rule to the list in the `rename_types` field of
+          the file named `bmr/rewrite_types_rules.json` within the
+          relevant ROS package, such as `ff_msgs`.
+
+        - Your rule must specify these four fields:
+
+            - `old_type`: The old message type name in
+              `some_pkg/SomeMsg` format.
+
+            - `old_type_md5sum`: You can determine the MD5 sum for the
+              old type by examining the output of `rosbag info` run on a
+              bag that contains the legacy message, or by running
+              `rosmsg md5 <old_type>` with the correct legacy version of
+              FSW checked out.
+
+            - `new_type`: The new (frozen) message type name.
+
+            - `new_type_md5sum`: Determine with `rosmsg md5 <new_type>`.
+
+        - The rule is interpreted as follows: if a bag contains messages
+          that match both `type = old_type` and `type_md5sum =
+          old_type_md5sum`, those messages will have their type and MD5
+          sum information rewritten to the new values.
+
+    - If you created a new rules file for the package, you may need to
+      add it to the list of rules files that `Makefile.rosbag_fix_all`
+      looks for.
+
+    - Once your renaming rule is added, `rosbag_fix_all.py` will apply
+      it as needed.
+
+    - TODO: Point to an example. (There is already an example written,
+      but it will be merged separately later.)
+
+    - Verify your new rule as described below.
 
 - Verifying message rewrite rules:
-  - The same approach applies, whether you wrote a migration rule or a type
-    renaming rule.
-  - Run `rosbag_fix_all.py` on an archived bag containing the legacy message.
-    It automatically applies various consistency checks.
-  - Run `rostopic echo -b <bag> -p <topic>` on the fixed bag and spot check
-    the field values in the output CSV file.
+
+    - The same approach applies, whether you wrote a migration rule or a
+      type renaming rule.
+
+    - Run `rosbag_fix_all.py` on an archived bag containing the legacy
+      message.  It automatically applies various consistency checks.
+
+    - Run `rostopic echo -b <bag> -p <topic>` on the fixed bag and spot
+      check the field values in the output CSV file.
 
 ## Ops approach for fixing bags
 
@@ -233,11 +268,13 @@ matter how many times we apply our automated fix script to an archived
 bag, a future FSW change could always break its compatibility again.
 
 Therefore, we should take a layered approach to fixing bags:
+
 - Whenever we make some use of an archived bag, particularly when we
   publicly release the data, we should try to fix the bag at that time
   (and create any retroactive migration rules as needed to support
   that). Regular usage of the fixing script should also help to avoid
   bit-rot.
+
 - Since future FSW changes will continue to break bags, and we don't
   want to take on the burden of reprocessing all the previously released
   bags after every breaking message definition change, we should also

--- a/doc/general_documentation/maintaining_telemetry.md
+++ b/doc/general_documentation/maintaining_telemetry.md
@@ -1,0 +1,277 @@
+
+# Maintaining Astrobee Telemetry Backward Compatibility
+
+## Motivation and scope
+
+The Astrobee Facility has built up a valuable archive of telemetry bags
+recorded by Astrobee robots on the ISS since commissioning in April
+2019. Astrobee's flight software (FSW) has also changed substantially over
+that time, including several changes to the definitions of the message
+types contained in the telemetry bags. As a result, it has become more
+difficult over time to analyze or play back older legacy bags with the
+latest version of FSW.
+
+This document establishes objectives for backward compatibility and
+proposes a maintenance approach.
+
+## Telemetry maintenance objectives
+
+1. Astrobee developers should be able to `rosbag play` archived Astrobee
+   ISS telemetry bags with the latest FSW, as a way to test the software
+   in the ISS environment. For example, localization system development
+   has relied heavily on bag playback as a way to iterate and overcome
+   challenges related to the complex ISS interior that can't be
+   replicated on the ground.
+
+2. External users without prior ROS experience should be able to analyze
+   archived Astrobee ISS telemetry bags with minimal training by
+   following simple, documented processes. These users could be Astrobee
+   guest scientists or could be third parties with less Astrobee
+   background and insider access who are opportunistically finding new
+   uses for our archived data. (For example, making new observations in
+   our ISS imagery.)
+
+3. We also have a priority list of bad outcomes to avoid:
+   a. Misleading users. If the message semantics has changed such that
+      trying to interpret legacy messages with the new semantics is
+      actively misleading, this is the worst case.
+   b. Breaking all messages. Some bag analysis tools are sensitive and
+      crash if the bag has even a single problematic message definition.
+      We should strive hard to avoid this problem.
+   c. Loss of ability to analyze specific message types or specific
+      fields. This may be more acceptable, depending on the specific
+      user needs.
+
+4. We should minimize the burden on Astrobee developers and the Astrobee
+   Facility ops team required to realize these goals.
+
+## Telemetry maintenance requirements
+
+1. Developers should have guidance about steps they can take to maintain
+   legacy bag compatibility with minimum effort (this document).
+
+2. Any required bag processing should be fully automated to the greatest
+   extent possible, minimizing burden on the Astrobee Facility and
+   users.
+
+3. Bags processed for developers or external users to work with should
+   pass `rosbag check`.  This tool applies a number of tests, but is
+   principally designed to check that the bag's messages can be played
+   back with the latest version of the FSW ROS environment (the message
+   definitions are compatible for all of the message types recorded in
+   the bag).
+
+4. Along the same lines, another test bags should pass is `rostopic echo
+   -b <bag> -a`. This forces message deserialization.
+
+4. Where message semantics have changed, we should either remap the
+   legacy message contents to accurately reflect the latest semantics,
+   or rename the legacy message type to clarify that it can't be
+   interpreted like the current type.
+
+5. ROS message types defined by guest scientists:
+   - If legacy bag compatibility is required for these messages, it
+     should be the responsibility of the guest science developers.
+   - As a fallback, the FSW team should provide a tool for filtering out
+     no-longer-compatible guest science messages, in case the other
+     messages in the bag are still valuable.
+
+6. Out of scope: The primary focus is on legacy messages recorded in ISS
+   telemetry bags, or particularly important ground experiments.  We
+   will avoid investing effort in backward compatibility with old
+   message definitions that were never recorded on the ISS. For example,
+   certain older versions of Astrobee perching messages were tested on
+   the ground, but never deployed on the ISS, and in those cases
+   backward compatibility is not important.
+
+## Telemetry maintenance approach
+
+We will provide a fully automated script that can fix arbitrary legacy
+ISS Astrobee bags to be compatible with the latest FSW.
+
+The starting point for the script is the standard [`rosbag`
+migration](http://wiki.ros.org/rosbag/migration) system provided with
+ROS. If we invest in maintaining the necessary `*.bmr` bag migration
+rules, the `rosbag fix` script can fix most but not all message
+definition problems.
+
+One remaining problem is incomplete message definitions in messages
+published by `rosjava` nodes. We have a script that can fix these
+message definitions. It must be run before `rosbag fix` in order to
+avoid a crash.
+
+The other remaining problem arises when there are substantial changes in
+a message definition that make migration to the new definition
+problematic. For example:
+- If a field has been deleted, any attempt to migrate an old message
+  instance to the new definition will necessarily involve data loss.
+- If the change is sufficiently complicated, it may not be worth the
+  effort to figure out how to reliably remap old data into the new
+  structure.
+
+When migration is problematic, we will instead "freeze" the old message
+definition by copying it to a legacy message type name, and rename the
+message type in legacy bags to use the frozen type name.
+
+## Developer guidelines for modifying messages
+
+- Begin by trying hard to get the initial design of any new messages
+  correct on the first pass, avoiding later changes that will cause a
+  migration hassle.
+
+- However, you can change a message's definition without worrying about
+  backward compatibility considerations up until the point when precious
+  (ISS) data is recorded.
+
+- Try to avoid message definition changes that are problematic for
+  backward compatibility.
+  - Adding a field is easy. However, if there is legacy data that needs
+    to be migrated, try to design the new field to accommodate a clear
+    no-data value that can be used to migrate old messages that didn't
+    contain the field.  (For example, rather than a `bool` field, you
+    might prefer to use an `int8` field with enumerated values that
+    include an explicit no-data value.)
+  - Deleting a field is problematic for migration, assuming the field
+    had any value when recorded in legacy messages. (Migrating to the
+    new message type could lose precious data.) This might or might not
+    be acceptable, depending on the situation.
+  - Try hard to avoid renumbering the label values for enumerated
+    types. If you do that, message migration will have to remap the
+    legacy values to the new values (which is complicated and
+    error-prone), or risk keeping values that are actively misleading
+    for data analysis. Instead, you should assign never-before-used
+    values as needed for new labels. If some old labels are no longer
+    used in new messages, you should still keep them in the message
+    definition as documentation for interpreting legacy
+    messages. However, it's encouraged to clarify their legacy status
+    (e.g., add a comment, or even prepend `OLD_` to the label text).
+  - If the message changes are so involved that you can't figure out how
+    you would migrate old message data to the new message type, consider
+    whether it might be better to simply define a brand-new message
+    type.
+
+- Legacy message types that were recorded in precious (ISS) bags but are
+  no longer published by the current software should not be deleted by
+  default, because they remain useful for backward compatibility with
+  the archived bags. Instead, document the legacy status of the message
+  (e.g., add it to a list of messages that are only present for backward
+  compatibility).
+
+- When you make a message definition change that is compatible with
+  `rosbag` migration, please define a migration rule for the message at
+  the same time, following the [migration
+  instructions](http://wiki.ros.org/rosbag/migration), ideally using
+  section 3.1 "Preferred Approach".
+  - Place your `*.bmr` file in the `bmr` folder of the appropriate ROS
+    package. See
+    [`ff_msgs/bmr`](https://github.com/nasa/astrobee/tree/develop/communications/ff_msgs/bmr)
+    for an example of naming and styling conventions.
+  - It is not necessary to export your `*.bmr` file in `package.xml` as
+    documented in section 4. Unfortunately, that helps only if `rosdep`
+    is configured on your host, which we can't always count on.
+    Instead, our automated bag processing keeps a list of folders to
+    search for migration rules.
+  - Once your `*.bmr` file is added, `rosbag_fix_all.py` will apply your
+    migration rules as needed.
+  - Verify your new rule, as described below.
+
+- If you are contemplating a new message definition change that is too
+  involved for migration to be feasible, you should probably just define
+  a brand-new message type instead and avoid any migration
+  hassle. However, we already have past message changes of this flavor
+  built up as technical debt. We deal with them by "freezing" a legacy
+  copy of the old message definition. Follow these conventions:
+  - Messages are frozen by copying their definition files (e.g.,
+    `*.msg` or `*.action`).
+  - To avoid clutter, the frozen copies may be placed in their
+    own package, for example [`ff_legacy_msgs`] for messages from
+    [`ff_msgs`] or [`ff_hw_msgs`].
+  - Files defining frozen messages should be named by appending a
+    version number to the original filename. For example,
+    `Inspection.action` would become `InspectionV1.action`.
+  - When you freeze a parent type, you should also freeze any subtypes
+    contained in its fields, if there is any chance their definition
+    could change in the future.
+  - Add a rule for renaming the message type, as follows:
+    - Append your rule to the list in the `rename_types` field of the
+      file named `bmr/rewrite_types_rules.json` within the relevant ROS
+      package, such as `ff_msgs`.
+    - Your rule must specify these four fields:
+      - `old_type`: The old message type name in `some_pkg/SomeMsg`
+        format.
+      - `old_type_md5sum`: You can determine the MD5 sum for the old
+        type by examining the output of `rosbag info` run on a bag that
+        contains the legacy message, or by running `rosmsg md5
+        <old_type>` with the legacy version of FSW checked out.
+      - `new_type`: The new (frozen) message type name.
+      - `new_type_md5sum`: Determine with `rosmsg md5 <new_type>`.
+    - The rule is interpreted as follows: if a bag contains messages
+      that match both `type = old_type` and `type_md5sum =
+      old_type_md5sum`, those messages will have their type and MD5 sum
+      information rewritten to the new values.
+  - If you created a new rules file for the package, you may need to add
+    it to the list of rules files that `Makefile.rosbag_fix_all` looks
+    for.
+  - Once your renaming rule is added, `rosbag_fix_all.py` will apply it
+    as needed.
+  - TODO: Point to an example. (There is an example, but it will be
+    merged separately later.)
+  - Verify your new rule as described below.
+
+- Verifying message rewrite rules:
+  - The same approach applies, whether you wrote a migration rule or a type
+    renaming rule.
+  - Run `rosbag_fix_all.py` on an archived bag containing the legacy message.
+    It automatically applies various consistency checks.
+  - Run `rostopic echo -b <bag> -p <topic>` on the fixed bag and spot check
+    the field values in the output CSV file.
+
+## Ops approach for fixing bags
+
+As long as FSW keeps evolving with changing message definitions, no
+matter how many times we apply our automated fix script to an archived
+bag, a future FSW change could always break its compatibility again.
+
+Therefore, we should take a layered approach to fixing bags:
+- Whenever we make some use of an archived bag, particularly when we
+  publicly release the data, we should try to fix the bag at that time
+  (and create any retroactive migration rules as needed to support
+  that). Regular usage of the fixing script should also help to avoid
+  bit-rot.
+- Since future FSW changes will continue to break bags, and we don't
+  want to take on the burden of reprocessing all the previously released
+  bags after every breaking message definition change, we should also
+  provide a simple, documented approach for external users to fix them.
+
+Usage instructions for fixing bags are documented in: \ref
+using_telemetry
+
+## Complementary backward compatibility approach
+
+This document focuses on maintaining backward compatibility of legacy
+bags with the ROS tools such as `rosbag` and `rostopic` that need the
+old messages to be compatible with the latest message
+definition. Clearly, this simplifies uses like testing the latest FSW
+using legacy bag playback.
+
+However, if all you need is offline analysis outside the ROS tools, the
+[`bagpy` library](https://jmscslgroup.github.io/bagpy/) for Python 3 is
+a viable alternative. It relies on the fact that the `rosbag` format
+includes complete embedded message definitions, allowing it to
+deserialize the binary messages and output CSV with named fields, even
+if the latest ROS packages that define the messages no longer have
+consistent message definitions. In fact, it doesn't even require a full
+ROS installation.  Fixed bags will never break from the `bagpy` analysis
+perspective.  Using `bagpy` may be especially attractive for users
+who lack prior ROS experience.
+
+## Retroactive migration technical debt
+
+Since Astrobee went through ISS commissioning in April 2019, there have
+been several message definition changes that lack corresponding
+migration rules.
+
+Our developers should retroactively create the necessary migration rules
+on a lazy as-needed basis. The most common triggering event to create a
+new rule would be noticing that `rosbag_fix_all.py` fails on an archived
+bag during the public data release process.

--- a/doc/general_documentation/public_data.md
+++ b/doc/general_documentation/public_data.md
@@ -293,6 +293,7 @@ If that doesn't work, you can try filtering out the bad topics instead of
 trying to fix their message definitions:
 
 ```console
+ASTROBEE_DIR=$HOME/astrobee
 $ASTROBEE_DIR/src/scripts/postprocessing/rosbag_topic_filter.py in.bag -r "/gs/*" -r /hw/cam_sci/compressed fixed.bag
 ```
 
@@ -300,7 +301,6 @@ And this command may help determine which topics are problematic
 in case more topics need to be fixed with the filtering approach:
 
 ```console
-ASTROBEE_DIR=$HOME/astrobee
 $ASTROBEE_DIR/src/scripts/postprocessing/rosbag_detect_bad_topics.py in.bag
 ```
 
@@ -310,15 +310,15 @@ deal with it.
 
 ### Bags containing messages with outdated message definitions
 
-TODO: Discuss how to handle older bags that include messages with
-outdated message definitions, where the message type has changed in the
-latest software version. For example, a new field may have been added to
-the message type, but messages in the older bag don't include it. A
-relevant resource: [rosbag
-migration](http://wiki.ros.org/rosbag/migration). In some cases, rather
-than migrating the bag, it might be easier to revert the installed
-version of the Astrobee flight software to the version that was used to
-record the bag file?
+When processing a bag file, you may see an error message indicating
+that some messages need to be migrated.
+
+This is because, as Astrobee flight software continues to evolve, its
+telemetry message definitions occasionally change in ways that break
+backward compatibility for analysis of archived telemetry bags.
+
+If you encounter this problem, [fix the bag as described
+above](#preparing-the-bag-for-analysis).
 
 ### Timestamp clock skew
 

--- a/doc/general_documentation/public_data.md
+++ b/doc/general_documentation/public_data.md
@@ -1,3 +1,4 @@
+\page using_telemetry
 
 # Using Astrobee Robot Telemetry Logs
 
@@ -155,10 +156,10 @@ your needs.
 
 ## Install before working with bags
 
-The short version is that you can get both the ROS bag file tools and
-the message definitions necessary for working with Astrobee bag files by
-following the installation instructions for the Astrobee robot software
-(\ref install-nonNASA).
+You can get both the ROS bag file tools and the message definitions
+necessary for working with Astrobee bag files by following the
+installation instructions for the Astrobee robot software: \ref
+install-nonNASA
 
 Depending on the activity, if there was guest science software installed
 and publishing additional message types, you may need to get the
@@ -175,6 +176,23 @@ the `isaac_msgs` and `isaac_hw_msgs` ROS packages from the
 [`isaac_msgs`](https://github.com/nasa/isaac_msgs) repo should suffice
 for ISAAC messages. (But that slimmed-down install process has not yet
 been tested and documented.)
+
+## Preparing the bag for analysis
+
+As Astrobee flight software continues to evolve, its telemetry message
+definitions occasionally change in ways that break backward
+compatibility for analysis of archived telemetry bags.
+
+We recommend "fixing" a bag (rewriting it for compatibility with the
+latest message definitions) before using it, as follows:
+
+```console
+ASTROBEE_DIR=$HOME/astrobee
+$ASTROBEE_DIR/src/scripts/postprocessing/rosbag_fix_all.py in.bag
+```
+
+However, fixing the bag may not be needed if you plan to analyze it
+only with `bagpy` and not with the core ROS tools.
 
 ## Figuring out what's in the bag
 
@@ -268,28 +286,22 @@ required message definition information, most commonly due to a
 [bug](https://github.com/nasa/astrobee/issues/402) with messages
 published by nodes using `rosjava`, which we use on the Astrobee HLP).
 
-You should be able to fix the problem by rewriting the message
-definitions for the affected message topics, as follows:
+If you encounter this problem, first make sure you [fixed the bag as
+described above](#preparing-the-bag-for-analysis).
 
-```console
-git clone https://github.com/trey0/rosbag_fixer.git
-FIXER_DIR=`pwd`/rosbag_fixer
-$FIXER_DIR/fix_bag_msg_def.py -l -t "/gs/*" -t /hw/cam_sci/compressed in.bag
-```
-
-If that doesn't work, you can try checking which topics are problematic
-in case more topics need to be fixed with the approach above:
-
-```console
-ASTROBEE_DIR=$HOME/astrobee
-$ASTROBEE_DIR/src/scripts/postprocessing/rosbag_detect_bad_topics.py in.bag
-```
-
-And an alternate approach is to filter out the bad topics instead of
+If that doesn't work, you can try filtering out the bad topics instead of
 trying to fix their message definitions:
 
 ```console
 $ASTROBEE_DIR/src/scripts/postprocessing/rosbag_topic_filter.py in.bag -r "/gs/*" -r /hw/cam_sci/compressed fixed.bag
+```
+
+And this command may help determine which topics are problematic
+in case more topics need to be fixed with the filtering approach:
+
+```console
+ASTROBEE_DIR=$HOME/astrobee
+$ASTROBEE_DIR/src/scripts/postprocessing/rosbag_detect_bad_topics.py in.bag
 ```
 
 As our processes improve, we hope to ensure future bag files have this

--- a/scripts/postprocessing/Makefile.rosbag_fix_all
+++ b/scripts/postprocessing/Makefile.rosbag_fix_all
@@ -1,0 +1,24 @@
+
+ifeq (,${ASTROBEE_DIR})
+  ASTROBEE_DIR = ${HOME}/astrobee
+endif
+REWRITE_TYPES = ${ASTROBEE_DIR}/src/scripts/postprocessing/rosbag_rewrite_types.py
+BMR = $(wildcard ${ASTROBEE_DIR}/src/communications/ff_msgs/bmr/*.bmr)
+REWRITE_RULES = -r ${ASTROBEE_DIR}/src/communications/ff_msgs/bmr/rosbag_rewrite_types_rules.json
+
+ifeq (,${ISAAC_DIR})
+  ISAAC_DIR = ${HOME}/isaac
+endif
+
+# If ISAAC_DIR exists, apply extra rules for ISAAC messages. Shouldn't hurt non-ISAAC bags.
+ifneq (,$(wildcard ${ISAAC_DIR}))
+  BMR += $(wildcard ${ISAAC_DIR}/src/isaac_msgs/isaac_msgs/bmr/*.bmr)
+  REWRITE_RULES += -r ${ISAAC_DIR}/src/isaac_msgs/isaac_msgs/bmr/rosbag_rewrite_types_rules.json
+endif
+
+%.rewrite_types.bag: %.bag
+	${REWRITE_TYPES} -v ${REWRITE_RULES} $< -o $@
+
+%.fix_all.bag: %.rewrite_types.bag
+	rosbag fix $< $@ ${BMR}
+	rosbag check $@  # test: post-migration consistency

--- a/scripts/postprocessing/Makefile.rosbag_fix_all
+++ b/scripts/postprocessing/Makefile.rosbag_fix_all
@@ -1,3 +1,19 @@
+# Copyright (c) 2017, United States Government, as represented by the
+# Administrator of the National Aeronautics and Space Administration.
+#
+# All rights reserved.
+#
+# The Astrobee platform is licensed under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with the
+# License. You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
 
 ifeq (,${ASTROBEE_DIR})
   ASTROBEE_DIR = ${HOME}/astrobee

--- a/scripts/postprocessing/rosbag_fix_all.py
+++ b/scripts/postprocessing/rosbag_fix_all.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python
+# Copyright (c) 2017, United States Government, as represented by the
+# Administrator of the National Aeronautics and Space Administration.
+#
+# All rights reserved.
+#
+# The Astrobee platform is licensed under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with the
+# License. You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+"""
+Master script to apply all passes of processing needed to fix our legacy bag
+files. The actual processing steps are found in Makefile.rosbag_fix_all.
+"""
+
+from __future__ import print_function
+
+import argparse
+import logging
+import os
+
+
+def dosys(cmd):
+    logging.info(cmd)
+    ret = os.system(cmd)
+    if ret != 0:
+        logging.warning("Command failed with return value %s\n" % ret)
+    return ret
+
+
+def rosbag_fix_all(inbag_paths, jobs):
+    this_folder = os.path.dirname(os.path.realpath(__file__))
+    makefile = os.path.join(this_folder, "Makefile.rosbag_fix_all")
+    outbag_paths = [os.path.splitext(p)[0] + ".fix_all.bag" for p in inbag_paths]
+    outbag_paths_str = " ".join(outbag_paths)
+    ret = dosys("make -f%s -j%s %s" % (makefile, jobs, outbag_paths_str))
+
+    logging.info("")
+    logging.info("====================")
+    if ret == 0:
+        logging.info("Fixed bags written to:")
+        for outbag_path in outbag_paths:
+            logging.info("  %s", outbag_path)
+    else:
+        logging.warning("Not all bags were fixed successfully (see errors above).")
+
+
+class CustomFormatter(
+    argparse.ArgumentDefaultsHelpFormatter,
+):
+    pass
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=CustomFormatter
+    )
+    parser.add_argument(
+        "-j",
+        "--jobs",
+        help="specifies the number of jobs to run simultaneously",
+        type=int,
+        default=1,
+    )
+    parser.add_argument("inbag", nargs="+", help="input bag")
+
+    args = parser.parse_args()
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+    rosbag_fix_all(args.inbag, args.jobs)
+
+    # suppress confusing ROS message at exit
+    logging.getLogger().setLevel(logging.WARN)

--- a/scripts/postprocessing/rosbag_rewrite_types.py
+++ b/scripts/postprocessing/rosbag_rewrite_types.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python
+# Copyright (c) 2017, United States Government, as represented by the
+# Administrator of the National Aeronautics and Space Administration.
+#
+# All rights reserved.
+#
+# The Astrobee platform is licensed under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with the
+# License. You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+"""
+This script has the same basic goal as rosbag migration ("rosbag fix")
+but takes an alternative approach of rewriting the message to have a
+different type name without changing the raw message contents.
+
+When and how to use it:
+
+1. Determine if you have a message type whose definition has changed
+   incompatibly such that it's not feasible to migrate legacy bags
+   containing the message to use the new definition of the same message
+   type. For example, maybe an important field of the old message has
+   been deleted or has changed semantics, so that there's no easy and
+   robust way to capture the old field's information in the new message.
+
+2. Define a new message type with a different name that has exactly the
+   same data structure as the old message type. Note: Take care! Because
+   this script copies over the raw message contents verbatim, any change
+   in the data structure could cause data corruption. By convention, if
+   the old message type was pkg_msgs/Msg, the new message type should be
+   something like pkg_legacy_msgs/MsgV1 (or V2, V3, ... if needed). If
+   you are copying a parent type that contains subtypes that may change
+   in the future, those subtypes should also be copied, and the
+   reference to the subtype in the parent type should be updated to
+   point to the copy.
+
+3. Add the message type to a rules file. An example file is
+   rosbag_rewrite_types_rules.json found in this folder. Message
+   instances whose type matches old_type and whose message definition
+   MD5 sum matches old_type_md5sum will have their type renamed to
+   new_type and MD5 sum updated to new_type_md5sum. You can figure out
+   both the old_type and old_type_md5sum to use by running 'rosbag info'
+   on the legacy bag you want to migrate. You can figure out
+   new_type_md5sum by running 'rosmsg md5 <new_type>'.
+
+4. Run the script to rename the types. The legacy messages should now
+   be compatible with the latest version of your package.
+
+Note: It seems like 'rosbag fix' should support this use case, but we
+tried hard and couldn't get it to work in practice. It always tried to
+rewrite the message to the latest version of the same type instead of
+renaming the type, regardless of what we put in the *.bmr update
+rules. Also, an advantage of using this script instead of 'rosbag fix'
+is that both the migration rules and the script itself are much simpler.
+"""
+
+from __future__ import print_function
+
+import argparse
+import collections
+import json
+import logging
+import os
+
+import genpy
+import pprint
+import rosbag
+import rosmsg
+
+DEFAULT_RULES_FILE = "rosbag_rewrite_types_rules.json"
+
+# See the following source for many of the rosbag/rosmsg/genpy patterns used
+# here:
+#   http://docs.ros.org/en/melodic/api/rosbag/html/python/rosbag.migration-pysrc.html
+
+def dosys(cmd):
+    logging.info(cmd)
+    ret = os.system(cmd)
+    if ret != 0:
+        logging.warning("Command failed with return value %s\n" % ret)
+    return ret
+
+
+def get_rule_entry(rule):
+    key = (rule["old_type"], rule["old_type_md5sum"])
+
+    new_type = rule["new_type"]
+    new_pytype = genpy.message.get_message_class(new_type)
+    latest_md5sum = rosmsg.rosmsg_md5(rosmsg.MODE_MSG, new_type)
+    if rule["new_type_md5sum"] != latest_md5sum:
+        logging.warning("warning: md5sum mismatch for: %s", new_type)
+        logging.warning("  migration rule md5sum: %s", rule["new_type_md5sum"])
+        logging.warning("  latest md5sum: %s", latest_md5sum)
+        logging.warning("  [a changed message definition could cause data corruption]")
+
+    val = {
+        "type": new_type,
+        "md5sum": rosmsg.rosmsg_md5(rosmsg.MODE_MSG, new_type),
+        "message_definition": new_pytype._full_text,
+        "pytype": new_pytype,
+    }
+
+    return (key, val)
+
+
+def get_rule_lookup(rules_files):
+    lookup = {}
+    for rules_file in rules_files:
+        rules = json.load(open(rules_file, "r"))
+        lookup.update(dict((get_rule_entry(r) for r in rules)))
+
+    return lookup
+
+
+def rewrite_msg_types1(inbag_path, outbag_path, rule_lookup, verbose=False, no_reindex=False):
+    if os.path.exists(outbag_path):
+        logging.error("Not overwriting existing file %s" % outbag_path)
+        return
+
+    ctr = collections.Counter()
+    with rosbag.Bag(inbag_path, "r") as inbag, rosbag.Bag(outbag_path, "w") as outbag:
+        for topic, msg, t, conn in inbag.read_messages(raw=True, return_connection_header=True):
+            old_type, msg_data, old_type_md5sum, msg_pos, msg_pytype = msg
+            tgt = rule_lookup.get((old_type, old_type_md5sum))
+            if tgt is None:
+                # just copy the message to outbag, no rewrite needed
+                outbag.write(topic, msg, t, raw=True)
+            else:
+                ctr[(old_type, old_type_md5sum)] += 1
+                # rewrite the necessary fields of the message and connection header
+                new_msg = (tgt["type"], msg_data, tgt["md5sum"], msg_pos, tgt["pytype"])
+                for k in ("type", "md5sum", "message_definition"):
+                    conn[k] = tgt[k]
+                outbag.write(topic, new_msg, t, connection_header=conn, raw=True)
+
+    if verbose:
+        # summary of migrated messages
+        migrated = sorted(ctr.keys())
+        logging.info("Migrated message counts:")
+        if not migrated:
+            logging.info("  [no matching messages found]")
+        for key in migrated:
+            old_type, old_type_md5sum = key
+            tgt = rule_lookup[key]
+            logging.info(
+                "  %5d %s %s -> %s %s",
+                ctr[key],
+                old_type,
+                old_type_md5sum,
+                tgt["type"],
+                tgt["md5sum"]
+            )
+
+    cmd = "rosbag reindex %s" % outbag_path
+    if no_reindex:
+        logging.info("%s probably needs to be re-indexed. Run: %s\n", outbag_path, cmd)
+    else:
+        dosys(cmd)
+        dosys("rm %s" % (os.path.splitext(outbag_path)[0] + ".orig.bag"))
+
+
+def rewrite_msg_types(inbag_paths, outbag_path_pattern, rules_files, verbose=False, no_reindex=False):
+    rule_lookup = get_rule_lookup(rules_files)
+
+    for inbag_path in inbag_paths:
+        inbag_name = os.path.splitext(inbag_path)[0]
+        outbag_path = outbag_path_pattern.format(inbag=inbag_name)
+        rewrite_msg_types1(inbag_path, outbag_path, rule_lookup, verbose)
+
+
+class CustomFormatter(argparse.ArgumentDefaultsHelpFormatter, argparse.RawDescriptionHelpFormatter):
+    pass
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=CustomFormatter
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        help="print debug info",
+        default=False,
+        action="store_true",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        help="path for output bag",
+        default="{inbag}.rewrite_types.bag",
+    )
+    parser.add_argument(
+        "-r",
+        "--rules",
+        nargs="*",
+        help="path to rewrite rules file (can specify multiple times) (default: %s)" % DEFAULT_RULES_FILE,
+    )
+    parser.add_argument(
+        "-n",
+        '--no-reindex',
+        action='store_true',
+        help="Suppress 'rosbag reindex' call",
+        default=False,
+    )
+    parser.add_argument("inbag", nargs="+", help="input bag")
+
+    args = parser.parse_args()
+
+    level = logging.DEBUG if args.verbose else logging.WARN
+    logging.basicConfig(level=level, format="%(message)s")
+
+    if not args.rules:
+        rules_file = DEFAULT_RULES_FILE
+        if not os.path.exists(rules_file):
+            # if default rules file not found in cwd, search in the same folder
+            # as this script
+            rules_file = os.path.join(
+                os.path.dirname(os.path.realpath(__file__)), rules_file
+            )
+        args.rules = [rules_file]
+
+    rewrite_msg_types(args.inbag, args.output, args.rules, args.verbose, args.no_reindex)
+
+    # suppress confusing ROS message at exit
+    logging.getLogger().setLevel(logging.WARN)

--- a/scripts/postprocessing/rosbag_rewrite_types.py
+++ b/scripts/postprocessing/rosbag_rewrite_types.py
@@ -17,30 +17,6 @@
 # under the License.
 
 """
-This script has the same basic goal as rosbag migration ("rosbag fix")
-but takes an alternative approach of rewriting the message to have a
-different type name without changing the raw message contents.
-
-When and how to use it:
-
-1. Determine if you have a message type whose definition has changed
-   incompatibly such that it's not feasible to migrate legacy bags
-   containing the message to use the new definition of the same message
-   type. For example, maybe an important field of the old message has
-   been deleted or has changed semantics, so that there's no easy and
-   robust way to capture the old field's information in the new message.
-
-2. Define a new message type with a different name that has exactly the
-   same data structure as the old message type. Note: Take care! Because
-   this script copies over the raw message contents verbatim, any change
-   in the data structure could cause data corruption. By convention, if
-   the old message type was pkg_msgs/Msg, the new message type should be
-   something like pkg_legacy_msgs/MsgV1 (or V2, V3, ... if needed). If
-   you are copying a parent type that contains subtypes that may change
-   in the future, those subtypes should also be copied, and the
-   reference to the subtype in the parent type should be updated to
-   point to the copy.
-
 3. Add the message type to a rules file. An example file is
    rosbag_rewrite_types_rules.json found in this folder. Message
    instances whose type matches old_type and whose message definition


### PR DESCRIPTION
I recommend starting review with the [design document](https://github.com/trey0/astrobee/blob/bag_migrate/doc/general_documentation/maintaining_telemetry.md).

I think the scripts involved might be better organized into Ryan's new `bag_processing` package, but I would rather address moving them in a second pass (there are some cross-references that should not be broken).