### PR TITLE
manually trigger some GitHub workflows

### DIFF
--- a/.github/workflows/ci_pr.yml
+++ b/.github/workflows/ci_pr.yml
@@ -3,6 +3,7 @@ name: Build and Test CI for Pull Requests
 on:
   pull_request:
     branches: [ 'master', 'develop' ]
+  workflow_dispatch:
 
 jobs:
 

--- a/.github/workflows/docker_push_latest_base.yml
+++ b/.github/workflows/docker_push_latest_base.yml
@@ -1,0 +1,90 @@
+# Push the latest-base Docker images without doing a release. Called
+# manually only when needed (basically, when we push a change that
+# affects the base image on the develop branch).
+
+name: Docker push latest base
+
+on: ['workflow_dispatch']
+
+jobs:
+
+  build-xenial:
+
+    runs-on: ubuntu-18.04
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Checkout submodule
+      run: git submodule update --init --depth 1 description/media
+
+    - name: Build base for Ubuntu 16 Xenial
+      run: ./scripts/docker/build.sh --xenial astrobee_base
+
+    - name: Build code for Ubuntu 16 Xenial
+      run: ./scripts/docker/build.sh --xenial astrobee
+
+    - name: Test code
+      run: ./scripts/docker/build.sh --xenial test_astrobee
+
+    - name: Log in to registry
+      run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.repository_owner }} --password-stdin
+
+    - name: Push Docker image
+      run: |
+        docker tag astrobee/astrobee:latest-base-ubuntu16.04 ghcr.io/${{ github.repository_owner }}/astrobee:latest-base-ubuntu16.04
+        docker push ghcr.io/${{ github.repository_owner }}/astrobee:latest-base-ubuntu16.04
+
+  build-bionic:
+
+    runs-on: ubuntu-18.04
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Checkout submodule
+      run: git submodule update --init --depth 1 description/media
+
+    - name: Build base for Ubuntu 18 Bionic
+      run: ./scripts/docker/build.sh --bionic astrobee_base
+
+    - name: Build code for Ubuntu 18 Bionic
+      run: ./scripts/docker/build.sh --bionic astrobee
+
+    - name: Test code
+      run: ./scripts/docker/build.sh --bionic test_astrobee
+
+    - name: Log in to registry
+      run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.repository_owner }} --password-stdin
+
+    - name: Push Docker image
+      run: |
+        docker tag astrobee/astrobee:latest-base-ubuntu18.04 ghcr.io/${{ github.repository_owner }}/astrobee:latest-base-ubuntu18.04
+        docker push ghcr.io/${{ github.repository_owner }}/astrobee:latest-base-ubuntu18.04
+
+  build-focal:
+
+    runs-on: ubuntu-20.04
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Checkout submodule
+      run: git submodule update --init --depth 1 description/media
+
+    - name: Build base for Ubuntu 20 Focal
+      run: ./scripts/docker/build.sh --focal astrobee_base
+
+    - name: Build code for Ubuntu 20 Focal
+      run: ./scripts/docker/build.sh --focal astrobee
+
+    - name: Test code
+      run: ./scripts/docker/build.sh --focal test_astrobee
+
+    - name: Log in to registry
+      run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.repository_owner }} --password-stdin
+
+    - name: Push Docker image
+      run: |
+        docker tag astrobee/astrobee:latest-base-ubuntu20.04 ghcr.io/${{ github.repository_owner }}/astrobee:latest-base-ubuntu20.04
+        docker push ghcr.io/${{ github.repository_owner }}/astrobee:latest-base-ubuntu20.04

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -2,7 +2,7 @@
 
 name: Check for lint errors
 
-on: ['push', 'pull_request']
+on: ['push', 'pull_request', 'workflow_dispatch']
 
 jobs:
   lint_check_cpp:


### PR DESCRIPTION
Two main changes here:
- Add `workflow_dispatch` trigger to the lint and test workflows. It [enables them to be run manually](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow). I would like this because I found myself filing bogus PRs in my personal repo just to trigger CI testing, which seems silly. I think Keenan also has done that.
- Add a new workflow whose sole purpose is to be manually triggered if we decide we want to update the base Docker image on `ghcr.io`. Currently the base Docker image is updated only on release, which is a pain when you want to push changes in the code that depend on recent changes in the base Docker image, but of course you can't because then the CI will fail. (But I'm also open to other workarounds for that problem.) A nice side point is I was able to use the latest `build.sh` script to simplify the workflow a lot.