### PR TITLE
auto-exposure; remove bayer service and control it only with the config

### DIFF
--- a/astrobee/config/cameras.config
+++ b/astrobee/config/cameras.config
@@ -105,9 +105,9 @@ nav_cam_to_sci_cam_timestamp_offset = robot_camera_calibrations.nav_cam_to_sci_c
 
 -- Auto-exposure parameters
 desired_msv = 2.5;
-k_p         = 0.05;
-k_i         = 0.01;
-max_i       = 3;
+k_p         = 20.0;
+k_i         = 2.0;
+max_i       = 50.0;
 
 -----------------------------------------------------
 --  PicoFlexx cameras support the following modes

--- a/astrobee/config/cameras.config
+++ b/astrobee/config/cameras.config
@@ -34,25 +34,27 @@ nav_cam = {
   device               = "/dev/nav_cam",
   gain                 = robot_camera_calibrations.nav_cam.gain,
   exposure             = robot_camera_calibrations.nav_cam.exposure,
+  auto_exposure        = true,
   calibration_gain     = 105,
   calibration_exposure = 30,
-  bayer_enable = false,
+  bayer_enable         = false,
   bayer_throttle_ratio = 3
 };
 
 dock_cam = {
-  width=1280,
-  height=960,
-  undistorted_width=3000,
-  undistorted_height=1800,
-  distortion_coeff=robot_camera_calibrations.dock_cam.distortion_coeff,
-  intrinsic_matrix=robot_camera_calibrations.dock_cam.intrinsic_matrix,
-  device="/dev/dock_cam",
-  gain=            robot_camera_calibrations.dock_cam.gain,
-  exposure=        robot_camera_calibrations.dock_cam.exposure,
+  width                = 1280,
+  height               = 960,
+  undistorted_width    = 3000,
+  undistorted_height   = 1800,
+  distortion_coeff     = robot_camera_calibrations.dock_cam.distortion_coeff,
+  intrinsic_matrix     = robot_camera_calibrations.dock_cam.intrinsic_matrix,
+  device               = "/dev/dock_cam",
+  gain                 = robot_camera_calibrations.dock_cam.gain,
+  exposure             = robot_camera_calibrations.dock_cam.exposure,
+  auto_exposure        = false,
   calibration_gain     = 105,
   calibration_exposure = 30,
-  bayer_enable = false,
+  bayer_enable         = false,
   bayer_throttle_ratio = 3
 };
 
