### PR TITLE
make python interpreter available in focal

### DIFF
--- a/scripts/setup/install_desktop_packages.sh
+++ b/scripts/setup/install_desktop_packages.sh
@@ -75,3 +75,11 @@ if ! sudo apt-get install -m -y $pkgs; then
     exit 1
   }
 fi
+
+DIST=`cat /etc/os-release | grep -oP "(?<=VERSION_CODENAME=).*"`
+if [ "$DIST" == "focal" ]; then
+  echo "Ubuntu 20.04 Focal Fossa detected"
+
+  echo "If 'python' interpreter is missing, point to 'python3'"
+  which python >/dev/null || sudo update-alternatives --install /usr/bin/python python /usr/bin/python3 1
+fi


### PR DESCRIPTION
Executable Astrobee Python scripts typically start with `#!/usr/bin/env python` and should be compatible with both Python 2.x and 3.x. This change allows them to be run under Focal (`python` = `python3`) as they are under Xenial and Bionic (`python` = `python2`) without any special fuss.