### PR TITLE
docker workflows consistently use build.sh

### DIFF
--- a/.github/workflows/ci_pr.yml
+++ b/.github/workflows/ci_pr.yml
@@ -19,18 +19,9 @@ jobs:
     - name: Checkout submodule
       run: git submodule update --init --depth 1 description/media
 
-    - name: Build code for Ubuntu 16
-      run: docker build . -f ./scripts/docker/astrobee.Dockerfile
-                          --build-arg UBUNTU_VERSION=16.04
-                          --build-arg ROS_VERSION=kinetic
-                          --build-arg PYTHON=''
-                          --build-arg REMOTE=ghcr.io/nasa
-                          -t astrobee/astrobee:latest-ubuntu16.04
-
-    - name: Test code
-      run: docker build . -f ./scripts/docker/test_astrobee.Dockerfile
-                          --build-arg UBUNTU_VERSION=16.04
-                          -t astrobee/astrobee:test-ubuntu16.04
+    - name: Build, test
+      run: ./scripts/docker/build.sh --xenial --remote
+                                     astrobee test_astrobee
 
   build-bionic:
 
@@ -44,18 +35,9 @@ jobs:
     - name: Checkout submodule
       run: git submodule update --init --depth 1 description/media
 
-    - name: Build code for Ubuntu 18
-      run: docker build . -f ./scripts/docker/astrobee.Dockerfile
-                          --build-arg UBUNTU_VERSION=18.04
-                          --build-arg ROS_VERSION=melodic
-                          --build-arg PYTHON=3
-                          --build-arg REMOTE=ghcr.io/nasa
-                          -t astrobee/astrobee:latest-ubuntu18.04
-
-    - name: Test code
-      run: docker build . -f ./scripts/docker/test_astrobee.Dockerfile
-                          --build-arg UBUNTU_VERSION=18.04
-                          -t astrobee/astrobee:test-ubuntu18.04
+    - name: Build, test
+      run: ./scripts/docker/build.sh --bionic --remote
+                                     astrobee test_astrobee
 
   build-focal:
 
@@ -69,15 +51,6 @@ jobs:
     - name: Checkout submodule
       run: git submodule update --init --depth 1 description/media
 
-    - name: Build code for Ubuntu 20
-      run: docker build . -f ./scripts/docker/astrobee.Dockerfile
-                          --build-arg UBUNTU_VERSION=20.04
-                          --build-arg ROS_VERSION=noetic
-                          --build-arg PYTHON=3
-                          --build-arg REMOTE=ghcr.io/nasa
-                          -t astrobee/astrobee:latest-ubuntu20.04
-
-    - name: Test code
-      run: docker build . -f ./scripts/docker/test_astrobee.Dockerfile
-                          --build-arg UBUNTU_VERSION=20.04
-                          -t astrobee/astrobee:test-ubuntu20.04
+    - name: Build, test
+      run: ./scripts/docker/build.sh --focal --remote
+                                     astrobee test_astrobee

--- a/.github/workflows/ci_push.yml
+++ b/.github/workflows/ci_push.yml
@@ -16,26 +16,13 @@ jobs:
     - name: Checkout submodule
       run: git submodule update --init --depth 1 description/media
 
-    - name: Build code for Ubuntu 16
-      run: docker build . -f ./scripts/docker/astrobee.Dockerfile
-                          --build-arg UBUNTU_VERSION=16.04
-                          --build-arg ROS_VERSION=kinetic
-                          --build-arg PYTHON=''
-                          --build-arg REMOTE=ghcr.io/nasa
-                          -t ghcr.io/${{ github.repository_owner }}/astrobee:latest-ubuntu16.04
-
-    - name: Test code
-      run: docker build . -f ./scripts/docker/test_astrobee.Dockerfile
-                          --build-arg UBUNTU_VERSION=16.04
-                          --build-arg REMOTE=ghcr.io/${{ github.repository_owner }}
-                          -t astrobee:test-ubuntu16.04
-
     - name: Log in to registry
       run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.repository_owner }} --password-stdin
 
-    - name: Push Docker image
-      run: |
-        if [ "${{ github.repository_owner }}" = "nasa" ]; then docker push ghcr.io/${{ github.repository_owner }}/astrobee:latest-ubuntu16.04; fi;
+    - name: Build, test, push docker
+      run: ./scripts/docker/build.sh --xenial --remote
+                                     --owner ${{ github.repository_owner }}
+				     astrobee test_astrobee push_astrobee
 
   build-bionic:
 
