### PR TITLE
Allow maps merged with --fix_fix_first_map to share imags, tune map import/export

### DIFF
--- a/localization/sparse_mapping/export_map.md
+++ b/localization/sparse_mapping/export_map.md
@@ -3,7 +3,8 @@
 # Overview
 
 The ``export_map`` tool is used to export a map from an Astrobee .map
-file in Protobuf format to the plain text .nvm file format. 
+file in Protobuf format to the plain text .nvm file format, which is a
+format used by various SfM packages, and can be exported by Theia.
 
 This tool does not export the camera intrinsics and image descriptors,
 but only the list of images, the position and orientation of each
@@ -12,8 +13,10 @@ camera, and the interest point matches (tracks).
 The obtained .nvm file can be imported back with the \ref import_map
 tool.
 
-The interest points are offset relative to the optical center, per the 
-NVM format convention.
+The interest points saved to the nvm file are offset relative to the
+optical center, per the NVM format convention. To not do that, use the
+``-no_shift`` option.  The ``import_map`` tool then must use the same
+option to import back such an .nvm file.
 
 Example:
 
@@ -28,3 +31,6 @@ Command line options:
       extension.
 -output_map <string (default="")>
     Output sparse map in NVM format.
+-no_shift
+    Save the features without shifting them relative to the optical
+    center. That makes visualizing them easier.

--- a/localization/sparse_mapping/import_map.md
+++ b/localization/sparse_mapping/import_map.md
@@ -21,6 +21,17 @@ Run:
     astrobee/devel/lib/sparse_mapping/import_map \
       -input_map map.nvm -output_map map.map
 
+The nvm file normally stores distorted interest points which are
+shifted relative to the optical center. The import operation unshifts
+these points, undistorts them, and shifts them relative to unidstored
+image center, per Astrobee sparse map conventions.
+
+If the interest points are saved with no shift relative to the optical
+center (such as done by ``export_map -no_shift), then invoke on
+importing the ``-no_shift`` option as well. The rest of the
+operations, of undistortion and shifting relative to the undistorted
+image center will still take place.
+
 See further down about how to rebuild the imported map.
     
 # Import an nvm map made with undistorted images

--- a/localization/sparse_mapping/readme.md
+++ b/localization/sparse_mapping/readme.md
@@ -262,6 +262,8 @@ need to be rebuilt for the extracted submap using
 
 ### Merge maps
 
+#### General usage
+
 Given a set of SURF maps, they can be merged using the command:
 
     merge_maps <input maps> -output_map merged.map \
@@ -282,9 +284,7 @@ in particular, if some of the same images show up at the endpoints of
 both maps. A larger value of `-num_image_overlaps_at_endpoints` may
 result in higher success but will take more time.
 
-Registration to the real-world coordinate system must be (re-)done
-after the maps are merged, as the bundle adjustment done during merging
-may move things somewhat.
+#### Registration and bundle adjustment
 
 The input maps to be merged need not be registered, but that may help
 improve the success of merging. Also, it may be preferable that
@@ -292,6 +292,10 @@ the images at the beginning and end of the maps to merge be close
 to points used in registration. The implication here is that the
 more geometrically correct the input maps are, and the more similar
 to each other, the more likely merging will succeed.
+
+Registration to the real-world coordinate system must be (re-)done
+after the maps are merged, as the bundle adjustment done during merging
+may move things somewhat.
 
 After a merged map is created and registered, it can be rebuilt with
 the BRISK detector to be used on the robot. 
@@ -302,12 +306,23 @@ be skipped during merging, using the
     -skip_bundle_adjustment
 
 option until the final map is computed, as this step can be
-time-consuming.
+time-consuming. Bundle adjustment must happen however eventually,
+before any map registration and rebuilding.
 
-If the first of the two maps to merge is already registered, it may be
-desirable to keep that portion fixed during merging when bundle
-adjustment happens. That is accomplished with the flag -fix_first_map.
-  
+#### Keeping first map fixed
+
+If there are only two maps to merge, and the first of the two maps to
+merge is already registered, it may be desirable to keep that portion
+fixed during merging when bundle adjustment happens, to avoid redoing
+the registration, and perhaps to keep consistency with other work
+already done, such as a dense map product.
+
+Then, use the flag `-fix_first_map` when merging the maps. In this case,
+if an image shows in both maps, then, once the maps are merged, the
+camera poses of the shared images will be replaced with the ones from
+the first map, before reoptimizing the remaining camera poses from the
+second map.
+
 ### How to build a map efficiently
 
 Often times map-building can take a long time, or it can fail. A

--- a/localization/sparse_mapping/tools/import_map.cc
+++ b/localization/sparse_mapping/tools/import_map.cc
@@ -34,8 +34,10 @@
 
 DEFINE_string(input_map, "",
               "Input map created with undistorted images, in a text file.");
