### PR TITLE
Fixed start recording data bagger bug.

### DIFF
--- a/management/data_bagger/src/data_bagger.cc
+++ b/management/data_bagger/src/data_bagger.cc
@@ -338,6 +338,15 @@ bool DataBagger::EnableDelayedRecordingService(ff_msgs::EnableRecording::Request
                                       ff_msgs::EnableRecording::Response &res) {
   // Check if we are starting a recording or stopping a recording
   if (req.enable) {
+    // Check to see if we are already recording a bag. If we are, reject
+    // starting a new recording.
+    if (combined_data_state_.recording) {
+      res.status = "Can't start a recording while already recording data. ";
+      res.status += "Please stop the current recording first!";
+      res.success = false;
+      return true;
+    }
+
     // Check to make sure a delayed profile is loaded
     if (delayed_profile_name_ == "" ||
                                 recorder_options_delayed_.topics.size() == 0) {

--- a/management/executive/src/executive.cc
+++ b/management/executive/src/executive.cc
@@ -3025,14 +3025,14 @@ bool Executive::StartGuestScience(ff_msgs::CommandStampedPtr const& cmd) {
 }
 
 bool Executive::StartRecording(ff_msgs::CommandStampedPtr const& cmd) {
-  NODELET_INFO("Executive executing start recordiing command.");
+  NODELET_INFO("Executive executing start recording command.");
   bool successful = true;
   std::string err_msg;
   uint8_t completed_status = ff_msgs::AckCompletedStatus::OK;
   if (cmd->args.size() != 1 ||
       cmd->args[0].data_type != ff_msgs::CommandArg::DATA_TYPE_STRING) {
     successful = false;
-    err_msg = "Malformed arguments for start recordinng command.";
+    err_msg = "Malformed arguments for start recording command.";
     completed_status = ff_msgs::AckCompletedStatus::BAD_SYNTAX;
   } else {
     ff_msgs::EnableRecording enable_rec_srv;


### PR DESCRIPTION
The data bagger didn't check if a recording was already started when
receiving a start recording command. This caused the data bagger and
it's nodelet manager to crash. The data bagger has been changed to
reject the start recording command when the bagger is already recording.