@@ -47,26 +34,13 @@ jobs:
     - name: Checkout submodule
       run: git submodule update --init --depth 1 description/media
 
-    - name: Build code for Ubuntu 18
-      run: docker build . -f ./scripts/docker/astrobee.Dockerfile
-                          --build-arg UBUNTU_VERSION=18.04
-                          --build-arg ROS_VERSION=melodic
-                          --build-arg PYTHON=3
-                          --build-arg REMOTE=ghcr.io/nasa
-                          -t ghcr.io/${{ github.repository_owner }}/astrobee:latest-ubuntu18.04
-
-    - name: Test code
-      run: docker build . -f ./scripts/docker/test_astrobee.Dockerfile
-                          --build-arg UBUNTU_VERSION=18.04
-                          --build-arg REMOTE=ghcr.io/${{ github.repository_owner }}
-                          -t astrobee:test-ubuntu18.04
-
     - name: Log in to registry
       run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.repository_owner }} --password-stdin
 
-    - name: Push Docker image
-      run: |
-        if [ "${{ github.repository_owner }}" = "nasa" ]; then docker push ghcr.io/${{ github.repository_owner }}/astrobee:latest-ubuntu18.04; fi;
+    - name: Build, test, push docker
+      run: ./scripts/docker/build.sh --bionic --remote
+                                     --owner ${{ github.repository_owner }}
+				     astrobee test_astrobee push_astrobee
 
   build-focal:
 
@@ -78,23 +52,10 @@ jobs:
     - name: Checkout submodule
       run: git submodule update --init --depth 1 description/media
 
-    - name: Build code for Ubuntu 20
-      run: docker build . -f ./scripts/docker/astrobee.Dockerfile
-                          --build-arg UBUNTU_VERSION=20.04
-                          --build-arg ROS_VERSION=noetic
-                          --build-arg PYTHON=3
-                          --build-arg REMOTE=ghcr.io/nasa
-                          -t ghcr.io/${{ github.repository_owner }}/astrobee:latest-ubuntu20.04
-
-    - name: Test code
-      run: docker build . -f ./scripts/docker/test_astrobee.Dockerfile
-                          --build-arg UBUNTU_VERSION=20.04
-                          --build-arg REMOTE=ghcr.io/${{ github.repository_owner }}
-                          -t astrobee:test-ubuntu20.0
-
     - name: Log in to registry
       run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.repository_owner }} --password-stdin
 
-    - name: Push Docker image
-      run: |
-        if [ "${{ github.repository_owner }}" = "nasa" ]; then docker push ghcr.io/${{ github.repository_owner }}/astrobee:latest-ubuntu20.04; fi;
+    - name: Build, test, push docker
+      run: ./scripts/docker/build.sh --focal --remote
+                                     --owner ${{ github.repository_owner }}
+				     astrobee test_astrobee push_astrobee

--- a/.github/workflows/ci_push.yml
+++ b/.github/workflows/ci_push.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Build, test, push docker
       run: ./scripts/docker/build.sh --xenial --remote
                                      --owner ${{ github.repository_owner }}
-				     astrobee test_astrobee push_astrobee
+                                     astrobee test_astrobee push_astrobee
 
   build-bionic:
 
@@ -40,7 +40,7 @@ jobs:
     - name: Build, test, push docker
       run: ./scripts/docker/build.sh --bionic --remote
                                      --owner ${{ github.repository_owner }}
-				     astrobee test_astrobee push_astrobee
+                                     astrobee test_astrobee push_astrobee
 
   build-focal:
 
@@ -58,4 +58,4 @@ jobs:
     - name: Build, test, push docker
       run: ./scripts/docker/build.sh --focal --remote
                                      --owner ${{ github.repository_owner }}
-				     astrobee test_astrobee push_astrobee
+                                     astrobee test_astrobee push_astrobee

--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -22,13 +22,13 @@ jobs:
     - name: Build, test, push base docker
       run: ./scripts/docker/build.sh --xenial
                                      --owner ${{ github.repository_owner }}
-				     astrobee_base astrobee test_astrobee
-				     push_astrobee_base
+                                     astrobee_base astrobee test_astrobee
+                                     push_astrobee_base
 
     - name: Push code docker
       run: |
         export VERSION=`grep -w -m 1 "Release" RELEASE.md | awk '{print $3}'`
