### PR TITLE
fixing docker run display commands

### DIFF
--- a/scripts/docker/run.sh
+++ b/scripts/docker/run.sh
@@ -169,10 +169,10 @@ if [ "$display" = "true" ]; then
     XAUTH=/tmp/.docker.xauth
     touch $XAUTH
     xauth nlist $DISPLAY | sed -e 's/^..../ffff/' | xauth -f $XAUTH nmerge -
-    display_args+=" --volume=$XSOCK:$XSOCK:rw"
-    display_args+=" --volume=$XAUTH:$XAUTH:rw"
-    display_args+=" --env=\"XAUTHORITY=${XAUTH}\""
-    display_args+=" --env=\"DISPLAY\""
+    display_args+=" --volume="$XSOCK":"$XSOCK":rw"
+    display_args+=" --volume="$XAUTH":"$XAUTH":rw"
+    display_args+=" --env=XAUTHORITY="${XAUTH}
+    display_args+=" --env=DISPLAY"
     display_args+=" --gpus all"
 fi
 


### PR DESCRIPTION
Fixing issue https://github.com/nasa/astrobee/issues/513 for bionic
Seems like the display settings were not being parsed properly

This bug was introduced in https://github.com/nasa/astrobee/pull/458