### PR TITLE
rosbag_fix_all.py: make it easier to clean up failed output bags

### DIFF
--- a/tools/bag_processing/scripts/Makefile.rosbag_fix_all
+++ b/tools/bag_processing/scripts/Makefile.rosbag_fix_all
@@ -52,8 +52,18 @@ endif
 %.rewrite_types.bag: %.bag
 	${REWRITE_TYPES} -v ${REWRITE_RULES} $< -o $@
 
-%.fix_all.bag: %.rewrite_types.bag
+%.fix_all_pre_check.bag: %.rewrite_types.bag
 	rosbag fix $< $@ ${BMR}
 	rm $<  # explicitly delete right away to save disk space
-	rosbag check $@  # test: post-migration consistency
-	${ROSBAG_VERIFY} ${ROSBAG_VERIFY_ARGS} $@ $(@:.fix_all.bag=.bag)
+
+# The fix_all_check targets are .PHONY but too much trouble and not
+# necessary to declare that.
+
+fix_all_check1-%: %.fix_all_pre_check.bag
+	rosbag check $<
+
+fix_all_check2-%: %.fix_all_pre_check.bag
+	${ROSBAG_VERIFY} ${ROSBAG_VERIFY_ARGS} $< $(<:.fix_all_pre_check.bag=.bag)
+
+%.fix_all.bag: %.fix_all_pre_check.bag fix_all_check1-% fix_all_check2-%
+	mv $< $@  # checks complete

--- a/tools/bag_processing/scripts/rosbag_fix_all.py
+++ b/tools/bag_processing/scripts/rosbag_fix_all.py
@@ -40,7 +40,7 @@ def dosys(cmd):
 def rosbag_fix_all(inbag_paths_in, jobs, deserialize=False):
     this_folder = os.path.dirname(os.path.realpath(__file__))
     makefile = os.path.join(this_folder, "Makefile.rosbag_fix_all")
-    inbag_paths = [p for p in inbag_paths_in if not p.endswith(".fix_all.bag")]
+    inbag_paths = [p for p in inbag_paths_in if not ".fix_all" in p]
     skip_count = len(inbag_paths_in) - len(inbag_paths)
     if skip_count:
         logging.info(
@@ -67,6 +67,12 @@ def rosbag_fix_all(inbag_paths_in, jobs, deserialize=False):
             logging.info("  %s", outbag_path)
     else:
         logging.warning("Not all bags were fixed successfully (see errors above).")
+        logging.warning(
+            "You can debug any failed output bags - ending in .fix_all_pre_check.bag"
+        )
+        logging.warning(
+            "If you want to try again, clean first: rm *.fix_all_pre_check.bag"
+        )
 
     return ret
 


### PR DESCRIPTION
With this update, at the end of a `rosbag_fix_all.py` run, any output bags that fail validation can be easily distinguished from the valid ones because they end in `.fix_all_pre_check.bag` instead of `.fix_all.bag`. You can debug what went wrong or easily clean them all up before trying again. And the script now outputs a helpful message that explains what is going on.

(Marina found the old behavior to be a big pain when any bags failed to migrate.)