-	docker tag astrobee/astrobee:latest-ubuntu16.04 ghcr.io/${{ github.repository_owner }}/astrobee:v${VERSION}-ubuntu16.04
+        docker tag astrobee/astrobee:latest-ubuntu16.04 ghcr.io/${{ github.repository_owner }}/astrobee:v${VERSION}-ubuntu16.04
         docker push ghcr.io/${{ github.repository_owner }}/astrobee:v${VERSION}-ubuntu16.04
 
   build-bionic:
@@ -47,13 +47,13 @@ jobs:
     - name: Build, test, push base docker
       run: ./scripts/docker/build.sh --bionic
                                      --owner ${{ github.repository_owner }}
-				     astrobee_base astrobee test_astrobee
-				     push_astrobee_base
+                                     astrobee_base astrobee test_astrobee
+                                     push_astrobee_base
 
     - name: Push code docker
       run: |
         export VERSION=`grep -w -m 1 "Release" RELEASE.md | awk '{print $3}'`
-	docker tag astrobee/astrobee:latest-ubuntu18.04 ghcr.io/${{ github.repository_owner }}/astrobee:v${VERSION}-ubuntu18.04
+        docker tag astrobee/astrobee:latest-ubuntu18.04 ghcr.io/${{ github.repository_owner }}/astrobee:v${VERSION}-ubuntu18.04
         docker push ghcr.io/${{ github.repository_owner }}/astrobee:v${VERSION}-ubuntu18.04
 
   build-focal:
@@ -72,11 +72,11 @@ jobs:
     - name: Build, test, push base docker
       run: ./scripts/docker/build.sh --focal
                                      --owner ${{ github.repository_owner }}
-				     astrobee_base astrobee test_astrobee
-				     push_astrobee_base
+                                     astrobee_base astrobee test_astrobee
+                                     push_astrobee_base
 
     - name: Push code docker
       run: |
         export VERSION=`grep -w -m 1 "Release" RELEASE.md | awk '{print $3}'`
-	docker tag astrobee/astrobee:latest-ubuntu20.04 ghcr.io/${{ github.repository_owner }}/astrobee:v${VERSION}-ubuntu20.04
+        docker tag astrobee/astrobee:latest-ubuntu20.04 ghcr.io/${{ github.repository_owner }}/astrobee:v${VERSION}-ubuntu20.04
         docker push ghcr.io/${{ github.repository_owner }}/astrobee:v${VERSION}-ubuntu20.04

--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -16,34 +16,19 @@ jobs:
     - name: Checkout submodule
       run: git submodule update --init --depth 1 description/media
 
-    - name: Build base for Ubuntu 16
-      run: docker build . -f ./scripts/docker/astrobee_base.Dockerfile
-                          --build-arg UBUNTU_VERSION=16.04
-                          --build-arg ROS_VERSION=kinetic
-                          --build-arg PYTHON=''
-                          -t astrobee/astrobee:latest-base-ubuntu16.04
-
-    - name: Build code for Ubuntu 16
-      run: docker build . -f ./scripts/docker/astrobee.Dockerfile
-                          --build-arg UBUNTU_VERSION=16.04
-                          --build-arg ROS_VERSION=kinetic
-                          --build-arg PYTHON=''
-                          -t astrobee/astrobee:latest-ubuntu16.04
-
-    - name: Test code
-      run: docker build . -f ./scripts/docker/test_astrobee.Dockerfile
-                          --build-arg UBUNTU_VERSION=16.04
-                          -t astrobee:test-ubuntu16.04
-
     - name: Log in to registry
       run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.repository_owner }} --password-stdin
 
-    - name: Push Docker image
+    - name: Build, test, push base docker
+      run: ./scripts/docker/build.sh --xenial
+                                     --owner ${{ github.repository_owner }}
+				     astrobee_base astrobee test_astrobee
+				     push_astrobee_base
+
+    - name: Push code docker
       run: |
         export VERSION=`grep -w -m 1 "Release" RELEASE.md | awk '{print $3}'`
