### PR TITLE
Set crop to zero properly

### DIFF
--- a/localization/camera/src/camera_params.cc
+++ b/localization/camera/src/camera_params.cc
@@ -146,6 +146,7 @@ camera::CameraParameters::CameraParameters(config_reader::ConfigReader* config, 
   SetUndistortedSize(size);
 
   // right now all our crops are zero
+  crop_offset_.setZero();
   // ff_common::ConfigReader::Table crop_table(&camera, "crop");
   // // Read in crop offset
   // if (!crop_table.GetInt("x", &size[0]))


### PR DESCRIPTION
If using this loader for `camera_params`, then `crop_offset_` is never set, which means it receives an undefined value.