### PR TITLE
Add some features to merge_bags, and documentation to merge_bags, import_map, export_map

### DIFF
--- a/localization/localization_node/tools/merge_bags.cc
+++ b/localization/localization_node/tools/merge_bags.cc
@@ -45,9 +45,9 @@
 DEFINE_string(output_bag, "", "The output bag.");
 DEFINE_double(start_time, -1.0, "If non-negative, start at this time, measured in "
               "seconds since epoch.");
-DEFINE_double(end_time, -1.0, "If non-negative, stop before this time, measured in "
+DEFINE_double(stop_time, -1.0, "If non-negative, stop before this time, measured in "
               "seconds since epoch.");
-DEFINE_string(save_topics, "", "if non-empty, the topics to write. Use quotes and a space "
+DEFINE_string(save_topics, "", "If non-empty, the topics to write. Use quotes and a space "
               "as separator. Example: '/hw/cam_nav /hw/cam_sci'.");
 DEFINE_double(min_time_spacing, -1.0,
               "If non-negative, for each input bag, keep only messages for a given topic which differ by no less than "
@@ -108,7 +108,7 @@ int main(int argc, char ** argv) {
     return 1;
   }
 
-  bool time_range_filter = (FLAGS_start_time >= 0 && FLAGS_end_time >= 0);
+  bool time_range_filter = (FLAGS_start_time >= 0 && FLAGS_stop_time >= 0);
 
   std::set<std::string> save_topics;
   std::istringstream iss(FLAGS_save_topics);
@@ -181,7 +181,7 @@ int main(int argc, char ** argv) {
       double curr_time = headerOrMessageTime(m);
 
       // Filter by time range, if specified
-      if (time_range_filter && (curr_time < FLAGS_start_time || curr_time >= FLAGS_end_time))
+      if (time_range_filter && (curr_time < FLAGS_start_time || curr_time >= FLAGS_stop_time))
         continue;
 
       // Filter by spacing

--- a/localization/sparse_mapping/CMakeLists.txt
+++ b/localization/sparse_mapping/CMakeLists.txt
@@ -142,6 +142,12 @@ add_dependencies(import_map ${catkin_EXPORTED_TARGETS})
 target_link_libraries(import_map
   sparse_mapping gflags glog ${catkin_LIBRARIES})
 
+## Declare a C++ executable: export_map
+add_executable(export_map tools/export_map.cc)
+add_dependencies(export_map ${catkin_EXPORTED_TARGETS})
+target_link_libraries(export_map
+  sparse_mapping gflags glog ${catkin_LIBRARIES})
+
 ## Declare a C++ executable: localize_cams
 add_executable(localize_cams tools/localize_cams.cc)
 add_dependencies(localize_cams ${catkin_EXPORTED_TARGETS})

--- a/localization/sparse_mapping/export_map.md
+++ b/localization/sparse_mapping/export_map.md
@@ -1,0 +1,27 @@
+\page export_map Exporting a map to the .nvm format
+
+# Overview
+
+The ``export_map`` tool is used to export a map from an Astrobee .map
+file in Protobuf format to the plain text .nvm file format. 
+
+This tool does not export the camera intrinsics and image descriptors,
+but only the list of images, the position and orientation of each
+camera, and the interest point matches (tracks). The obtained .nvm
+file can be imported back with the \ref import_map tool.
+
+The interest points are offset relative to the optical center.
+
+Example:
+
+    $HOME/astrobee/devel/lib/sparse_mapping/export_map  \
+      -input_map input.map                              \
+      -output_map output.nvm
+
+Command line options:
+
+-input_map <string (default="")>
+    Input sparse map file, in Astrobee's protobuf format, with .map
+      extension.
+-output_map <string (default="")>
+    Output sparse map in NVM format.

--- a/localization/sparse_mapping/export_map.md
+++ b/localization/sparse_mapping/export_map.md
@@ -7,10 +7,13 @@ file in Protobuf format to the plain text .nvm file format.
 
 This tool does not export the camera intrinsics and image descriptors,
 but only the list of images, the position and orientation of each
-camera, and the interest point matches (tracks). The obtained .nvm
-file can be imported back with the \ref import_map tool.
+camera, and the interest point matches (tracks). 
 
-The interest points are offset relative to the optical center.
+The obtained .nvm file can be imported back with the \ref import_map
+tool.
+
+The interest points are offset relative to the optical center, per the 
+NVM format convention.
 
 Example:
 

--- a/localization/sparse_mapping/import_map.md
+++ b/localization/sparse_mapping/import_map.md
@@ -1,0 +1,97 @@
+\page import_map Importing a map in .nvm format
+
+# Overview
+
+The ``import_map`` tool is used to import a map from the NVM format,
+which Theia and other SfM packages export to, to Astrobee's .map
+format. The \ref export_map program does the reverse operation.
+
+It is assumed that the NVM map was built with nav_cam images, which
+were either undistorted or distorted (original ones), and that the
+name of the robot which acquired the images is known.
+
+In either case, the NVM file does not store descriptors, so 
+a map needs to be rebuilt after it is imported. 
+
+# Import an nvm map made with distorted images
+
+Run:
+
+    export ASTROBEE_ROBOT=bumble
+    astrobee/devel/lib/sparse_mapping/import_map                             \
+      -undistorted_camera_params "wid_x wid_y focal_len opt_ctr_x opt_ctr_y" \
+      <undistorted images>                                                   \
+      -input_map map.nvm -output_map map.map
+
+See further down about how to rebuild the imported map.
+    
+# Import an nvm map made with undistorted images
+
+There are two cases to consider.
+
+## Keep, after importing, the undistorted images and camera model
+ 
+Run:
+
+    export ASTROBEE_ROBOT=bumble
+    astrobee/devel/lib/sparse_mapping/import_map                             \
+      -undistorted_camera_params "wid_x wid_y focal_len opt_ctr_x opt_ctr_y" \
+      <undistorted images>                                                   \
+      -input_map map.nvm -output_map map.map
+
+It is very important that the robot name be specified corretly.
+
+It is assumed that the images were acquired with the nav camera of the
+robot given by $ASTROBEE_ROBOT and undistorted with the Astrobee
+program ``undistort_image``. The undistorted camera parameters to use
+should be as printed on the screen (and saved to disk) by
+``undistort_image``.
+
+## Replace, on importing, the camera model and the images
+
+If desired to replace on importing the undistorted images with the
+original distorted ones, and same for the camera parameters, as it is
+usually expected of a sparse map, the above command should be called
+instead as:
+   
+    export ASTROBEE_ROBOT=bumble
+    astrobee/devel/lib/sparse_mapping/import_map \
+      -undistorted_images_list undist_list.txt   \
+      -distorted_images_list dist_list.txt       \
+      -input_map map.nvm -output_map map.map
+
+Here, the files ``undist_list.txt`` and ``dist_list.txt`` must have
+one image per line and be in one-to-one correspondence. It is
+important that both undistorted and distorted images be specified, as
+the former are needed to look up camera poses and other data in the
+.nvm file before being replaced with the distorted ones.
+
+It is very important to note that the interest point matches will not
+be correct. Only the image names, robot camera parameters, and camera
+poses will be accurate. So, this map should be rebuilt right away. 
+
+# Rebuilding an imported map
+
+To rebuild an imported map while keeping the camera poses read from
+the nvm file, run:
+
+    export ASTROBEE_ROBOT=bumble
+    build_map -rebuild -rebuild_detector SURF \
+     -output_map map.map 
+
+To also reoptimize the camera poses, add the option: 
+
+    -rebuild_refloat_cameras
+
+Do not use this option with the BRISK detector, as this detector may
+not create enough features for the camera poses to be optimized
+correctly.
+
+Note that if the NVM file is created by Theia, it may have the image
+names be specified without the path to the directory having them (that
+is, instead of image_dir/image1.jpg it may list just image1.jpg). Then
+this NVM file needs to be edited manually to add the correct path to
+the images before running the import tool.
+
+This is taken care of if both ``-undistorted_images_list`` and
+``-distorted_images_list`` are specified.

--- a/localization/sparse_mapping/import_map.md
+++ b/localization/sparse_mapping/import_map.md
@@ -18,9 +18,7 @@ a map needs to be rebuilt after it is imported.
 Run:
 
     export ASTROBEE_ROBOT=bumble
-    astrobee/devel/lib/sparse_mapping/import_map                             \
-      -undistorted_camera_params "wid_x wid_y focal_len opt_ctr_x opt_ctr_y" \
-      <undistorted images>                                                   \
+    astrobee/devel/lib/sparse_mapping/import_map \
       -input_map map.nvm -output_map map.map
 
 See further down about how to rebuild the imported map.
@@ -47,7 +45,7 @@ program ``undistort_image``. The undistorted camera parameters to use
 should be as printed on the screen (and saved to disk) by
 ``undistort_image``.
 
-## Replace, on importing, the camera model and the images
+## Replace with distorted data
 
 If desired to replace on importing the undistorted images with the
 original distorted ones, and same for the camera parameters, as it is
@@ -67,8 +65,9 @@ the former are needed to look up camera poses and other data in the
 .nvm file before being replaced with the distorted ones.
 
 It is very important to note that the interest point matches will not
-be correct. Only the image names, robot camera parameters, and camera
-poses will be accurate. So, this map should be rebuilt right away. 
+be correct, as they are left undistorted. Only the image names, robot
+camera parameters, and camera poses will be accurate. So, this map
+should be rebuilt right away.
 
 # Rebuilding an imported map
 
@@ -91,7 +90,7 @@ Note that if the NVM file is created by Theia, it may have the image
 names be specified without the path to the directory having them (that
 is, instead of image_dir/image1.jpg it may list just image1.jpg). Then
 this NVM file needs to be edited manually to add the correct path to
-the images before running the import tool.
+the images before running the import tool. This is taken care of if
+both ``-undistorted_images_list`` and ``-distorted_images_list`` are
+specified.
 
-This is taken care of if both ``-undistorted_images_list`` and
-``-distorted_images_list`` are specified.

--- a/localization/sparse_mapping/import_map.md
+++ b/localization/sparse_mapping/import_map.md
@@ -64,6 +64,10 @@ important that both undistorted and distorted images be specified, as
 the former are needed to look up camera poses and other data in the
 .nvm file before being replaced with the distorted ones.
 
+This use case was tested only with a map exported by Theia, 
+which records the images without a directory path, so that is how
+they should be specified in the undistorted image list as well. 
+
 It is very important to note that the interest point matches will not
 be correct, as they are left undistorted. Only the image names, robot
 camera parameters, and camera poses will be accurate. So, this map

--- a/localization/sparse_mapping/include/sparse_mapping/ransac.h
+++ b/localization/sparse_mapping/include/sparse_mapping/ransac.h
@@ -128,8 +128,10 @@ class RandomSampleConsensus {
           if (!m_reduce_min_num_output_inliers_if_no_fit)
             break;
           reduce_min_num_output_inliers();
-           // Can't possibly compute a transform with 1 or 0 samples!
-          if (m_min_num_output_inliers < 2)
+          // Can't possibly compute a transform with less than 3 samples
+          // TODO(oalexan1): The number 3 works only for similarity transforms,
+          // for others a different number may be needed.
+          if (m_min_num_output_inliers < 3)
             break;
           LOG(INFO) << "Attempting RANSAC with " << m_min_num_output_inliers
                     << " output inliers.\n";

--- a/localization/sparse_mapping/include/sparse_mapping/ransac.h
+++ b/localization/sparse_mapping/include/sparse_mapping/ransac.h
@@ -128,9 +128,7 @@ class RandomSampleConsensus {
           if (!m_reduce_min_num_output_inliers_if_no_fit)
             break;
           reduce_min_num_output_inliers();
-          // Can't possibly compute a transform with less than 3 samples
-          // TODO(oalexan1): The number 3 works only for similarity transforms,
-          // for others a different number may be needed.
+          // A similarity transform needs at least 3 samples
           if (m_min_num_output_inliers < 3)
             break;
           LOG(INFO) << "Attempting RANSAC with " << m_min_num_output_inliers

--- a/localization/sparse_mapping/include/sparse_mapping/sparse_map.h
+++ b/localization/sparse_mapping/include/sparse_mapping/sparse_map.h
@@ -83,6 +83,7 @@ bool Localize(cv::Mat const& test_descriptors,
  **/
 struct SparseMap {
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
   /**
    * Constructs a new sparse map from a list of image files and their
    * associate keypoint and descriptor files. If use_cached_features
@@ -300,10 +301,14 @@ struct SparseMap {
   std::mutex mutex_detector_;
 
  private:
+  // Create an empty map. It is strongly recommended to not use this function,
+  // as it requires carefully initializing many members. Hence this is made
+  // private. Consider using the other constructors.
+  SparseMap();
+
   // I found out the hard way that sparse maps cannot be copied
   // correctly, hence prohibit this. The only good way seems to be to
   // load a copy from disk. (oalexan1)
-  SparseMap();
   SparseMap(SparseMap &);
   SparseMap& operator=(const SparseMap&);
 

--- a/localization/sparse_mapping/merge_bags.md
+++ b/localization/sparse_mapping/merge_bags.md
@@ -1,0 +1,36 @@
+\page merge_bags Merge bags
+
+Often times an Astrobee recording is in multiple bags, so those need
+to be merged before further processing. There exist two tools for
+that: this one, ``merge_bags``, written in C++, and ``merge_bags.py``,
+written in Python. The C++ tool, which is documented here, is more
+robust, as apparently the Python one may fail if certain topics are
+present in the the input bag files.
+
+The ``merge_bags`` program is also more versatile. It can filter
+images by acquisition time range, topic, and can keep only one image
+for a given time interval (useful if the images are too frequent).
+
+The acquisition time for an image or point cloud message is determined
+from the timestamp field in the header of that message, which is more
+reliable than extracting it from the message time itself.
+
+Example:
+
+    merge_bags bag1.bag bag2.bag -output_bag merged_bag.bag
+
+Command-line options:
+
+-output_bag <string (default="")>
+  The output bag.
+-start_time <double (default=-1.0)>
+  If non-negative, start at this time, measured in seconds since epoch.
+-stop_time <double (default=-1.0)>
+  If non-negative, stop before this time, measured in seconds since epoch.
+-save_topics <string (default="")>
+  If non-empty, the topics to write. Use quotes and a space as separator. 
+  Example: '/hw/cam_nav /hw/cam_sci'.
+-min_time_spacing <double (default=-1.0)>
+  If non-negative, for each input bag, keep only messages for a given topic 
+  which differ by no less than this time amount, in seconds. Assumes that 
+  messages in a bag are stored in ascending order of time.

--- a/localization/sparse_mapping/readme.md
+++ b/localization/sparse_mapping/readme.md
@@ -326,12 +326,20 @@ the two maps can be first merged with the same small map of that
 shared location, and then the newly merged map which now will have
 shared images can be merged with the `-fast_merge` flags.
 
+The `-fast_merge` option assumes that a decent number of images
+are shared among the maps, and that those cover a reasonably large
+and representative portion of the desired environment, otherwise
+it may not give accurate results. In either case, bundle adjustment
+must be applied after the merge operations are done and before
+registration, which can be done either with ``merge_maps`` or
+``build_map``.
+  
 To summarize, with careful map surgery (extract submaps and merge
 submaps) large maps can be made from smaller or damaged ones within
 reasonable time.
 
-All these operations should be performed on maps with SURF features.
-Hence the general approach for building maps is to create small SURF
+All these operations should be applied on maps with SURF features.
+Hence, the general approach for building large maps is to create small SURF
 maps using the command:
 
     build_map -feature_detection -feature_matching -track_building    \
@@ -339,8 +347,8 @@ maps using the command:
      -histogram_equalization -num_subsequent_images 100               \
      images/*jpg -output_map <map file>
 
-examine them individually, merging them as appropriate, then
-performing bundle adjustment and registration as per the \ref
+Then, examine the maps individually, merge them as appropriate, and
+perform bundle adjustment and registration as per the \ref
 map_building section. Only when a good enough map is obtained, a
 renamed copy of it should be rebuilt with BRISK features and a
 vocabulary database to be used on the robot.

--- a/localization/sparse_mapping/readme.md
+++ b/localization/sparse_mapping/readme.md
@@ -91,6 +91,11 @@ as follows:
     $ASTROBEE_BUILD_PATH/devel/lib/localization_node/merge_bags \
       -output_bag <output bag> <input bags>
 
+This tool can also save images only in a given time range, and 
+filter out some images, for example, by keeping only one image per second.
+
+See \ref merge_bags for the full documentation.
+
 ### Extracting images
 
 To extract images from a bag file:
@@ -510,3 +515,6 @@ added back to it.
 \subpage granite_lab_registration
 \subpage faro
 \subpage theia_map
+\subpage import_map
+\subpage export_map
+\subpage merge_bags

--- a/localization/sparse_mapping/src/sparse_map.cc
+++ b/localization/sparse_mapping/src/sparse_map.cc
@@ -123,21 +123,23 @@ SparseMap::SparseMap(const std::vector<Eigen::Affine3d>& cid_to_cam_t,
 
 // Form a sparse map by reading a text file from disk. This is for comparing
 // bundler, nvm or theia maps.
-SparseMap::SparseMap(bool bundler_format, std::string const& filename, std::vector<std::string> const& all_image_files)
-    : camera_params_(Eigen::Vector2i(640, 480), Eigen::Vector2d::Constant(300),
-                     Eigen::Vector2d(320, 240)),  // these are placeholders and must be changed
-      num_similar_(FLAGS_num_similar),
-      num_ransac_iterations_(FLAGS_num_ransac_iterations),
-      ransac_inlier_tolerance_(FLAGS_ransac_inlier_tolerance),
-      early_break_landmarks_(FLAGS_early_break_landmarks),
-      histogram_equalization_(FLAGS_histogram_equalization) {
+SparseMap::SparseMap(bool bundler_format, std::string const& filename,
+                     std::vector<std::string> const& all_image_files):
+  camera_params_(Eigen::Vector2i(640, 480), Eigen::Vector2d::Constant(300),
+                 Eigen::Vector2d(320, 240)),  // these are placeholders and must be changed
+  num_similar_(FLAGS_num_similar),
+  num_ransac_iterations_(FLAGS_num_ransac_iterations),
+  ransac_inlier_tolerance_(FLAGS_ransac_inlier_tolerance),
+  early_break_landmarks_(FLAGS_early_break_landmarks),
+  histogram_equalization_(FLAGS_histogram_equalization) {
   std::string ext = ff_common::file_extension(filename);
   boost::to_lower(ext);
 
   if (ext == "nvm") {
     std::cout << "NVM format detected." << std::endl;
 
-    sparse_mapping::ReadNVM(filename, &cid_to_keypoint_map_, &cid_to_filename_, &pid_to_cid_fid_, &pid_to_xyz_,
+    sparse_mapping::ReadNVM(filename, &cid_to_keypoint_map_, &cid_to_filename_,
+                            &pid_to_cid_fid_, &pid_to_xyz_,
                             &cid_to_cam_t_global_);
 
     // Descriptors are not saved, so let them be empty

--- a/localization/sparse_mapping/src/sparse_mapping.cc
+++ b/localization/sparse_mapping/src/sparse_mapping.cc
@@ -701,7 +701,7 @@ void sparse_mapping::ParseHuginControlPoints(std::string const& hugin_file,
                                              Eigen::MatrixXd * points) {
   // Initialize the outputs
   (*images).clear();
-  *points = Eigen::MatrixXd(6, 1);
+  *points = Eigen::MatrixXd(6, 0);  // this will be resized as points are added
 
   std::ifstream hf(hugin_file.c_str());
   if (!hf.good())

--- a/localization/sparse_mapping/src/sparse_mapping.cc
+++ b/localization/sparse_mapping/src/sparse_mapping.cc
@@ -129,15 +129,15 @@ bool sparse_mapping::IsBinaryDescriptor(std::string const& descriptor) {
 }
 
 // Writes the NVM control network format.
-void sparse_mapping::WriteNVM(std::vector<Eigen::Matrix2Xd > const& cid_to_keypoint_map,
+void sparse_mapping::WriteNVM(std::vector<Eigen::Matrix2Xd> const& cid_to_keypoint_map,
                               std::vector<std::string> const& cid_to_filename,
-                              std::vector<std::map<int, int> > const& pid_to_cid_fid,
+                              std::vector<std::map<int, int>> const& pid_to_cid_fid,
                               std::vector<Eigen::Vector3d> const& pid_to_xyz,
                               std::vector<Eigen::Affine3d> const&
-                              cid_to_cam_t_global,
-                              double focal_length,
+                              cid_to_cam_t_global, double focal_length,
                               std::string const& output_filename) {
   std::fstream f(output_filename, std::ios::out);
+  f.precision(17);  // use high precision since we will write positions and orientations
   f << "NVM_V3\n";
 
   CHECK(cid_to_filename.size() == cid_to_keypoint_map.size())

--- a/localization/sparse_mapping/theia_map.md
+++ b/localization/sparse_mapping/theia_map.md
@@ -188,38 +188,5 @@ That page also has information for how the map can be rebuilt to use
 BRISK features, and how it can be validated for localization by
 playing a bag against it.
 
-# Auxiliary import_map tool
-
-This tool is used to import a map from the NVM format, which Theia
-exports to. These operations are done automatically by the
-``build_theia_map.py`` tool. This documentation is provided for
-reference only.
- 
-An NVM map exported by Theia (or some other SfM tool) can be saved as
-an Astrobee sparse map with the command:
-
-    astrobee/devel/lib/sparse_mapping/import_map                             \
-      -undistorted_camera_params "wid_x wid_y focal_len opt_ctr_x opt_ctr_y" \
-      <undistorted images>                                                   \
-      -input_map map.nvm -output_map map.map
- 
-This assumes that the images were acquired with the nav camera of the
-robot given by $ASTROBEE_ROBOT and undistorted with the Astrobee
-program ``undistort_image``. The undistorted camera parameters to use
-should be as printed on the screen (and saved to disk) by
-``undistort_image``.
-
-If desired to replace on importing the undistorted images with the
-original distorted ones, as it is usually expected of a sparse map,
-the above command should be called instead as:
-  
-    astrobee/devel/lib/sparse_mapping/import_map \
-      -undistorted_images_list undist_list.txt   \
-      -distorted_images_list dist_list.txt       \
-      -input_map map.nvm -output_map map.map
-
-Here, the files ``undist_list.txt`` and ``dist_list.txt`` must have
-one image per line and be in one-to-one correspondence. It is
-important that both undistorted and distorted images be specified, as
-the former are needed to look up camera poses and other data in the
-.nvm file before being replaced with the distorted ones.
+The \ref import_map program is used by this tool to import a sparse
+map from Theia's format.

--- a/localization/sparse_mapping/tools/export_map.cc
+++ b/localization/sparse_mapping/tools/export_map.cc
@@ -1,0 +1,63 @@
+/* Copyright (c) 2017, United States Government, as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ *
+ * All rights reserved.
+ *
+ * The Astrobee platform is licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+#include <ff_common/init.h>
+#include <ff_common/thread.h>
+#include <ff_common/utils.h>
+#include <sparse_mapping/tensor.h>
+#include <sparse_mapping/sparse_map.h>
+#include <sparse_mapping/sparse_mapping.h>
+
+#include <sparse_map.pb.h>
+
+#include <gflags/gflags.h>
+#include <glog/logging.h>
+
+#include <iostream>
+#include <fstream>
+#include <algorithm>
+#include <thread>
+
+// Export a map to nvm format.
+// Can be imported back with import_map
+
+DEFINE_string(input_map, "",
+              "Input sparse map file, in Astrobee's protobuf format, with .map extension.");
+DEFINE_string(output_map, "output.nvm",
+              "Output sparse map in NVM format.");
+
+int main(int argc, char** argv) {
+  ff_common::InitFreeFlyerApplication(&argc, &argv);
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  if (FLAGS_input_map == "" || FLAGS_output_map == "")
+    LOG(FATAL) << "The input and output maps were not specified.\n";
+
+  sparse_mapping::SparseMap map(FLAGS_input_map);
+
+  std::cout << "Writing: " << FLAGS_output_map << std::endl;
+  sparse_mapping::WriteNVM(map.cid_to_keypoint_map_,
+                           map.cid_to_filename_,
+                           map.pid_to_cid_fid_,
+                           map.pid_to_xyz_,
+                           map.cid_to_cam_t_global_,
+                           map.camera_params_.GetFocalLength(),
+                           FLAGS_output_map);
+
+  google::protobuf::ShutdownProtobufLibrary();
+  return 0;
+}

--- a/scripts/calibrate/readme.md
+++ b/scripts/calibrate/readme.md
@@ -3,24 +3,25 @@
 This folder contains various scripts for calibration.
 
 # Setup
+
 - Build and install the Astrobee code on the robot.
 - Install Kalibr on your computer.
 
 ## Installation instructions for Kalibr for Ubuntu 18.04
 
-sudo apt install python-rosinstall ipython python-software-properties \
-        python-git ipython python-catkin-tools
-sudo apt install libopencv-dev ros-melodic-vision-opencv
+    sudo apt install python-rosinstall ipython python-software-properties \
+            python-git ipython python-catkin-tools
+    sudo apt install libopencv-dev ros-melodic-vision-opencv
 
 # Install pip and use it to install python packages
 
 We assume that Python 2 is used.
 
-curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-sudo python get-pip.py
-sudo -H pip install testresources
-sudo -H pip install python-igraph==0.8 --upgrade
-sudo -H pip install  numpy==1.15.0 opencv-python==4.2.0.32
+    curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+    sudo python get-pip.py
+    sudo -H pip install testresources
+    sudo -H pip install python-igraph==0.8 --upgrade
+    sudo -H pip install  numpy==1.15.0 opencv-python==4.2.0.32
 
 If necessary, pip and the other packages can be installed in user
 space. The PYTHONPATH may need to be set for such packages.
@@ -29,21 +30,22 @@ The pip flags --user, --force, and --verbose may be useful.
 Kalibr uses Python 2, and many packages are transitioning to Python 3,
 so some effort may be needed to install the Python 2 dependencies.
 
-# Build using catkin
-export KALIBR_WS=$HOME/source/kalibr_workspace
-mkdir -p $KALIBR_WS/src
-cd $KALIBR_WS
-source /opt/ros/melodic/setup.bash
-catkin init
-catkin config --extend /opt/ros/melodic
-catkin config --cmake-args -DCMAKE_BUILD_TYPE=Release
-cd $KALIBR_WS/src
-git clone git@github.com:oleg-alexandrov/Kalibr.git
+    # Build using catkin
+    export KALIBR_WS=$HOME/source/kalibr_workspace
+    mkdir -p $KALIBR_WS/src
+    cd $KALIBR_WS
+    source /opt/ros/melodic/setup.bash
+    catkin init
+    catkin config --extend /opt/ros/melodic
+    catkin config --cmake-args -DCMAKE_BUILD_TYPE=Release
+    cd $KALIBR_WS/src
+    git clone git@github.com:oleg-alexandrov/Kalibr.git
 
-# This line takes care of catkin not finding numpy.
-ln -s /usr/local/lib/python2.7/dist-packages/numpy/core/include/numpy $KALIBR_WS/src/Kalibr/Schweizer-Messer/numpy_eigen/include
+    # This line takes care of catkin not finding numpy.
+    ln -s /usr/local/lib/python2.7/dist-packages/numpy/core/include/numpy \
+      $KALIBR_WS/src/Kalibr/Schweizer-Messer/numpy_eigen/include
 
-catkin build -DCMAKE_BUILD_TYPE=Release -j4
+    catkin build -DCMAKE_BUILD_TYPE=Release -j4
 
 # Prepare the environment. This is expected for all the steps below.
 
@@ -58,12 +60,12 @@ Two calibration target are in use. In the granite lab the April tag
 target can be used. It is on the dock and is a combination of AR
 tags. Its definition is in:
 
-   $SOURCE_PATH/scripts/calibrate/config/granite_april_tag.yaml
+    $SOURCE_PATH/scripts/calibrate/config/granite_april_tag.yaml
 
 Calibration on the ISS uses a checkerboard pattern. That one is
 defined in:
 
-  $SOURCE_PATH/scripts/calibrate/config/iss_checkerboard.yaml
+    $SOURCE_PATH/scripts/calibrate/config/iss_checkerboard.yaml
 
 and has 12 rows and 7 columns of black and white squares, each one
 being of size 1 inch (2.54 cm).
@@ -85,7 +87,7 @@ config_filename: config file where the specifications of AR tags of
 the target are defined. Default value is
 dock_markers_specs.config. This will write the file:
 
-   $SOURCE_PATH/scripts/calibrate/config/granite_april_tag.yaml
+    $SOURCE_PATH/scripts/calibrate/config/granite_april_tag.yaml
 
 Note that $KALIBR_WS should be defined since the script will also
 automatically add a header file to Kalibr's directory describing the
@@ -111,13 +113,13 @@ Prepare the environment:
 
 To launch the nodes needed for calibration, do:
 
-   cd $SCRIPT_DIR
-   roslaunch calibration.launch
+    cd $SCRIPT_DIR
+    roslaunch calibration.launch
 
 On the flight unit, more specifically on MLP, do:
 
-   roslaunch astrobee astrobee.launch llp:=??? mlp:=??? \
-     nodes:=calibration_nav_cam,calibration_dock_cam,calibration_imu,pico_driver,framestore
+    roslaunch astrobee astrobee.launch llp:=??? mlp:=??? \
+      nodes:=calibration_nav_cam,calibration_dock_cam,calibration_imu,pico_driver,framestore
 
 This will start the IMU driver, camera drivers, and an image
 viewer. 
@@ -132,7 +134,7 @@ refer to the high-resolution nav and dock cameras as the HD camera.
 To be able to record the amplitude, which is necessary for haz_cam
 calibration, the file 
 
- /opt/astrobee/config/cameras.config
+    /opt/astrobee/config/cameras.config
 
 (on the robot's MLP, not on the local machine) needs to be edited
 before calibration.launch is started. The api_key variable in the
@@ -147,16 +149,16 @@ amplitude data.
 With the current default setup on the robot, this node should start
 automatically. If it did not, it can be run with the command:
 
-  roslaunch $SOURCE_PATH/hardware/pico_driver/launch/pico_proxy.launch 
+    roslaunch $SOURCE_PATH/hardware/pico_driver/launch/pico_proxy.launch 
   
  Note that on the robot itself this file is stored at:
 
- /opt/astrobee/share/pico_driver/launch/pico_proxy.launch
+    /opt/astrobee/share/pico_driver/launch/pico_proxy.launch
 
 When it is desired to record the amplitude for the perch camera,
 one should pass to roslaunch the argument:
 
-  topic:=/hw/depth_perch/extended
+    topic:=/hw/depth_perch/extended
 
 To calibrate nav_cam attached to a standalone computer, rather than
 astrobee's built in one, one can do instead:
@@ -189,7 +191,7 @@ Begin recording the bag. Example to record nav_cam and haz_cam:
 
 For the dock and perch cams, one should do:
 
-      rosbag record /hw/cam_dock /hw/depth_perch/extended/amplitude_int
+    rosbag record /hw/cam_dock /hw/depth_perch/extended/amplitude_int
 
 Move the AR tag in front of the camera. If the AR tag is only
 partially visible in some frames that is fine. Try to cover the entire


### PR DESCRIPTION
This pull request:

 - Adds a tool to export a sparse map to the nvm format and expands the tool for importing a sparse map from this format. This is a plain text format to which Theia can export to, and which is used by my rig_calibrator program. 
 -  Expand the logic of merge_bags. It can save only one message for a given topic in a given time interval (such as one image per second), can save only messages within a given time range, and looks up for images and clouds the timestamp from the header of each message (which is the creation time), rather than relying on message timestamp, which can be messed up by some bag processing tools.
 - Expanded a bit the map building documentation. 
 - Added manual pages for import_map, export_map, and merge_bags.  