-        docker tag astrobee/astrobee:latest-base-ubuntu16.04 ghcr.io/${{ github.repository_owner }}/astrobee:latest-base-ubuntu16.04
-        docker push ghcr.io/${{ github.repository_owner }}/astrobee:latest-base-ubuntu16.04
-        docker tag astrobee/astrobee:latest-ubuntu16.04 ghcr.io/${{ github.repository_owner }}/astrobee:v${VERSION}-ubuntu16.04
+	docker tag astrobee/astrobee:latest-ubuntu16.04 ghcr.io/${{ github.repository_owner }}/astrobee:v${VERSION}-ubuntu16.04
         docker push ghcr.io/${{ github.repository_owner }}/astrobee:v${VERSION}-ubuntu16.04
 
   build-bionic:
@@ -56,34 +41,19 @@ jobs:
     - name: Checkout submodule
       run: git submodule update --init --depth 1 description/media
 
-    - name: Build base for Ubuntu 18
-      run: docker build . -f ./scripts/docker/astrobee_base.Dockerfile
-                          --build-arg UBUNTU_VERSION=18.04
-                          --build-arg ROS_VERSION=melodic
-                          --build-arg PYTHON=''
-                          -t astrobee/astrobee:latest-base-ubuntu18.04
-
-    - name: Build code for Ubuntu 18
-      run: docker build . -f ./scripts/docker/astrobee.Dockerfile
-                          --build-arg UBUNTU_VERSION=18.04
-                          --build-arg ROS_VERSION=melodic
-                          --build-arg PYTHON=''
-                          -t astrobee/astrobee:latest-ubuntu18.04
-
-    - name: Test code
-      run: docker build . -f ./scripts/docker/test_astrobee.Dockerfile
-                          --build-arg UBUNTU_VERSION=18.04
-                          -t astrobee:test-ubuntu18.04
-
     - name: Log in to registry
       run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.repository_owner }} --password-stdin
 
-    - name: Push Docker image
+    - name: Build, test, push base docker
+      run: ./scripts/docker/build.sh --bionic
+                                     --owner ${{ github.repository_owner }}
+				     astrobee_base astrobee test_astrobee
+				     push_astrobee_base
+
+    - name: Push code docker
       run: |
         export VERSION=`grep -w -m 1 "Release" RELEASE.md | awk '{print $3}'`
-        docker tag astrobee/astrobee:latest-base-ubuntu18.04 ghcr.io/${{ github.repository_owner }}/astrobee:latest-base-ubuntu18.04
-        docker push ghcr.io/${{ github.repository_owner }}/astrobee:latest-base-ubuntu18.04
-        docker tag astrobee/astrobee:latest-ubuntu18.04 ghcr.io/${{ github.repository_owner }}/astrobee:v${VERSION}-ubuntu18.04
+	docker tag astrobee/astrobee:latest-ubuntu18.04 ghcr.io/${{ github.repository_owner }}/astrobee:v${VERSION}-ubuntu18.04
         docker push ghcr.io/${{ github.repository_owner }}/astrobee:v${VERSION}-ubuntu18.04
 
   build-focal:
@@ -96,32 +66,17 @@ jobs:
     - name: Checkout submodule
       run: git submodule update --init --depth 1 description/media
 
-    - name: Build base for Ubuntu 20
-      run: docker build . -f ./scripts/docker/astrobee_base.Dockerfile
-                          --build-arg UBUNTU_VERSION=20.04
-                          --build-arg ROS_VERSION=noetic
-                          --build-arg PYTHON=3
-                          -t astrobee/astrobee:latest-base-ubuntu20.04
-
-    - name: Build code for Ubuntu 20
-      run: docker build . -f ./scripts/docker/astrobee.Dockerfile
-                          --build-arg UBUNTU_VERSION=20.04
-                          --build-arg ROS_VERSION=noetic
-                          --build-arg PYTHON=3
-                          -t astrobee/astrobee:latest-ubuntu20.04
-
-    - name: Test code
-      run: docker build . -f ./scripts/docker/test_astrobee.Dockerfile
-                          --build-arg UBUNTU_VERSION=20.04
-                          -t astrobee:test-ubuntu20.04
-
     - name: Log in to registry
       run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.repository_owner }} --password-stdin
 
-    - name: Push Docker image
+    - name: Build, test, push base docker
+      run: ./scripts/docker/build.sh --focal
+                                     --owner ${{ github.repository_owner }}
+				     astrobee_base astrobee test_astrobee
+				     push_astrobee_base
+
+    - name: Push code docker
       run: |
         export VERSION=`grep -w -m 1 "Release" RELEASE.md | awk '{print $3}'`
