### PR TITLE
Update the name of the namespaced body frame for relative motion

### DIFF
--- a/management/executive/tools/teleop_tool.cc
+++ b/management/executive/tools/teleop_tool.cc
@@ -245,7 +245,7 @@ bool SendMobilityCommand() {
     // Set frame
     cmd.args[0].data_type = ff_msgs::CommandArg::DATA_TYPE_STRING;
     if (FLAGS_relative) {
-      cmd.args[0].s = "body";
+      cmd.args[0].s = (FLAGS_ns.empty() ? "body" : FLAGS_ns + "/" + std::string(FRAME_NAME_BODY));
     } else {
       cmd.args[0].s = "world";
     }


### PR DESCRIPTION
This PR fixes an error I was getting when trying to use the teleop tool for commanding relative motions for a namespaced Astrobee. Before the PR, if I send a command like this:
` rosrun executive teleop_tool -ns "bumble" -move -relative -pos "0.5 1 0.5"
`
I would get an error like this: 
`(ros.executive./bumble/executive) Executive: Command failed with message: Move goal failed with response: Invalid reference frame`

With this small fix, the error no longer occurs and Astrobee moves as expected when using the relative-pos option.