-DEFINE_string(output_map, "output.map",
+DEFINE_string(output_map, "",
               "Output sparse map as expected by Astrobee software.");
+DEFINE_bool(no_shift, false,
+            "Import the features without shifting them relative to the optical center.");
 DEFINE_bool(bundler_map, false,
             "If true, read the Bundler format. This will be ignored for input .nvm files.");
 DEFINE_string(undistorted_camera_params, "",
@@ -74,8 +76,9 @@ namespace {
     config.AddFile("cameras.config");
     if (!config.ReadFiles()) LOG(FATAL) << "Failed to read config files.\n";
 
-    camera::CameraParameters cam_params(&config, "nav_cam");
-    map.SetCameraParameters(cam_params);
+    // Save the camera parameters for the given robot.
+    camera::CameraParameters camera_params(&config, "nav_cam");
+    map.SetCameraParameters(camera_params);
 
     // Replace the undistorted images with distorted ones
     std::vector<std::string> distorted_images;
@@ -105,6 +108,9 @@ int main(int argc, char** argv) {
   ff_common::InitFreeFlyerApplication(&argc, &argv);
   GOOGLE_PROTOBUF_VERIFY_VERSION;
 
+  if (FLAGS_input_map == "" || FLAGS_output_map == "")
+    LOG(FATAL) << "The input and output maps were not specified.\n";
+
   if (FLAGS_undistorted_images_list   == "" &&
       FLAGS_distorted_images_list     == "" &&
       FLAGS_undistorted_camera_params == "") {
@@ -117,23 +123,46 @@ int main(int argc, char** argv) {
       LOG(FATAL) << "Failed to read the robot configuration.";
       return 1;
     }
-    camera::CameraParameters cam_params(&config, "nav_cam");
+    camera::CameraParameters camera_params(&config, "nav_cam");
 
     // Create a sparse map with the given camera parameters
-    sparse_mapping::SparseMap m(std::vector<std::string>(), "SURF", cam_params);
-    sparse_mapping::ReadNVM(FLAGS_input_map, &m.cid_to_keypoint_map_,
-                            &m.cid_to_filename_, &m.pid_to_cid_fid_,
-                            &m.pid_to_xyz_, &m.cid_to_cam_t_global_);
+    sparse_mapping::SparseMap map(std::vector<std::string>(), "SURF", camera_params);
+    sparse_mapping::ReadNVM(FLAGS_input_map, &map.cid_to_keypoint_map_,
+                            &map.cid_to_filename_, &map.pid_to_cid_fid_,
+                            &map.pid_to_xyz_, &map.cid_to_cam_t_global_);
+
+    Eigen::Vector2d optical_center = camera_params.GetOpticalOffset();
+    Eigen::Vector2d dist_pix, undist_pix;
+
+    for (size_t cid = 0; cid < map.cid_to_keypoint_map_.size(); cid++) {
+      Eigen::Vector2d dist_pix;
+      for (int fid = 0; fid < map.cid_to_keypoint_map_[cid].cols(); fid++) {
+        dist_pix = map.cid_to_keypoint_map_[cid].col(fid);
+
+        if (!FLAGS_no_shift) {
+          // Undo the shift relative to the optical center
+          dist_pix += optical_center;
+        }
+
+        // Undistort and center. Write the result to the map.
+        camera_params.Convert<camera::DISTORTED, camera::UNDISTORTED_C>
+          (dist_pix, &undist_pix);
+        map.cid_to_keypoint_map_[cid].col(fid) = undist_pix;
+      }
+    }
 
     // Descriptors are not saved, so let them be empty
-    m.cid_to_descriptor_map_.resize(m.cid_to_keypoint_map_.size());
+    map.cid_to_descriptor_map_.resize(map.cid_to_keypoint_map_.size());
 
-    m.Save(FLAGS_output_map);
+    map.Save(FLAGS_output_map);
 
     google::protobuf::ShutdownProtobufLibrary();
 
     return 0;
   }
+
+  if (FLAGS_no_shift)
+    LOG(FATAL) << "The --no_shift option does not work with undistorted images.\n";
 
   // Read the images from a list file or individually specified on the command line
   std::vector<std::string> undist_images;
@@ -156,11 +185,16 @@ int main(int argc, char** argv) {
     double widx = vals[0], widy = vals[1], f = vals[2], cx = vals[3], cy = vals[4];
     LOG(INFO) << "Using undistorted camera parameters: "
               << widx << ' ' << widy << ' ' << f << ' ' << cx << ' ' << cy;
-    camera::CameraParameters cam_params = camera::CameraParameters(Eigen::Vector2i(widx, widy),
-                                                                   Eigen::Vector2d::Constant(f),
-                                                                   Eigen::Vector2d(cx, cy));
-    map.SetCameraParameters(cam_params);
+
+    // Save the undistorted params in the map
+    camera::CameraParameters camera_params
+      = camera::CameraParameters(Eigen::Vector2i(widx, widy),
+                                 Eigen::Vector2d::Constant(f),
+                                 Eigen::Vector2d(cx, cy));
+    map.SetCameraParameters(camera_params);
+
   } else {
+    // Replace the images and robot camera params with distorted (original) ones
     replaceWithDistortedImages(undist_images, FLAGS_distorted_images_list, map);
   }
 


### PR DESCRIPTION
This pull request does two things:

 - Allow merge_maps -fix_first_map to use maps sharing images. This is quite useful for appending a second map to a first map which is already registered and from which already a dense mesh was made and one does not want to redo that but append to it. 
 -  Tweak the import and export tools. Astrobee's sparse map stores undistorted features centered around undistorted image center. NVM files store distorted features centered around optical center. This is now handled properly. Also allow exporting and importing without that offset around optical center, which is useful when the images are made with different sensors, each with its own optical center. 