-        docker tag astrobee/astrobee:latest-base-ubuntu20.04 ghcr.io/${{ github.repository_owner }}/astrobee:latest-base-ubuntu20.04
-        docker push ghcr.io/${{ github.repository_owner }}/astrobee:latest-base-ubuntu20.04
-        docker tag astrobee/astrobee:latest-ubuntu20.04 ghcr.io/${{ github.repository_owner }}/astrobee:v${VERSION}-ubuntu20.04
+	docker tag astrobee/astrobee:latest-ubuntu20.04 ghcr.io/${{ github.repository_owner }}/astrobee:v${VERSION}-ubuntu20.04
         docker push ghcr.io/${{ github.repository_owner }}/astrobee:v${VERSION}-ubuntu20.04

--- a/.github/workflows/docker_push_latest_base.yml
+++ b/.github/workflows/docker_push_latest_base.yml
@@ -18,22 +18,13 @@ jobs:
     - name: Checkout submodule
       run: git submodule update --init --depth 1 description/media
 
-    - name: Build base for Ubuntu 16 Xenial
-      run: ./scripts/docker/build.sh --xenial astrobee_base
-
-    - name: Build code for Ubuntu 16 Xenial
-      run: ./scripts/docker/build.sh --xenial astrobee
-
-    - name: Test code
-      run: ./scripts/docker/build.sh --xenial test_astrobee
-
     - name: Log in to registry
       run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.repository_owner }} --password-stdin
 
-    - name: Push Docker image
-      run: |
-        docker tag astrobee/astrobee:latest-base-ubuntu16.04 ghcr.io/${{ github.repository_owner }}/astrobee:latest-base-ubuntu16.04
-        docker push ghcr.io/${{ github.repository_owner }}/astrobee:latest-base-ubuntu16.04
+    - name: Build base, build, test, push base docker
+      run: ./scripts/docker/build.sh --xenial
+                                     --owner ${{ github.repository_owner }}
+                                     astrobee_base astrobee test_astrobee push_astrobee_base
 
   build-bionic:
 
@@ -45,22 +36,13 @@ jobs:
     - name: Checkout submodule
       run: git submodule update --init --depth 1 description/media
 
-    - name: Build base for Ubuntu 18 Bionic
-      run: ./scripts/docker/build.sh --bionic astrobee_base
-
-    - name: Build code for Ubuntu 18 Bionic
-      run: ./scripts/docker/build.sh --bionic astrobee
-
-    - name: Test code
-      run: ./scripts/docker/build.sh --bionic test_astrobee
-
     - name: Log in to registry
       run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.repository_owner }} --password-stdin
 
-    - name: Push Docker image
-      run: |
-        docker tag astrobee/astrobee:latest-base-ubuntu18.04 ghcr.io/${{ github.repository_owner }}/astrobee:latest-base-ubuntu18.04
-        docker push ghcr.io/${{ github.repository_owner }}/astrobee:latest-base-ubuntu18.04
+    - name: Build base, build, test, push base docker
+      run: ./scripts/docker/build.sh --bionic
+                                     --owner ${{ github.repository_owner }}
+                                     astrobee_base astrobee test_astrobee push_astrobee_base
 
   build-focal:
 
@@ -72,19 +54,10 @@ jobs:
     - name: Checkout submodule
       run: git submodule update --init --depth 1 description/media
 
-    - name: Build base for Ubuntu 20 Focal
-      run: ./scripts/docker/build.sh --focal astrobee_base
-
-    - name: Build code for Ubuntu 20 Focal
-      run: ./scripts/docker/build.sh --focal astrobee
-
-    - name: Test code
-      run: ./scripts/docker/build.sh --focal test_astrobee
-
     - name: Log in to registry
       run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.repository_owner }} --password-stdin
 
-    - name: Push Docker image
-      run: |
-        docker tag astrobee/astrobee:latest-base-ubuntu20.04 ghcr.io/${{ github.repository_owner }}/astrobee:latest-base-ubuntu20.04
-        docker push ghcr.io/${{ github.repository_owner }}/astrobee:latest-base-ubuntu20.04
+    - name: Build base, build, test, push base docker
+      run: ./scripts/docker/build.sh --focal
+                                     --owner ${{ github.repository_owner }}
+                                     astrobee_base astrobee test_astrobee push_astrobee_base

