### PR TITLE
make docs build robust to missing folders

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -59,7 +59,8 @@ jobs:
         cd ..
     - name: Replace old documentation with new
       run: |
-        rm -r docs/html
+        [ -d docs ] || mkdir docs
+        [ -d docs/html ] && rm -r docs/html
         cp -r repo/doc/html docs
     - name: Commit and Push
       run: |


### PR DESCRIPTION
I saw the docs build workflow fail the first time it was called in a new repo without this fix. The fix shouldn't change the behavior on subsequent runs.