### PR TITLE
organize docs

### DIFF
--- a/astrobee.doxyfile
+++ b/astrobee.doxyfile
@@ -605,7 +605,7 @@ STRICT_PROTO_MATCHING  = NO
 # list. This list is created by putting \todo commands in the documentation.
 # The default value is: YES.
 
-GENERATE_TODOLIST      = YES
+GENERATE_TODOLIST      = NO
 
 # The GENERATE_TESTLIST tag can be used to enable (YES) or disable (NO) the test
 # list. This list is created by putting \test commands in the documentation.

--- a/doc/general_documentation/astrobee_usage.md
+++ b/doc/general_documentation/astrobee_usage.md
@@ -23,4 +23,6 @@
 
 \subpage adding_a_command
 
-\subpage command_dictionary
+\subpage using_telemetry
+
+\subpage maintaining_telemetry

--- a/doc/general_documentation/maintaining_telemetry.md
+++ b/doc/general_documentation/maintaining_telemetry.md
@@ -1,5 +1,5 @@
 
-# Maintaining Astrobee Telemetry Backward Compatibility
+\page maintaining_telemetry Maintaining Astrobee Telemetry Backward Compatibility
 
 ## Motivation and scope
 

--- a/doc/general_documentation/public_data.md
+++ b/doc/general_documentation/public_data.md
@@ -1,6 +1,4 @@
-\page using_telemetry
-
-# Using Astrobee Robot Telemetry Logs
+\page using_telemetry Using Astrobee Robot Telemetry Logs
 
 The ISS Astrobee Facility has established an [Astrobee ISS telemetry
 log public release

--- a/doc/general_documentation/subsystems.md
+++ b/doc/general_documentation/subsystems.md
@@ -74,6 +74,9 @@ Definition of topic names are maintained in \subpage shared:<br>
     - Bridge
     - Msg / Srv / Action
 
+### Description (URDF Robot Description)
+  - \subpage urdf
+
 ### Drivers (hardware)
   - \subpage hw
   - directory: `hardware`

--- a/tools/bag_processing/readme.md
+++ b/tools/bag_processing/readme.md
@@ -1,4 +1,4 @@
-\page bagprocessing Bag Processing
+\page bag_processing Bag Processing
 
 # Package Overview
 The bag processing package provides several helper tools for handling bagfiles.

--- a/tools/imu_bias_tester/readme.md
+++ b/tools/imu_bias_tester/readme.md
@@ -1,4 +1,4 @@
-\page imubiastester Imu Bias Tester 
+\page imubiastester IMU Bias Tester
 
 ## ImuBiasTester
 The ImuBiasTester integrates IMU measurements using the latest estimated IMU biases from graph_state messages.


### PR DESCRIPTION
I noticed the gh-pages documentation sidebar index was getting untidy and tried to clean it up a bit. Unfortunately, I don't know how to test what the new index will look like before the PR is merged, but hopefully the intent is clear in each case.