### PR TITLE
View Map Poses

### DIFF
--- a/localization/sparse_mapping/build_map_from_multiple_bags.md
+++ b/localization/sparse_mapping/build_map_from_multiple_bags.md
@@ -28,12 +28,20 @@ Run
 
 This builds individual maps in parallel for each spliced bag in the directory. The mapping process first removes low movement images from a bagfile to prevent triangulation issues and make the mapping process more efficient, then builds a surf map (detects image features, matches features, runs incremental bundle adjustment using successive images, runs a final round of bundle adjustment on the whole map).
 
+View the map poses using  
+`rosrun sparse_mapping nvm_visualize -only_poses`
+to ensure the maps were built successfully.
+
 
 ### 4. Merge SURF maps
 A common merge strategy for a set of movements is to identify the longest movement that covers the most of an area and incrementally merge in maps that have sufficient overlap with this. Use:    
 `rosrun sparse_mapping merge_maps larger_map_name smaller_map_name -output_map combined_map_name -num_image_overlaps_at_endpoints 1000000`
 
 First merge the new movements together using the above strategy, then optionally merge the resultant combined new movements map into an already existing map (that has some overlap with the new combined movements maps). 
+
+View the resulting map poses using  
+`rosrun sparse_mapping nvm_visualize -only_poses`
+to ensure the maps were built successfully.
 
 ### 5. Register SURF map using provided world points
 Since mapping is perfomed using monocular images, no set scale is provied and the map needs to be registered using real world points before being used for localization. Additionally, providing known point locations for images in the map can improve the accuracy of the map creation. 

--- a/localization/sparse_mapping/tools/nvm_visualize.cc
+++ b/localization/sparse_mapping/tools/nvm_visualize.cc
@@ -39,6 +39,8 @@
 #include <fstream>
 #include <sstream>
 
+DEFINE_bool(only_poses, false,
+            "Only view camera poses in 3D.");
 DEFINE_bool(jump_to_3d_view, false,
             "Skip displaying images and features, go directly to the 3D view.");
 DEFINE_bool(skip_3d_points, false,
@@ -495,7 +497,8 @@ int main(int argc, char** argv) {
     return 0;
   }
 
-  if (FLAGS_jump_to_3d_view) {
+  if (FLAGS_only_poses) {
+    FLAGS_jump_to_3d_view = true;
     FLAGS_skip_3d_points = true;
     FLAGS_skip_3d_images = true;
   }

--- a/localization/sparse_mapping/tools/nvm_visualize.cc
+++ b/localization/sparse_mapping/tools/nvm_visualize.cc
@@ -495,6 +495,11 @@ int main(int argc, char** argv) {
     return 0;
   }
 
+  if (FLAGS_jump_to_3d_view) {
+    FLAGS_skip_3d_points = true;
+    FLAGS_skip_3d_images = true;
+  }
+
   // Do a visualization of all the projected keypoints into the
   // cameras. Navigate with the arrow keys or with 'a' and 'd'. Press
   // 'c' to show the cameras and points in 3D.


### PR DESCRIPTION
Added an option to just view map poses.  Also fixed an issue where if the map visualizer is called from a different directory relative to where the map was built, the user can still view just the map poses (before the images were always loaded and on a failure this would prevent viewing the map poses).

@amoravargas 