### PR TITLE
Splice bag enter key fix

### DIFF
--- a/tools/bag_processing/scripts/splice_bag.py
+++ b/tools/bag_processing/scripts/splice_bag.py
@@ -221,7 +221,7 @@ def select_splice_timestamps_and_splice_bag(bagfile, image_topic):
                         3,
                     )
 
-            elif key == 13:  # Enter key
+            elif key == 13 or key == 10:  # Enter key
                 if not splice_timestamps:
                     message = "No splice timestamps added."
                     print(message)


### PR DESCRIPTION
Ubuntu 20 uses the new line ascii key (10) for enter rather than carriage return (13) (see https://www.asciitable.com/).  To account for this, this fix catches enter with values of 13 or 10.