### PR TITLE
Fixed BRISK descriptor usage in Sparse Map Database

### DIFF
--- a/localization/sparse_mapping/include/sparse_mapping/FBrisk.h
+++ b/localization/sparse_mapping/include/sparse_mapping/FBrisk.h
@@ -1,0 +1,77 @@
+/* Copyright (c) 2017, United States Government, as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ *
+ * All rights reserved.
+ *
+ * The Astrobee platform is licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef SPARSE_MAPPING_FBRISK_H_
+#define SPARSE_MAPPING_FBRISK_H_
+
+#include <DBoW2/FClass.h>
+
+#include <opencv2/core.hpp>
+#include <bitset>
+#include <vector>
+#include <string>
+
+// Adapted from DBoW2 FBrief.h
+namespace DBoW2 {
+
+/// Functions to manipulate BRIEF descriptors
+class FBrisk : protected FClass {
+ public:
+  static const int L = 512;  // Descriptor length (in bits)
+  typedef std::bitset<L> TDescriptor;
+  typedef const TDescriptor* pDescriptor;
+
+  /**
+   * Calculates the mean value of a set of descriptors
+   * @param descriptors
+   * @param mean mean descriptor
+   */
+  static void meanValue(const std::vector<pDescriptor>& descriptors, TDescriptor& mean);
+
+  /**
+   * Calculates the distance between two descriptors
+   * @param a
+   * @param b
+   * @return distance
+   */
+  static double distance(const TDescriptor& a, const TDescriptor& b);
+
+  /**
+   * Returns a string version of the descriptor
+   * @param a descriptor
+   * @return string version
+   */
+  static std::string toString(const TDescriptor& a);
+
+  /**
+   * Returns a descriptor from a string
+   * @param a descriptor
+   * @param s string version
+   */
+  static void fromString(TDescriptor& a, const std::string& s);
+
+  /**
+   * Returns a mat with the descriptors in float format
+   * @param descriptors
+   * @param mat (out) NxL 32F matrix
+   */
+  static void toMat32F(const std::vector<TDescriptor>& descriptors, cv::Mat& mat);
+};
+}  // namespace DBoW2
+
+#endif  // SPARSE_MAPPING_FBRISK_H_

--- a/localization/sparse_mapping/src/FBrisk.cc
+++ b/localization/sparse_mapping/src/FBrisk.cc
@@ -1,0 +1,91 @@
+/* Copyright (c) 2017, United States Government, as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ *
+ * All rights reserved.
+ *
+ * The Astrobee platform is licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <sparse_mapping/FBrisk.h>
+
+#include <vector>
+#include <string>
+#include <sstream>
+
+// Adapted from DBoW2 FBrief.cc
+namespace DBoW2 {
+
+// --------------------------------------------------------------------------
+
+void FBrisk::meanValue(const std::vector<FBrisk::pDescriptor>& descriptors, FBrisk::TDescriptor& mean) {
+  mean.reset();
+
+  if (descriptors.empty()) return;
+
+  const int N2 = descriptors.size() / 2;
+
+  std::vector<int> counters(FBrisk::L, 0);
+
+  std::vector<FBrisk::pDescriptor>::const_iterator it;
+  for (it = descriptors.begin(); it != descriptors.end(); ++it) {
+    const FBrisk::TDescriptor& desc = **it;
+    for (int i = 0; i < FBrisk::L; ++i) {
+      if (desc[i]) counters[i]++;
+    }
+  }
+
+  for (int i = 0; i < FBrisk::L; ++i) {
+    if (counters[i] > N2) mean.set(i);
+  }
+}
+
+// --------------------------------------------------------------------------
+
+double FBrisk::distance(const FBrisk::TDescriptor& a, const FBrisk::TDescriptor& b) {
+  return static_cast<double>(a ^ b).count();
+}
+
+// --------------------------------------------------------------------------
+
+std::string FBrisk::toString(const FBrisk::TDescriptor& a) {
+  return a.to_string();  // reversed
+}
+
+// --------------------------------------------------------------------------
+
+void FBrisk::fromString(FBrisk::TDescriptor& a, const std::string& s) {
+  std::stringstream ss(s);
+  ss >> a;
+}
+
+// --------------------------------------------------------------------------
+
+void FBrisk::toMat32F(const std::vector<TDescriptor>& descriptors, cv::Mat& mat) {
+  if (descriptors.empty()) {
+    mat.release();
+    return;
+  }
+
+  const int N = descriptors.size();
+
+  mat.create(N, FBrisk::L, CV_32F);
+
+  for (int i = 0; i < N; ++i) {
+    const TDescriptor& desc = descriptors[i];
+    float* p = mat.ptr<float>(i);
+    for (int j = 0; j < FBrisk::L; ++j, ++p) {
+      *p = (desc[j] ? 1.f : 0.f);
+    }
+  }
+}
+}  // namespace DBoW2


### PR DESCRIPTION
Currently the sparse map uses BRIEF database descriptors for the DBOW2 image database since no BRISK feature is provided by DBOW2.  However, the DBOW2 BRIEF length is only half as long as our BRISK features, so the latter half of our BRISK descriptors are not being using when building and querying the database. This fix changes the descriptor length to 512 (from 256 for BRIEF) so that the entire BRISK feature is used for the DBOW2 database creation and image queries. This currently only affects localization since the database isn't being used during mapping.  