### PR TITLE
Change physics engine option

### DIFF
--- a/astrobee/launch/controller/sim_start.launch
+++ b/astrobee/launch/controller/sim_start.launch
@@ -21,6 +21,7 @@
   <arg name="vmware" default="true" />
   <arg name="speed" default="1" />
   <arg name="debug" default="false" />
+  <arg name="physics" default="ode"/>
   <!-- Fix for running in vmware with DRI -->
   <env if="$(arg vmware)" name="SVGA_VGPU10" value="0" />
   <!-- Launch the requested world -->
@@ -29,5 +30,6 @@
     <arg name="gui" value="$(arg sviz)"/>
     <arg name="speed" value="$(arg speed)" />
     <arg name="debug" value="$(arg debug)" />
+    <arg name="physics" value="$(arg physics)"/>
   </include>
 </launch>

--- a/astrobee/launch/sim.launch
+++ b/astrobee/launch/sim.launch
@@ -28,6 +28,7 @@
   <arg name="nodes" default=""/>                <!-- Launch specific nodes   -->
   <arg name="extra" default=""/>                <!-- Inject additional node  -->
   <arg name="debug" default=""/>                <!-- Debug node group        -->
+  <arg name="physics" default="ode"/>           <!-- Physics engine          -->
   <arg name="sim" default="local" />            <!-- SIM IP address          -->
   <arg name="llp" default="local" />            <!-- LLP IP address          -->
   <arg name="mlp" default="local" />            <!-- MLP IP address          -->
@@ -142,6 +143,7 @@
     <arg name="vmware" value="$(arg vmware)" />
     <arg name="speed" value="$(arg speed)" />
     <arg name="debug" value="$(arg sdebug)" />
+    <arg name="physics" value="$(arg physics)" />
   </include>
 
   <!-- Auto-inert platform #1 at a desired initial location -->
@@ -183,6 +185,7 @@
       <arg name="llp" value="$(arg llp)" />          <!-- LLP IP address     -->
       <arg name="mlp" value="$(arg mlp)" />          <!-- MLP IP address     -->
       <arg name="dds" value="$(arg dds)" />          <!-- Enable DDS         -->
+      <arg name="ground_truth_localizer" value="$(arg ground_truth_localizer)" /> <!-- Use Ground Truth Localizer    -->
     </include>
   </group>
 
@@ -205,6 +208,7 @@
       <arg name="llp" value="$(arg llp)" />          <!-- LLP IP address     -->
       <arg name="mlp" value="$(arg mlp)" />          <!-- MLP IP address     -->
       <arg name="dds" value="$(arg dds)" />          <!-- Enable DDS         -->
+      <arg name="ground_truth_localizer" value="$(arg ground_truth_localizer)" /> <!-- Use Ground Truth Localizer    -->
     </include>
   </group>
 
@@ -227,6 +231,7 @@
       <arg name="llp" value="$(arg llp)" />          <!-- LLP IP address     -->
       <arg name="mlp" value="$(arg mlp)" />          <!-- MLP IP address     -->
       <arg name="dds" value="$(arg dds)" />          <!-- Enable DDS         -->
+      <arg name="ground_truth_localizer" value="$(arg ground_truth_localizer)" /> <!-- Use Ground Truth Localizer    -->
     </include>
   </group>
 

--- a/simulation/launch/start_simulation.launch
+++ b/simulation/launch/start_simulation.launch
@@ -21,6 +21,7 @@
   <arg name="world" default="worlds/empty.world"/>
   <arg name="speed" default="1"/>
   <arg name="debug" default="false"/>
+  <arg name="physics" default="ode"/>
 
   <!-- Use simulation time -->
   <param name="/use_sim_time" value="true" />
@@ -35,7 +36,7 @@
   <group unless="$(arg debug)">
     <node name="gazebo" pkg="astrobee_gazebo" type="start_server"
           respawn="false" output="screen"
-          args="$(arg world)" />
+          args="-e $(arg physics) $(arg world)" />
   </group>
 
   <!-- start gazebo client -->

--- a/simulation/worlds/iss.world
+++ b/simulation/worlds/iss.world
@@ -1,7 +1,13 @@
 <sdf version='1.6'>
   <world name='default'>
 
-    <physics name='default_physics' default='0' type='ode'>
+    <physics name='default_physics' default='1' type='ode'>
+      <max_step_size>0.008</max_step_size>
+      <real_time_factor>1</real_time_factor>
+      <real_time_update_rate>125</real_time_update_rate>
+    </physics>
+
+    <physics name='dart_physics' default='0' type='dart'>
       <max_step_size>0.008</max_step_size>
       <real_time_factor>1</real_time_factor>
       <real_time_update_rate>125</real_time_update_rate>


### PR DESCRIPTION
Adding the option to change the physics engine when starting simulation
Because https://answers.gazebosim.org/question/16241/ray-sensor-doesnt-work-properly-with-dart/ added random dist for sparse mapping plugin