--- a/scripts/docker/build.sh
+++ b/scripts/docker/build.sh
@@ -26,12 +26,15 @@ usage: build.sh [-h] [-x] [-b] [-f] [-r] [-d]
 -b or --bionic: Build Ubuntu 18.04 docker images
 -f or --focal: Build Ubuntu 20.04 docker images
 -r or --remote: Build first target on top of a pre-built remote image
+-o or --owner: Set ghcr.io owner for push action (default: nasa)
 -d or --dry-run: Just print what commands would be run
 
 Build specified docker image targets. Available targets:
 - astrobee_base
 - astrobee
 - test_astrobee
+- push_astrobee_base (push astrobee_base to ghcr.io)
+- push_astrobee (push astrobee to ghcr.io)
 
 Default if no targets are specified: astrobee_base astrobee
 
@@ -50,9 +53,13 @@ os=`cat /etc/os-release | grep -oP "(?<=VERSION_CODENAME=).*"`
 build_astrobee_base="false"
 build_astrobee="false"
 build_test_astrobee="false"
+push_astrobee_base="false"
+push_astrobee="false"
 
 remote="false"
+owner="nasa"
 dry_run="false"
+revision="latest-"
 
 while [ "$1" != "" ]; do
     case $1 in
@@ -65,16 +72,23 @@ while [ "$1" != "" ]; do
                                         ;;
         -f | --focal )                  os="focal"
                                         ;;
-	-r | --remote )                 remote="true"
-					;;
-	-d | --dry-run )                dry_run="true"
-					;;
-	astrobee_base )                 build_astrobee_base="true"
-					;;
-	astrobee )                      build_astrobee="true"
-					;;
-	test_astrobee )                 build_test_astrobee="true"
-					;;
+        -r | --remote )                 remote="true"
+                                        ;;
+        -o | --owner )                  owner=$2
+                                        shift
+                                        ;;
+        -d | --dry-run )                dry_run="true"
+                                        ;;
+        astrobee_base )                 build_astrobee_base="true"
+                                        ;;
+        astrobee )                      build_astrobee="true"
+                                        ;;
+        test_astrobee )                 build_test_astrobee="true"
+                                        ;;
+        push_astrobee_base )            push_astrobee_base="true"
+                                        ;;
+        push_astrobee )                 push_astrobee="true"
+                                        ;;
         * )                             usage
                                         exit 1
     esac
@@ -86,21 +100,23 @@ if [ "$dry_run" = "true" ]; then
 
     docker()
     {
-	# dry run, do nothing
-	{ : ; } 2>/dev/null
+        # dry run, do nothing
+        { : ; } 2>/dev/null
     }
 fi
 
 if [[ "$build_astrobee_base" == "false" \
-	  && "$build_astrobee" == "false" \
-	  && "$build_test_astrobee" == "false" ]]; then
+          && "$build_astrobee" == "false" \
+          && "$build_test_astrobee" == "false" \
+          && "$push_astrobee_base" == "false" \
+          && "$push_astrobee" == "false" ]]; then
    # if user didn't specify any targets, set defaults
    build_astrobee_base="true"
    build_astrobee="true"
 fi
 
 if [[ "$build_astrobee_base" == "true" \
-	  && "$remote" == "true" ]]; then
+          && "$remote" == "true" ]]; then
     echo "Error: --remote doesn't make sense when first target is astrobee_base."
     echo "Run with -h for help."
     exit 1
@@ -117,63 +133,79 @@ PYTHON=''
 if [ "$os" = "bionic" ]; then
     UBUNTU_VERSION=18.04
     ROS_VERSION=melodic
-    PYTHON=''
+    PYTHON='3'
 elif [ "$os" = "focal" ]; then
     UBUNTU_VERSION=20.04
     ROS_VERSION=noetic
     PYTHON='3'
 fi
-
-remote_repo="ghcr.io/nasa"
-
 echo "Building Ubuntu $UBUNTU_VERSION images"
 