@@ -100,6 +102,12 @@ sci_cam = {
 
 nav_cam_to_haz_cam_timestamp_offset = robot_camera_calibrations.nav_cam_to_haz_cam_timestamp_offset;
 nav_cam_to_sci_cam_timestamp_offset = robot_camera_calibrations.nav_cam_to_sci_cam_timestamp_offset;
+
+-- Auto-exposure parameters
+desired_msv = 2.5;
+k_p         = 0.05;
+k_i         = 0.01;
+max_i       = 3;
 
 -----------------------------------------------------
 --  PicoFlexx cameras support the following modes

--- a/astrobee/config/cameras.config
+++ b/astrobee/config/cameras.config
@@ -107,8 +107,8 @@ nav_cam_to_sci_cam_timestamp_offset = robot_camera_calibrations.nav_cam_to_sci_c
 desired_msv = 2.5;            -- should be 2.5 as histogram size is 5
 k_p         = 20.0;           -- proportional gain
 k_i         = 2.0;            -- integral gain
-tolerance   = 0.2;            -- msv tolerance to minimize exposure reconfigure
 max_i       = 50.0;           -- maximum i
+tolerance   = 0.2;            -- msv tolerance to minimize exposure reconfigure
 
 -----------------------------------------------------
 --  PicoFlexx cameras support the following modes

--- a/astrobee/config/cameras.config
+++ b/astrobee/config/cameras.config
@@ -105,9 +105,9 @@ nav_cam_to_sci_cam_timestamp_offset = robot_camera_calibrations.nav_cam_to_sci_c
 
 -- Auto-exposure parameters
 desired_msv = 2.5;            -- should be 2.5 as histogram size is 5
-k_p         = 20.0;           -- proportional gain
-k_i         = 2.0;            -- integral gain
-max_i       = 50.0;           -- maximum i
+k_p         = 25.0;           -- proportional gain
+k_i         = 8.0;            -- integral gain
+max_i       = 100.0;          -- maximum i
 tolerance   = 0.2;            -- msv tolerance to minimize exposure reconfigure
 
 -----------------------------------------------------

--- a/astrobee/config/cameras.config
+++ b/astrobee/config/cameras.config
@@ -34,7 +34,7 @@ nav_cam = {
   device               = "/dev/nav_cam",
   gain                 = robot_camera_calibrations.nav_cam.gain,
   exposure             = robot_camera_calibrations.nav_cam.exposure,
-  auto_exposure        = true,
+  auto_exposure        = false,
   calibration_gain     = 105,
   calibration_exposure = 30,
   bayer_enable         = false,
@@ -104,10 +104,11 @@ nav_cam_to_haz_cam_timestamp_offset = robot_camera_calibrations.nav_cam_to_haz_c
 nav_cam_to_sci_cam_timestamp_offset = robot_camera_calibrations.nav_cam_to_sci_cam_timestamp_offset;
 
 -- Auto-exposure parameters
-desired_msv = 2.5;
-k_p         = 20.0;
-k_i         = 2.0;
-max_i       = 50.0;
+desired_msv = 2.5;            -- should be 2.5 as histogram size is 5
+k_p         = 20.0;           -- proportional gain
+k_i         = 2.0;            -- integral gain
+tolerance   = 0.2;            -- msv tolerance to minimize exposure reconfigure
+max_i       = 50.0;           -- maximum i
 
 -----------------------------------------------------
 --  PicoFlexx cameras support the following modes

--- a/hardware/is_camera/include/is_camera/camera.h
+++ b/hardware/is_camera/include/is_camera/camera.h
@@ -61,7 +61,7 @@ class CameraNodelet : public ff_util::FreeFlyerNodelet {
   // lifetime, but in this case we're publishing at a lower rate and
   // expecting the subscriber callback to at most de-Bayer the image
   // before passing it on, so the buffer doesn't need to be so long.
-  static constexpr size_t kBayerImageMsgBufferLength = 10;
+  static constexpr size_t kBayerImageMsgBufferLength = 5;
 
   static constexpr size_t kImageWidth = 1280;
   static constexpr size_t kImageHeight = 960;

--- a/hardware/is_camera/include/is_camera/camera.h
+++ b/hardware/is_camera/include/is_camera/camera.h
@@ -74,8 +74,8 @@ class CameraNodelet : public ff_util::FreeFlyerNodelet {
 
  private:
   void PublishLoop();
-  void EnableBayer();
-  bool EnableBayerService(ff_msgs::SetBool::Request& req, ff_msgs::SetBool::Response& res);  // NOLINT
+  void EnableBayer(bool enable);
+  void AutoExposure(ros::TimerEvent const& te);
   size_t getNumBayerSubscribers();
 
   ros::NodeHandle *nh_;
@@ -87,11 +87,11 @@ class CameraNodelet : public ff_util::FreeFlyerNodelet {
   std::atomic<bool> thread_running_;
   ros::Publisher pub_;
   ros::Publisher bayer_pub_;
-  ros::ServiceServer enable_bayer_srv_;
   std::shared_ptr<V4LStruct> v4l_;
 
   config_reader::ConfigReader config_;
   ros::Timer config_timer_;
+  ros::Timer auto_exposure_timer_;
   std::string camera_device_;
   std::string camera_topic_;
   std::string bayer_camera_topic_;
@@ -108,6 +108,10 @@ class CameraNodelet : public ff_util::FreeFlyerNodelet {
   // published. Larger n reduces I/O overhead.
   unsigned int bayer_throttle_ratio_;
   size_t bayer_throttle_ratio_counter_;
+
+  // Auto exposure parameters
+  bool auto_exposure_;
+  double desired_msv_, k_p_, k_i_, max_i_, err_p_, err_i_;
 };
 
 }  // end namespace is_camera

--- a/hardware/is_camera/include/is_camera/camera.h
+++ b/hardware/is_camera/include/is_camera/camera.h
@@ -48,20 +48,20 @@ struct V4LStruct;
 class CameraNodelet : public ff_util::FreeFlyerNodelet {
  public:
   // The size of the image message ring buffer for publishing
-  // grayscale images.  15 images = 17.6 MB of buffer space. This
+  // grayscale images.  30 images = 35.2 MB of buffer space. This
   // number is so large because it sets the lifetime for each image
   // message sent out. Eventually we'll write over the pointer we've
-  // handed out. At 15 Hz, 15 frames means an image will stay valid
-  // for 1.0 seconds.  Localization can process at 2 Hz, so it only
-  // needs an image for 0.5 seconds.
-  static constexpr size_t kImageMsgBuffer = 15;
+  // handed out. At 15 Hz, 30 frames means an image will stay valid
+  // for 2.0 seconds.  Localization can process at 1 Hz, so it only
+  // needs an image for 1.0 second.
+  static constexpr size_t kImageMsgBuffer = 30;
 
   // The size of the image message ring buffer for publishing raw
   // Bayer format images.  The same comments apply about message
-  // lifetime, but in this case we're expecting the subscriber
-  // callback to at most de-Bayer the image before passing it on, so
-  // the buffer doesn't need to be so long.
-  static constexpr size_t kBayerImageMsgBufferLength = 5;
+  // lifetime, but in this case we're publishing at a lower rate and
+  // expecting the subscriber callback to at most de-Bayer the image
+  // before passing it on, so the buffer doesn't need to be so long.
+  static constexpr size_t kBayerImageMsgBufferLength = 10;
 
   static constexpr size_t kImageWidth = 1280;
   static constexpr size_t kImageHeight = 960;
@@ -76,7 +76,7 @@ class CameraNodelet : public ff_util::FreeFlyerNodelet {
  private:
   void PublishLoop();
   void EnableBayer(bool enable);
-  void AutoExposure(ros::TimerEvent const& te);
+  void AutoExposure();
   size_t getNumBayerSubscribers();
 
   ros::NodeHandle *nh_;
@@ -98,7 +98,7 @@ class CameraNodelet : public ff_util::FreeFlyerNodelet {
   std::string camera_topic_;
   std::string bayer_camera_topic_;
   std::string config_name_;
-  int camera_gain_, camera_exposure_;
+  int camera_gain_, camera_exposure_, camera_auto_exposure_;
   bool calibration_mode_;
 
   // bayer_enable: Set to true to enable publishing raw Bayer image

--- a/hardware/is_camera/include/is_camera/camera.h
+++ b/hardware/is_camera/include/is_camera/camera.h
@@ -25,6 +25,7 @@
 #include <opencv2/imgproc/imgproc.hpp>
 #include <ff_msgs/SetBool.h>
 #include <ff_util/ff_nodelet.h>
+#include <std_msgs/Int32.h>
 
 #include <thread>
 #include <atomic>
@@ -87,6 +88,7 @@ class CameraNodelet : public ff_util::FreeFlyerNodelet {
   std::atomic<bool> thread_running_;
   ros::Publisher pub_;
   ros::Publisher bayer_pub_;
+  ros::Publisher pub_exposure_;
   std::shared_ptr<V4LStruct> v4l_;
 
   config_reader::ConfigReader config_;

--- a/hardware/is_camera/include/is_camera/camera.h
+++ b/hardware/is_camera/include/is_camera/camera.h
@@ -25,7 +25,7 @@
 #include <opencv2/imgproc/imgproc.hpp>
 #include <ff_msgs/SetBool.h>
 #include <ff_util/ff_nodelet.h>
-#include <std_msgs/Int32.h>
+#include <std_msgs/Int32MultiArray.h>
 
 #include <thread>
 #include <atomic>
@@ -113,7 +113,8 @@ class CameraNodelet : public ff_util::FreeFlyerNodelet {
 
   // Auto exposure parameters
   bool auto_exposure_;
-  double desired_msv_, k_p_, k_i_, max_i_, err_p_, err_i_;
+  int hist_size_;
+  double desired_msv_, k_p_, k_i_, max_i_, err_p_, err_i_, tolerance_;
 };
 
 }  // end namespace is_camera

--- a/hardware/is_camera/src/camera.cc
+++ b/hardware/is_camera/src/camera.cc
@@ -210,6 +210,7 @@ namespace is_camera {
                               &CameraNodelet::AutoExposure, this, false, false);
 
     pub_ = nh->advertise<sensor_msgs::Image>(camera_topic_, 1);
+    pub_exposure_ = nh->advertise<std_msgs::Int32>(camera_topic_ + "_exposure", 1);
 
     // Allocate space for our output msg buffer
     for (size_t i = 0; i < kImageMsgBuffer; i++) {
@@ -384,6 +385,11 @@ namespace is_camera {
     if (abs(err_p_) > 0.5) {
       v4l_->SetParameters(camera_gain_, camera_exposure_ + k_p_ * err_p_ + k_i_ * err_i_);
     }
+
+    // Publish exposure data
+    std_msgs::Int32 exposure_msg;
+    exposure_msg.data = camera_exposure_ + k_p_ * err_p_ + k_i_ * err_i_;
+    pub_exposure_.publish(exposure_msg);
   }
 
   void CameraNodelet::PublishLoop() {

--- a/hardware/is_camera/src/camera.cc
+++ b/hardware/is_camera/src/camera.cc
@@ -373,7 +373,7 @@ namespace is_camera {
     // Calculate mean sample value
     double mean_sample_value = 0;
 
-    for (int i = 0; i < histSize; ++i) {
+    for (int i = 0; i < hist_size; ++i) {
       mean_sample_value += hist.at<float>(i) * (i+1);
     }
     mean_sample_value /= (kImageHeight * kImageWidth);

--- a/hardware/is_camera/src/camera.cc
+++ b/hardware/is_camera/src/camera.cc
@@ -401,8 +401,8 @@ namespace is_camera {
       }
       // Update camera exposure parameter
       camera_auto_exposure_ = std::round(camera_exposure_ + k_p_ * err_p_ + k_i_ * err_i_);
-      if (camera_auto_exposure_ < 0) camera_auto_exposure_ = 0;
-      else if (camera_auto_exposure_ > 300000) camera_auto_exposure_ = 300000;
+      if (camera_auto_exposure_ < 50.0) camera_auto_exposure_ = 50.0;
+      else if (camera_auto_exposure_ > 250.0) camera_auto_exposure_ = 250.0;
 
       v4l_->SetParameters(camera_gain_, camera_auto_exposure_);
     }

--- a/hardware/is_camera/src/camera.cc
+++ b/hardware/is_camera/src/camera.cc
@@ -209,8 +209,18 @@ namespace is_camera {
     auto_exposure_timer_ = GetPrivateHandle()->createTimer(
       ros::Duration(1),
       [this](ros::TimerEvent e) {
-        if (auto_exposure_) AutoExposure();
-      },
+        // Publish exposure data
+        std_msgs::Int32MultiArray msg;
+        msg.data.push_back(camera_gain_);
+        if (auto_exposure_) {
+          AutoExposure();
+          msg.data.push_back(camera_auto_exposure_);
+        } else {
+          msg.data.push_back(camera_exposure_);
+        }
+        pub_exposure_.publish(msg);
+      }
+      ,
       false, true);
 
     pub_ = nh->advertise<sensor_msgs::Image>(camera_topic_, 1);
@@ -396,12 +406,6 @@ namespace is_camera {
 
       v4l_->SetParameters(camera_gain_, camera_auto_exposure_);
     }
-
-    // Publish exposure data
-    std_msgs::Int32MultiArray msg;
-    msg.data.push_back(camera_gain_);
-    msg.data.push_back(camera_auto_exposure_);
-    pub_exposure_.publish(msg);
   }
 
   void CameraNodelet::PublishLoop() {

--- a/localization/sparse_mapping/include/sparse_mapping/sparse_map.h
+++ b/localization/sparse_mapping/include/sparse_mapping/sparse_map.h
@@ -297,6 +297,7 @@ struct SparseMap {
   std::vector<Eigen::Matrix2Xd> user_cid_to_keypoint_map_;
   std::vector<std::map<int, int> > user_pid_to_cid_fid_;
   std::vector<Eigen::Vector3d> user_pid_to_xyz_;
+  std::mutex mutex_detector_;
 
  private:
   // I found out the hard way that sparse maps cannot be copied

--- a/localization/sparse_mapping/src/sparse_map.cc
+++ b/localization/sparse_mapping/src/sparse_map.cc
@@ -424,8 +424,10 @@ void SparseMap::Load(const std::string & protobuf_file, bool localization) {
 
 void SparseMap::SetDetectorParams(int min_features, int max_features, int retries,
                                   double min_thresh, double default_thresh, double max_thresh) {
+  mutex_detector_.lock();
   detector_.Reset(detector_.GetDetectorName(), min_features, max_features, retries,
                   min_thresh, default_thresh, max_thresh);
+  mutex_detector_.unlock();
 }
 
 void SparseMap::Save(const std::string & protobuf_file) const {
@@ -610,6 +612,7 @@ void SparseMap::DetectFeatures(const cv::Mat& image,
 #endif
 
   std::vector<cv::KeyPoint> storage;
+  mutex_detector_.lock();
   if (!multithreaded) {
     detector_.Detect(*image_ptr, &storage, descriptors);
   } else {
@@ -626,6 +629,7 @@ void SparseMap::DetectFeatures(const cv::Mat& image,
                                                    min_thresh, default_thresh, max_thresh);
     local_detector.Detect(*image_ptr, &storage, descriptors);
   }
+  mutex_detector_.unlock();
 
   if (FLAGS_verbose_localization)
     std::cout << "Features detected " << storage.size() << std::endl;

--- a/shared/ff_util/include/ff_util/ff_names.h
+++ b/shared/ff_util/include/ff_util/ff_names.h
@@ -435,7 +435,6 @@
 #define SERVICE_HARDWARE_EPS_GET_BOARD_INFO         "hw/eps/get_board_info"
 #define SERVICE_HARDWARE_EPS_CLEAR_TERMINATE        "hw/eps/clear_terminate"
 
-#define SERVICE_HARDWARE_BAYER_ENABLE               "hw/cam_nav_bayer/enable"
 #define SERVICE_HARDWARE_PERCHING_ARM_ENABLE        "hw/arm/enable_arm"
 #define SERVICE_HARDWARE_PERCHING_ARM_DIST_VEL      "hw/arm/set_dist_vel"
 #define SERVICE_HARDWARE_PERCHING_ARM_PROX_VEL      "hw/arm/set_prox_vel"


### PR DESCRIPTION
Auto-exposure algorithm based on https://www.araa.asn.au/acra/acra2007/papers/paper84final.pdf,
which has a reference implementation in https://github.com/rishchou/auto_exposure_ROS/blob/master/src/auto_exposure_control.py