-if [ "$build_astrobee_base" = "true" ]; then
+set -x
+cd "${checkout_dir}"
+{ set +x; } 2>/dev/null
+
+build () {
+    stage=$1
+    tag_revision=$2
+    tag_stage=$3
+
     echo ======================================================================
-    echo "Building astrobee_base"
+    echo "Building ${stage}"
+
+    remote_args=""
+    if [ "$remote" = "true" ]; then
+        echo "[Building on top of remote image]"
+        # note: pull from ghcr.io/nasa even if we push to another owner
+        remote_args="--build-arg REMOTE=ghcr.io/nasa"
+        remote="false"  # build subsequent targets on local image
+    fi
+
     set -x
-    docker build ${checkout_dir}/ \
-           -f ${checkout_dir}/scripts/docker/astrobee_base.Dockerfile \
+    docker build . \
+           -f ./scripts/docker/${stage}.Dockerfile \
            --build-arg UBUNTU_VERSION=${UBUNTU_VERSION} \
            --build-arg ROS_VERSION=${ROS_VERSION} \
            --build-arg PYTHON=${PYTHON} \
-           -t astrobee/astrobee:latest-base-ubuntu${UBUNTU_VERSION}
+           $remote_args \
+           -t astrobee/astrobee:${tag_revision}${tag_stage}ubuntu${UBUNTU_VERSION}
     { set +x; } 2>/dev/null
+}
+
+push () {
+    stage=$1
+    tag_revision=$2
+    tag_stage=$3
+
+    tag_suffix="astrobee:${tag_revision}${tag_stage}ubuntu${UBUNTU_VERSION}"
+    local_tag="astrobee/$tag_suffix"
+    remote_tag="ghcr.io/${owner}/$tag_suffix"
+
+    echo ======================================================================
+    echo "Pushing ${stage}"
+
+    set -x
+    docker tag $local_tag $remote_tag
+    docker push $remote_tag
+    { set +x; } 2>/dev/null
+}
+
+if [ "$build_astrobee_base" = "true" ]; then
+    build astrobee_base "$revision" "base-"
 fi
 
 if [ "$build_astrobee" = "true" ]; then
-    echo ======================================================================
-    echo "Building astrobee"
-    remote_args=""
-    if [ "$remote" = "true" ]; then
-	echo "[Building on top of remote image]"
-	remote_args="--build-arg REMOTE=${remote_repo}"
-	remote="false"  # build subsequent targets on local image
-    fi
-    set -x
-    docker build ${checkout_dir}/ \
-           -f ${checkout_dir}/scripts/docker/astrobee.Dockerfile \
-           --build-arg UBUNTU_VERSION=${UBUNTU_VERSION} \
-           --build-arg ROS_VERSION=${ROS_VERSION} \
-	   $remote_args \
-           -t astrobee/astrobee:latest-ubuntu${UBUNTU_VERSION}
-    { set +x; } 2>/dev/null
+    build astrobee "$revision" ""
 fi
 
 if [ "$build_test_astrobee" = "true" ]; then
-    echo ======================================================================
-    echo "Building test_astrobee"
-    remote_args=""
-    if [ "$remote" = "true" ]; then
-	echo "[Building on top of remote image]"
-	remote_args="--build-arg REMOTE=${remote_repo}"
-	remote="false"  # build subsequent targets on local image
-    fi
-    set -x
-    docker build ${checkout_dir}/ \
-           -f ${checkout_dir}/scripts/docker/test_astrobee.Dockerfile \
-           --build-arg UBUNTU_VERSION=${UBUNTU_VERSION} \
-	   $remote_args \
-           -t astrobee/astrobee:test-ubuntu${UBUNTU_VERSION}
-    { set +x; } 2>/dev/null
+    build test_astrobee "" "test-"
+fi
+
+if [ "$push_astrobee_base" = "true" ]; then
+    push astrobee_base "$revision" "base-"
+fi
+
+if [ "$push_astrobee" = "true" ]; then
+    push astrobee "$revision" ""
 fi


### PR DESCRIPTION
Fixes #467 

While working on this, I discovered a minor inconsistency between `build.sh` and CI workflows in terms of arguments they pass to Docker. Under Ubuntu 18.04 Bionic, `build.sh` used Python 2 but the CI workflows used Python 3. Luckily, both seemed to work equally well. When I merged the two code paths, I updated `build.sh` to use Python 3 to be consistent with the previous CI workflow.

Otherwise, the intent of these changes is simply to reduce the amount of repetitious copy/paste and unify code paths without changing the behavior at all. I was not able to test all of the workflows in my personal repo, but the ones I could easily test seemed to be fine.

If you are ever trying to understand the logic of `build.sh` and `run.sh`, I would like to highlight that they both now take a `--dry-run` parameter, so you can quickly experiment with how to call them and get the behavior you want.