### PR TITLE
Added Script to Remove Rotation-Only Image Sequences

### DIFF
--- a/localization/sparse_mapping/CMakeLists.txt
+++ b/localization/sparse_mapping/CMakeLists.txt
@@ -185,7 +185,7 @@ target_link_libraries(remove_low_movement_images
   sparse_mapping ${catkin_LIBRARIES})
 
 ## Declare a C++ executable: remove_rotation_only_images
-add_executable(remove_rotation_only_images tools/remove_rotation_only_images.cc)
+add_executable(remove_rotation_only_images tools/remove_rotation_only_images.cc tools/utilities.cc)
 add_dependencies(remove_rotation_only_images ${catkin_EXPORTED_TARGETS})
 target_link_libraries(remove_rotation_only_images
   sparse_mapping ${catkin_LIBRARIES})

--- a/localization/sparse_mapping/CMakeLists.txt
+++ b/localization/sparse_mapping/CMakeLists.txt
@@ -179,7 +179,7 @@ target_link_libraries(parse_cam
   sparse_mapping gflags glog ${catkin_LIBRARIES})
 
 ## Declare a C++ executable: remove_low_movement_images
-add_executable(remove_low_movement_images tools/remove_low_movement_images.cc)
+add_executable(remove_low_movement_images tools/remove_low_movement_images.cc tools/utilities.cc)
 add_dependencies(remove_low_movement_images ${catkin_EXPORTED_TARGETS})
 target_link_libraries(remove_low_movement_images
   sparse_mapping ${catkin_LIBRARIES})

--- a/localization/sparse_mapping/CMakeLists.txt
+++ b/localization/sparse_mapping/CMakeLists.txt
@@ -183,6 +183,13 @@ add_executable(remove_low_movement_images tools/remove_low_movement_images.cc)
 add_dependencies(remove_low_movement_images ${catkin_EXPORTED_TARGETS})
 target_link_libraries(remove_low_movement_images
   sparse_mapping ${catkin_LIBRARIES})
+
+## Declare a C++ executable: remove_rotation_only_images
+add_executable(remove_rotation_only_images tools/remove_rotation_only_images.cc)
+add_dependencies(remove_rotation_only_images ${catkin_EXPORTED_TARGETS})
+target_link_libraries(remove_rotation_only_images
+  sparse_mapping ${catkin_LIBRARIES})
+
 endif (NOT USE_CTC)
 
 

--- a/localization/sparse_mapping/build_map.md
+++ b/localization/sparse_mapping/build_map.md
@@ -65,14 +65,16 @@ Remove low movement images:
 
 This will delete subsequent images with low movement from that directory to improve mapping performance and accuracy. 
 
-This is a non-reversible operation, so it should be invoked on a copy
+Remove rotation-only movement images:
+    rosrun sparse_mapping remove_rotation_only_images image_directory_name config_path
+
+Removes rotation only image sequences and optionally saves different movement sequences to different subdirectories.
+
+These are non-reversible operations, so they should be invoked on a copy
 of the images.
 
-It is important to avoid rotating the bot in place when acquiring
-images, as then the map could be of poor quality. Hence, the robot
-should have some translation motion (in addition to any rotation) when
+If possible, the robot should have some translation motion (in addition to any rotation) when
 the data is acquired.
-
 
 ## Building a map
 

--- a/localization/sparse_mapping/build_map.md
+++ b/localization/sparse_mapping/build_map.md
@@ -58,7 +58,7 @@ temporarily modify the above files to reflect your camera's parameters
 More details on these and other environmental variables can be found
 in the \ref astrobee configuration documentation.
 
-## Reduce the number of images
+## Reduce the number of images and remove images that might cause errors during bundle-adjustment 
 
 Remove low movement images:
     rosrun sparse_mapping remove_low_movement_images image_directory_name
@@ -68,13 +68,15 @@ This will delete subsequent images with low movement from that directory to impr
 Remove rotation-only movement images:
     rosrun sparse_mapping remove_rotation_only_images image_directory_name config_path
 
-Removes rotation only image sequences and optionally saves different movement sequences to different subdirectories.
+Removes rotation only image sequences and optionally saves different movement sequences to different subdirectories. See 'rosrun sparse_mapping remove_rotation_only_images -h' for more usage details, options, and instructions.
 
 These are non-reversible operations, so they should be invoked on a copy
 of the images.
 
 If possible, the robot should have some translation motion (in addition to any rotation) when
 the data is acquired.
+
+Removing low movement and rotation only movement images helps the accuracy of bundle adjustment, which struggles to optimize camera poses with small or no translation changes.
 
 ## Building a map
 

--- a/localization/sparse_mapping/theia_map.md
+++ b/localization/sparse_mapping/theia_map.md
@@ -133,11 +133,16 @@ that option.
 Remove low movement images:
     rosrun sparse_mapping remove_low_movement_images image_directory_name
 
-This will delete subsequent images with low movement from that directory to improve mapping performance and accuracy. 
+Remove rotation-only movement images:
+    rosrun sparse_mapping remove_rotation_only_images image_directory_name config_path
 
-It is suggested to avoid images with pure camera rotation, or at least
-to have in the mix additional images of the same environemnt without
-such rotations.
+Removes rotation only image sequences and optionally saves different movement sequences to different subdirectories.
+
+These are non-reversible operations, so they should be invoked on a copy
+of the images.
+
+If possible, the robot should have some translation motion (in addition to any rotation) when
+the data is acquired.
 
 Put the selected images in a list:
 

--- a/localization/sparse_mapping/theia_map.md
+++ b/localization/sparse_mapping/theia_map.md
@@ -133,16 +133,20 @@ that option.
 Remove low movement images:
     rosrun sparse_mapping remove_low_movement_images image_directory_name
 
+This will delete subsequent images with low movement from that directory to improve mapping performance and accuracy. 
+
 Remove rotation-only movement images:
     rosrun sparse_mapping remove_rotation_only_images image_directory_name config_path
 
-Removes rotation only image sequences and optionally saves different movement sequences to different subdirectories.
+Removes rotation only image sequences and optionally saves different movement sequences to different subdirectories. See 'rosrun sparse_mapping remove_rotation_only_images -h' for more usage details, options, and instructions.
 
 These are non-reversible operations, so they should be invoked on a copy
 of the images.
 
 If possible, the robot should have some translation motion (in addition to any rotation) when
 the data is acquired.
+
+Removing low movement and rotation only movement images helps the accuracy of bundle adjustment, which struggles to optimize camera poses with small or no translation changes.
 
 Put the selected images in a list:
 

--- a/localization/sparse_mapping/tools/remove_rotation_only_images.cc
+++ b/localization/sparse_mapping/tools/remove_rotation_only_images.cc
@@ -294,9 +294,10 @@ vc::LKOpticalFlowFeatureDetectorAndMatcherParams LoadParams() {
   return params;
 }
 
-void SaveResultsToSubdirectories(const std::vector<Result>& results) {
+void SaveResultsToSubdirectories(const std::string& image_directory, const std::vector<Result>& results) {
   // Save continous sets of non-removed sequences to different subdirectories
   int subdirectory_index = 0;
+  CreateSubdirectory(image_directory, std::to_string(subdirectory_index));
   bool previous_result_removed = false;
   for (const auto& result : results) {
     if (result.removed) {
@@ -304,6 +305,7 @@ void SaveResultsToSubdirectories(const std::vector<Result>& results) {
         continue;
       } else {
         ++subdirectory_index;
+        CreateSubdirectory(image_directory, std::to_string(subdirectory_index));
         previous_result_removed = true;
       }
     } else {
@@ -467,6 +469,6 @@ int main(int argc, char** argv) {
   LogInfo("Removed " << num_removed_images << " of " << num_original_images << " images.");
   if (save_results_to_subdirectories) {
     LogInfo("Saving results to subdirectories.");
-    SaveResultsToSubdirectories(results);
+    SaveResultsToSubdirectories(image_directory, results);
   }
 }

--- a/localization/sparse_mapping/tools/remove_rotation_only_images.cc
+++ b/localization/sparse_mapping/tools/remove_rotation_only_images.cc
@@ -188,7 +188,10 @@ bool RotationOnlyImageSequence(const vc::FeatureMatches& matches, const camera::
                   CV_FONT_NORMAL, 2, cv_color, 4, cv::LINE_AA);
     cv::Mat resized_projection_img;
     cv::resize(projection_img, resized_projection_img, cv::Size(projection_img.cols * 2, projection_img.rows * 2));
-    cv::imshow("ratio_image", resized_projection_img);
+    const std::string window_name("ratio_image");
+    cv::namedWindow(window_name);
+    cv::moveWindow(window_name, 0, 0);
+    cv::imshow(window_name, resized_projection_img);
     cv::waitKey(0);
   }
 

--- a/localization/sparse_mapping/tools/remove_rotation_only_images.cc
+++ b/localization/sparse_mapping/tools/remove_rotation_only_images.cc
@@ -211,8 +211,8 @@ int RemoveRotationSequences(const int max_distance_between_removed_images, const
       // Add all images from start to end that have a max distance less than the provided threshold to other rotation
       // images
       for (int query_index = start_index + 1;
-           query_index < (static_cast<int>(results.size()) &&
-                          (current_distance_between_removed_images < max_distance_between_removed_images));
+           (query_index < static_cast<int>(results.size()) &&
+            (current_distance_between_removed_images < max_distance_between_removed_images));
            ++query_index) {
         if (results[query_index].removed) {
           end_index = query_index;
@@ -227,14 +227,16 @@ int RemoveRotationSequences(const int max_distance_between_removed_images, const
           auto& result = results[i];
           if (!result.removed) {
             RemoveOrMove(move_images, result);
+            std::cout << "Removed image in rotation sequence. Img: " << result.image_name << ", index: " << i
+                      << ", start index: " << start_index << ", end index: " << *end_index << std::endl;
             ++num_removed_images;
           }
         }
         start_index = *end_index + 1;
+        continue;
       }
-    } else {
-      ++start_index;
     }
+    ++start_index;
   }
   return num_removed_images;
 }

--- a/localization/sparse_mapping/tools/remove_rotation_only_images.cc
+++ b/localization/sparse_mapping/tools/remove_rotation_only_images.cc
@@ -173,18 +173,19 @@ bool RotationOnlyImageSequence(const vc::FeatureMatches& matches, const camera::
             << ", error ratio: " << error_ratio << ", mean rot error: " << mean_rotation_corrected_error
             << ", mean of error: " << mean_optical_flow_error << std::endl;
   if (view_images) {
-    // Scale color to be more white for a lower error ratio
-    // TODO(rsoussan): Use color image! Make red if above threshold!
-    const int color = 50.0 / error_ratio;
+    const int color = 40.0 / error_ratio;
+    const cv::Mat gray_color(1, 1, CV_8UC1, color);
+    cv::Mat heatmap_color;
+    cv::applyColorMap(gray_color, heatmap_color, cv::COLORMAP_JET);
+    const cv::Scalar cv_color(heatmap_color.data[0], heatmap_color.data[1], heatmap_color.data[2]);
     cv::putText(projection_img,
                 "ratio: " + std::to_string(error_ratio) + ", rot: " + std::to_string(mean_rotation_corrected_error) +
                   ", of: " + std::to_string(mean_optical_flow_error),
-                cv::Point(projection_img.cols / 2 - 320, projection_img.rows - 20), CV_FONT_NORMAL, 0.9,
-                CV_RGB(color, color, color), 4, cv::LINE_AA);
+                cv::Point(projection_img.cols / 2 - 320, projection_img.rows - 20), CV_FONT_NORMAL, 0.9, cv_color, 4,
+                cv::LINE_AA);
     if (remove_image)
-      // TODO(rsoussan): clean this up! move higher and make bigger!
-      cv::putText(projection_img, "Remove!", cv::Point(projection_img.cols / 2 - 100, projection_img.rows - 20),
-                  CV_FONT_NORMAL, 0.5, CV_RGB(color, color, color), 4, cv::LINE_AA);
+      cv::putText(projection_img, "Removing", cv::Point(projection_img.cols / 2 - 100, projection_img.rows - 200),
+                  CV_FONT_NORMAL, 2, cv_color, 4, cv::LINE_AA);
     cv::Mat resized_projection_img;
     cv::resize(projection_img, resized_projection_img, cv::Size(projection_img.cols * 2, projection_img.rows * 2));
     cv::imshow("ratio_image", resized_projection_img);

--- a/localization/sparse_mapping/tools/remove_rotation_only_images.cc
+++ b/localization/sparse_mapping/tools/remove_rotation_only_images.cc
@@ -154,7 +154,9 @@ bool RotationOnlyImageSequence(const vc::FeatureMatches& matches, const camera::
   double total_optical_flow_error = 0;
   int good_triangulation_count = 0;
   cv::Mat projection_img;
-  if (view_images) cv::cvtColor(kImg.clone(), projection_img, cv::COLOR_GRAY2RGB);
+  if (view_images) {
+    cv::cvtColor(kImg.clone(), projection_img, cv::COLOR_GRAY2RGB);
+  }
   for (const auto& inlier_match : inliers) {
     const auto& match = matches[inlier_match.imgIdx];
     const Eigen::Vector2d& source_point = match.source_point;
@@ -212,10 +214,7 @@ bool RotationOnlyImageSequence(const vc::FeatureMatches& matches, const camera::
                   CV_FONT_NORMAL, 2, cv_color, 4, cv::LINE_AA);
     cv::Mat resized_projection_img;
     cv::resize(projection_img, resized_projection_img, cv::Size(projection_img.cols * 2, projection_img.rows * 2));
-    const std::string window_name("ratio_image");
-    cv::namedWindow(window_name);
-    cv::moveWindow(window_name, 0, 0);
-    cv::imshow(window_name, resized_projection_img);
+    cv::imshow("ratio_image", resized_projection_img);
     cv::waitKey(0);
   }
 
@@ -331,6 +330,14 @@ int RemoveRotationOnlyImages(const std::vector<std::string>& image_names, const 
   auto current_image = LoadImage(current_image_index, image_names, detector);
   auto next_image = LoadImage(next_image_index, image_names, detector);
   int num_removed_images = 0;
+  if (view_images) {
+    const std::string window_name("ratio_image");
+    cv::namedWindow(window_name);
+    cv::moveWindow(window_name, 50, 30);
+  }
+
+  // Manually add first image
+  results.emplace_back(Result(0, image_names[0], false));
   while (current_image_index < image_names.size()) {
     bool removed_rotation_sequence = false;
     while (next_image_index < image_names.size()) {
@@ -385,7 +392,6 @@ int main(int argc, char** argv) {
   bool save_results_to_subdirectories;
   int min_separation_between_sets;
   po::options_description desc("Removes any rotation only image sequences.");
-  // TODO(rsoussan): Tune rotation sequence distance
   // TODO(rsoussan): Add option to print debug info? just use LogDebug!!!
   desc.add_options()("help,h", "produce help message")(
     "image-directory", po::value<std::string>()->required(),

--- a/localization/sparse_mapping/tools/remove_rotation_only_images.cc
+++ b/localization/sparse_mapping/tools/remove_rotation_only_images.cc
@@ -303,7 +303,11 @@ int main(int argc, char** argv) {
   bool view_images;
   bool save_results_to_subdirectories;
   int min_separation_between_sets;
-  po::options_description desc("Removes any rotation only image sequences.");
+  po::options_description desc(
+    "Removes any rotation-only image sequences. Checks sequential images and removes the subsequent image if it fits a "
+    "rotation-only movement model. Further prunes results by removing any images bounded within a provided threhsold "
+    "by detected rotations. Optionally saves results to subdirectories where each subdirectory contains a different "
+    "sequence of non-rotation movement, where each sequence is separated by a set of removed rotation images.");
   desc.add_options()("help,h", "produce help message")(
     "image-directory", po::value<std::string>()->required(),
     "Directory containing images. Images are assumed to be named in sequential order.")(
@@ -389,11 +393,11 @@ int main(int argc, char** argv) {
   LogInfo("Removing rotation sequences, max allowed separation: " + std::to_string(max_separation_in_sequence));
   num_removed_images += RemoveRotationSequences(max_separation_in_sequence, move_removed_images, results);
 
-  LogInfo("Removed " << (num_removed_images - num_removed_rotation_only_images) << " of " << num_original_images
-                     << " images.");
+  LogInfo("Removed " << (num_removed_images - num_removed_rotation_only_images) << " of "
+                     << (num_original_images - num_removed_rotation_only_images) << " images.");
   if (save_results_to_subdirectories) {
     LogInfo("Saving results to subdirectories.");
     SaveResultsToSubdirectories(image_directory, min_separation_between_sets, results);
   }
-  LogInfo("Total images removed: " << num_removed_images << " of " << num_original_images << " .");
+  LogInfo("Total images removed: " << num_removed_images << " of " << num_original_images << ".");
 }

--- a/localization/sparse_mapping/tools/remove_rotation_only_images.cc
+++ b/localization/sparse_mapping/tools/remove_rotation_only_images.cc
@@ -1,0 +1,270 @@
+/* Copyright (c) 2017, United States Government, as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ *
+ * All rights reserved.
+ *
+ * The Astrobee platform is licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+#include <camera/camera_params.h>
+#include <ff_common/init.h>
+#include <localization_common/averager.h>
+#include <localization_common/logger.h>
+#include <localization_common/utilities.h>
+#include <sparse_mapping/ransac.h>
+#include <vision_common/lk_optical_flow_feature_detector_and_matcher.h>
+#include <vision_common/utilities.h>
+
+#include <glog/logging.h>
+
+#include <boost/filesystem.hpp>
+#include <boost/program_options.hpp>
+
+#include <mutex>
+
+namespace fs = boost::filesystem;
+namespace lc = localization_common;
+namespace po = boost::program_options;
+namespace vc = vision_common;
+
+boost::optional<vc::FeatureMatches> Matches(const vc::FeatureImage& current_image, const vc::FeatureImage& next_image,
+                                            vc::LKOpticalFlowFeatureDetectorAndMatcher& detector_and_matcher) {
+  const auto& matches = detector_and_matcher.Match(current_image, next_image);
+  if (matches.size() < 5) {
+    LogError("Too few matches: " << matches.size() << ", current image keypoints: " << current_image.keypoints().size()
+                                 << ", next image keypoints: " << next_image.keypoints().size());
+    return boost::none;
+  }
+  LogDebug("Found matches: " << matches.size() << ", current image keypoints: " << current_image.keypoints().size()
+                             << ", next image keypoints: " << next_image.keypoints().size());
+  return matches;
+}
+
+Eigen::Matrix3d Rotation(const std::vector<Eigen::Vector3d>& points_a, const std::vector<Eigen::Vector3d>& points_b) {
+  Eigen::Vector3d points_a_mean(Eigen::Vector3d::Zero());
+  Eigen::Vector3d points_b_mean(Eigen::Vector3d::Zero());
+  for (int i = 0; i < static_cast<int>(points_a.size()); ++i) {
+    points_a_mean += points_a[i];
+    points_b_mean += points_b[i];
+  }
+  points_a_mean /= static_cast<double>(points_a.size());
+  points_b_mean /= static_cast<double>(points_b.size());
+
+  Eigen::Matrix3d covariance(Eigen::Matrix3d::Zero());
+  for (int i = 0; i < static_cast<int>(points_a.size()); ++i) {
+    const Eigen::Vector3d point_a_mean_centered = points_a[i] - points_a_mean;
+    const Eigen::Vector3d point_b_mean_centered = points_b[i] - points_b_mean;
+    covariance += point_a_mean_centered * point_b_mean_centered.transpose();
+  }
+
+  Eigen::JacobiSVD<Eigen::Matrix3d> svd(covariance, Eigen::ComputeFullU | Eigen::ComputeFullV);
+  Eigen::Matrix3d rotation = svd.matrixU() * svd.matrixV().transpose();
+  if (rotation.determinant() < 0) rotation *= -1.0;
+  return rotation;
+}
+
+struct RotationFittingFunctor {
+  using result_type = Eigen::Matrix3d;
+  size_t min_elements_needed_for_fit() const { return 3; }
+  result_type operator()(const std::vector<Eigen::Vector3d>& points_a,
+                         const std::vector<Eigen::Vector3d>& points_b) const {
+    // TODO(rsoussan): Transpose here??
+    return Rotation(points_a, points_b).transpose();
+  }
+};
+
+struct RotationError {
+  double operator()(const Eigen::Matrix3d& rotation, const Eigen::Vector3d& point_a,
+                    const Eigen::Vector3d& point_b) const {
+    // TODO(rsoussan): is rotation frame correct here?
+    return (1.0 - (rotation * point_a).dot(point_b));
+  }
+};
+
+using RansacEstimateRotation = sparse_mapping::RandomSampleConsensus<RotationFittingFunctor, RotationError>;
+
+bool RotationOnlyImageSequence(const vc::FeatureMatches& matches, const camera::CameraParameters& camera_params,
+                               const double rotation_inlier_threshold, const double min_percent_rotation_inliers) {
+  // Backproject with unit depth
+  std::vector<Eigen::Vector3d> backprojected_points_a;
+  std::vector<Eigen::Vector3d> backprojected_points_b;
+  const Eigen::Matrix3d intrinsics = camera_params.GetIntrinsicMatrix<camera::DISTORTED>();
+  for (const auto& match : matches) {
+    Eigen::Vector2d undistorted_source_point;
+    Eigen::Vector2d undistorted_target_point;
+    camera_params.Convert<camera::DISTORTED, camera::UNDISTORTED>(match.source_point, &undistorted_source_point);
+    camera_params.Convert<camera::DISTORTED, camera::UNDISTORTED>(match.target_point, &undistorted_target_point);
+    backprojected_points_a.emplace_back(vc::Backproject(undistorted_source_point, intrinsics, 1.0));
+    backprojected_points_b.emplace_back(vc::Backproject(undistorted_target_point, intrinsics, 1.0));
+  }
+
+  const int num_iterations = 1000;
+  const int min_num_output_inliers = matches.size() / 2;
+  const bool reduce_min_num_output_inliers_if_no_fit = false;
+  const bool increase_threshold_if_no_fit = false;
+  RansacEstimateRotation ransac(RotationFittingFunctor(), RotationError(), num_iterations, rotation_inlier_threshold,
+                                min_num_output_inliers, reduce_min_num_output_inliers_if_no_fit,
+                                increase_threshold_if_no_fit);
+  const Eigen::Matrix3d rotation = ransac(backprojected_points_a, backprojected_points_b);
+  LogError("rotation: " << rotation.matrix());
+  const auto inlier_indices = ransac.inlier_indices(rotation, backprojected_points_a, backprojected_points_b);
+  const double percent_inliers = static_cast<double>(inlier_indices.size()) / static_cast<double>(matches.size());
+  LogError("percent inliers: " << percent_inliers);
+  return percent_inliers >= min_percent_rotation_inliers;
+}
+
+vc::FeatureImage LoadImage(const int index, const std::vector<std::string>& image_names, cv::Feature2D& detector) {
+  auto image = cv::imread(image_names[index], cv::IMREAD_GRAYSCALE);
+  if (image.empty()) LogFatal("Failed to load image " << image_names[index]);
+  cv::resize(image, image, cv::Size(), 0.5, 0.5);
+  // TODO(rsoussan): Add option to undistort image, use histogram equalization
+  return vc::FeatureImage(image, detector);
+}
+
+vc::LKOpticalFlowFeatureDetectorAndMatcherParams LoadParams() {
+  vc::LKOpticalFlowFeatureDetectorAndMatcherParams params;
+  // TODO(rsoussan): Add config file for these
+  params.max_iterations = 10;
+  params.termination_epsilon = 0.03;
+  params.window_length = 31;
+  params.max_level = 3;
+  params.min_eigen_threshold = 0.001;
+  params.max_flow_distance = 180;
+  params.max_backward_match_distance = 0.5;
+  params.good_features_to_track.max_corners = 100;
+  params.good_features_to_track.quality_level = 0.01;
+  params.good_features_to_track.min_distance = 40;
+  params.good_features_to_track.block_size = 3;
+  params.good_features_to_track.use_harris_detector = false;
+  params.good_features_to_track.k = 0.04;
+  return params;
+}
+
+int RemoveRotationOnlyImages(const std::vector<std::string>& image_names, const camera::CameraParameters& camera_params,
+                             const double rotation_inlier_threshold, const double min_percent_rotation_inliers) {
+  const vc::LKOpticalFlowFeatureDetectorAndMatcherParams params = LoadParams();
+  vc::LKOpticalFlowFeatureDetectorAndMatcher detector_and_matcher(params);
+  auto& detector = *(detector_and_matcher.detector());
+  // Compare current image with subsequent image and mark subsequent image for removal if it displays rotation only
+  // movement. Repeat and create image directories around rotation only sequences.
+  int current_image_index = 0;
+  int next_image_index = 1;
+  auto current_image = LoadImage(current_image_index, image_names, detector);
+  auto next_image = LoadImage(next_image_index, image_names, detector);
+  int num_removed_images = 0;
+  while (current_image_index < image_names.size()) {
+    bool removed_rotation_sequence = false;
+    while (next_image_index < image_names.size()) {
+      const auto matches = Matches(current_image, next_image, detector_and_matcher);
+      if (matches &&
+          RotationOnlyImageSequence(*matches, camera_params, rotation_inlier_threshold, min_percent_rotation_inliers)) {
+        LogDebug("Removing image index: " << next_image_index << ", current image index: " << current_image_index);
+        std::remove((image_names[next_image_index]).c_str());
+        ++num_removed_images;
+        current_image = next_image;
+        current_image_index = next_image_index;
+        // Don't load next image if index is past the end of the sequence
+        if (++next_image_index >= image_names.size()) break;
+        next_image = LoadImage(next_image_index, image_names, detector);
+        removed_rotation_sequence = true;
+      } else {
+        break;
+      }
+    }
+    current_image = next_image;
+    current_image_index = next_image_index;
+    // Exit if current image is the last image in the sequence
+    if (current_image_index >= image_names.size() - 1) break;
+    next_image = LoadImage(++next_image_index, image_names, detector);
+  }
+
+  return num_removed_images;
+}
+
+std::vector<std::string> GetImageNames(const std::string& image_directory,
+                                       const std::string& image_extension = ".jpg") {
+  std::vector<std::string> image_names;
+  for (const auto& file : fs::recursive_directory_iterator(image_directory)) {
+    if (fs::is_regular_file(file) && file.path().extension() == image_extension)
+      image_names.emplace_back(fs::absolute(file.path()).string());
+  }
+  std::sort(image_names.begin(), image_names.end());
+  LogInfo("Found " << image_names.size() << " images.");
+  return image_names;
+}
+
+int main(int argc, char** argv) {
+  double max_low_movement_mean_distance;
+  double rotation_inlier_threshold;
+  double min_percent_rotation_inliers;
+  std::string robot_config_file;
+  po::options_description desc(
+    "Removes any rotation only image sequences. Splits images into subdirectories when a sequence is removed.");
+  desc.add_options()("help,h", "produce help message")(
+    "image-directory", po::value<std::string>()->required(),
+    "Directory containing images. Images are assumed to be named in sequential order.")(
+    "--rotation-inlier-threshold,t", po::value<double>(&rotation_inlier_threshold)->default_value(0.01),
+    "Threshold for a point to be an inlier for the RANSAC rotation estimate. Computed using the dot "
+    "product of the rotated point and matching point, so perfect alignment yields a value of 0 and "
+    "the worst aligment yields a value of 1."
+    "sequential images to be classified as a rotation only pair.")(
+    "--min-rotation-only-inliers-percent,p", po::value<double>(&min_percent_rotation_inliers)->default_value(0.95),
+    "Min percent of matches that are inliers to rotation only movement between "
+    "sequential images to be classified as a rotation only pair.")("config-path,c",
+                                                                   po::value<std::string>()->required(), "Config path")(
+    "robot-config-file,r", po::value<std::string>(&robot_config_file)->default_value("config/robots/bumble.config"),
+    "robot config file");
+  po::positional_options_description p;
+  p.add("image-directory", 1);
+  p.add("config-path", 1);
+  po::variables_map vm;
+  try {
+    po::store(po::command_line_parser(argc, argv).options(desc).positional(p).run(), vm);
+    if (vm.count("help") || (argc <= 1)) {
+      std::cout << desc << "\n";
+      return 1;
+    }
+    po::notify(vm);
+  } catch (std::exception& e) {
+    std::cerr << "Error: " << e.what() << "\n";
+    return 1;
+  }
+
+  const std::string image_directory = vm["image-directory"].as<std::string>();
+  const std::string config_path = vm["config-path"].as<std::string>();
+
+  // Only pass program name to free flyer so that boost command line options
+  // are ignored when parsing gflags.
+  int ff_argc = 1;
+  ff_common::InitFreeFlyerApplication(&ff_argc, &argv);
+  lc::SetEnvironmentConfigs(config_path, "iss", robot_config_file);
+  config_reader::ConfigReader config;
+  config.AddFile("cameras.config");
+  config.AddFile("geometry.config");
+  if (!config.ReadFiles()) {
+    LogFatal("Failed to read config files.");
+  }
+  // TODO(rsoussan): Allow for other cameras?
+  const camera::CameraParameters camera_parameters(&config, "nav_cam");
+
+  if (!fs::exists(image_directory) || !fs::is_directory(image_directory)) {
+    LogFatal("Image directory " << image_directory << " not found.");
+  }
+
+  const auto image_names = GetImageNames(image_directory);
+  if (image_names.empty()) LogFatal("No images found.");
+
+  const int num_original_images = image_names.size();
+  const int num_removed_images =
+    RemoveRotationOnlyImages(image_names, camera_parameters, rotation_inlier_threshold, min_percent_rotation_inliers);
+  LogInfo("Removed " << num_removed_images << " of " << num_original_images << " images.");
+}

--- a/localization/sparse_mapping/tools/remove_rotation_only_images.cc
+++ b/localization/sparse_mapping/tools/remove_rotation_only_images.cc
@@ -313,28 +313,34 @@ int main(int argc, char** argv) {
     "Directory containing images. Images are assumed to be named in sequential order.")(
     "max-rotation-error-ratio,e", po::value<double>(&max_rotation_error_ratio)->default_value(0.25),
     "Maximum ratio of rotation corrected error to optical flow error for matched points in a sequential set "
-    "of images to be considered rotation only movement. The lower the ratio, the more the rotation fully explains "
-    "the movement between the images.")(
+    "of images to be considered rotation only movement. The lower the ratio, the more the rotation must fully explain "
+    "the movement between the images and the fewer images will be labeled as rotation only.")(
     "min-relative-pose-inliers-ratio,p", po::value<double>(&min_relative_pose_inliers_ratio)->default_value(0.7),
-    "Minimum ratio of matches that are inliers in the estimated relative pose between images.")(
+    "Minimum ratio of matches that are inliers in the estimated relative pose between images. Setting to a lower value "
+    "enables less accurate pose estimates to be used to determine if movement is rotation only. Images that do not "
+    "have enough matches are labeled erroneous and are discared unless --keep-erroneous-images is provided.")(
     "max-separation-in-sequence,d", po::value<int>(&max_separation_in_sequence)->default_value(10),
-    "Maximum distance between detected rotations for sequence removal.")(
+    "Maximum distance between detected rotations for sequence removal. Setting to a larger value removes more images "
+    "in between detected rotations.")(
     "min-separation-between-sets,b", po::value<int>(&min_separation_between_sets)->default_value(10),
-    "Minimum separation between non-rotation image sets if --keep-images-in-directory not enabled. Setting to a lower "
-    "value "
-    "allows for smaller subdirectories.")(
+    "Minimum separation between non-rotation image sets if --keep-images-in-directory not enabled. Setting to a larger "
+    "value enables more movements separated by detected rotations to be combined into the same subdirectories. This is "
+    "useful if some of the rotations are short and the movements before and after the rotation should be considered "
+    "the same continous movement.")(
     "remove-images,x", po::bool_switch(&move_removed_images)->default_value(true),
     "Remove images. Default behavior saves these to a directory called removed instead of deleting them.")(
     "keep-erroneous-images,k", po::bool_switch(&remove_erroneous_images)->default_value(true),
     "Keep images with too few relative pose inliers or too few matches between images. Default behavior removes "
     "these.")("view-images,v", po::bool_switch(&view_images)->default_value(false),
-              "View images with projected features and error ratios.")(
+              "View images with projected features and error ratios for each provided image in the image directory. "
+              "Helpful for tuning the error ratio or visualizing rotation movement while the script is running.")(
     "keep-images-in-directory,s", po::bool_switch(&save_results_to_subdirectories)->default_value(true),
     "Keep non-removed images in original directory. Default behavior saves results to subdirectories, where each "
     "continous set of images separated by a rotation seqeunce is saved to a "
     "different subdirectory.")
 
-    ("config-path,c", po::value<std::string>()->required(), "Config path")(
+    ("config-path,c", po::value<std::string>()->required(),
+     "Full path to astrobee/src/astrobee directory location, e.g. ~/astrobee/src/astrobee.")(
       "robot-config-file,r", po::value<std::string>(&robot_config_file)->default_value("config/robots/bumble.config"),
       "robot config file");
   po::positional_options_description p;

--- a/localization/sparse_mapping/tools/utilities.cc
+++ b/localization/sparse_mapping/tools/utilities.cc
@@ -1,0 +1,120 @@
+/* Copyright (c) 2017, United States Government, as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ *
+ * All rights reserved.
+ *
+ * The Astrobee platform is licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+#include <localization_common/logger.h>
+#include <localization_common/utilities.h>
+#include <sparse_mapping/tensor.h>
+#include <vision_common/utilities.h>
+
+#include <glog/logging.h>
+
+#include <boost/filesystem.hpp>
+
+#include <algorithm>
+#include <mutex>
+
+#include "utilities.h" // NOLINT
+
+namespace fs = boost::filesystem;
+namespace sm = sparse_mapping;
+namespace vc = vision_common;
+
+namespace sparse_mapping {
+cv::Point2f CvPoint2(const Eigen::Vector2d& point) { return cv::Point2f(point.x(), point.y()); }
+
+void CreateSubdirectory(const std::string& directory, const std::string& subdirectory) {
+  const auto subdirectory_path = fs::path(directory) / fs::path(subdirectory);
+  if (!boost::filesystem::exists(subdirectory_path)) {
+    boost::filesystem::create_directories(subdirectory_path);
+  }
+}
+
+boost::optional<vc::FeatureMatches> Matches(const vc::FeatureImage& current_image, const vc::FeatureImage& next_image,
+                                            vc::LKOpticalFlowFeatureDetectorAndMatcher& detector_and_matcher) {
+  const auto& matches = detector_and_matcher.Match(current_image, next_image);
+  if (matches.size() < 5) {
+    LogError("Too few matches: " << matches.size() << ", current image keypoints: " << current_image.keypoints().size()
+                                 << ", next image keypoints: " << next_image.keypoints().size());
+    return boost::none;
+  }
+  LogDebug("Found matches: " << matches.size() << ", current image keypoints: " << current_image.keypoints().size()
+                             << ", next image keypoints: " << next_image.keypoints().size());
+  return matches;
+}
+
+Eigen::Affine3d EstimateAffine3d(const vc::FeatureMatches& matches, const camera::CameraParameters& camera_params,
+                                 std::vector<cv::DMatch>& inliers) {
+  Eigen::Matrix2Xd source_image_points(2, matches.size());
+  Eigen::Matrix2Xd target_image_points(2, matches.size());
+  std::vector<cv::DMatch> cv_matches;
+  for (int i = 0; i < matches.size(); ++i) {
+    const auto& match = matches[i];
+    Eigen::Vector2d undistorted_source_point;
+    Eigen::Vector2d undistorted_target_point;
+    camera_params.Convert<camera::DISTORTED, camera::UNDISTORTED_C>(match.source_point, &undistorted_source_point);
+    camera_params.Convert<camera::DISTORTED, camera::UNDISTORTED_C>(match.target_point, &undistorted_target_point);
+    source_image_points.col(i) = undistorted_source_point;
+    target_image_points.col(i) = undistorted_target_point;
+    cv_matches.emplace_back(cv::DMatch(i, i, i, 0));
+  }
+
+  std::mutex mutex;
+  CIDPairAffineMap affines;
+  BuildMapFindEssentialAndInliers(source_image_points, target_image_points, cv_matches, camera_params, false, 0, 0,
+                                  &mutex, &affines, &inliers, false, nullptr);
+  const Eigen::Affine3d target_T_source = affines[std::make_pair(0, 0)];
+  return target_T_source.inverse();
+}
+
+vc::FeatureImage LoadImage(const int index, const std::vector<std::string>& image_names, cv::Feature2D& detector) {
+  auto image = cv::imread(image_names[index], cv::IMREAD_GRAYSCALE);
+  if (image.empty()) LogFatal("Failed to load image " << image_names[index]);
+  cv::resize(image, image, cv::Size(), 0.5, 0.5);
+  // TODO(rsoussan): Add option to undistort image, use histogram equalization
+  return vc::FeatureImage(image, detector);
+}
+
+vc::LKOpticalFlowFeatureDetectorAndMatcherParams LoadParams() {
+  vc::LKOpticalFlowFeatureDetectorAndMatcherParams params;
+  // TODO(rsoussan): Add config file for these
+  params.max_iterations = 10;
+  params.termination_epsilon = 0.03;
+  params.window_length = 31;
+  params.max_level = 3;
+  params.min_eigen_threshold = 0.001;
+  params.max_flow_distance = 180;
+  params.max_backward_match_distance = 0.5;
+  params.good_features_to_track.max_corners = 100;
+  params.good_features_to_track.quality_level = 0.01;
+  params.good_features_to_track.min_distance = 40;
+  params.good_features_to_track.block_size = 3;
+  params.good_features_to_track.use_harris_detector = false;
+  params.good_features_to_track.k = 0.04;
+  return params;
+}
+
+std::vector<std::string> GetImageNames(const std::string& image_directory, const std::string& image_extension) {
+  std::vector<std::string> image_names;
+  for (const auto& file : fs::recursive_directory_iterator(image_directory)) {
+    if (fs::is_regular_file(file) && file.path().extension() == image_extension)
+      image_names.emplace_back(fs::absolute(file.path()).string());
+  }
+  std::sort(image_names.begin(), image_names.end());
+  LogInfo("Found " << image_names.size() << " images.");
+  return image_names;
+}
+}  // namespace sparse_mapping

--- a/localization/sparse_mapping/tools/utilities.cc
+++ b/localization/sparse_mapping/tools/utilities.cc
@@ -27,7 +27,7 @@
 #include <algorithm>
 #include <mutex>
 
-#include "utilities.h" // NOLINT
+#include "utilities.h"  // NOLINT
 
 namespace fs = boost::filesystem;
 namespace sm = sparse_mapping;
@@ -47,7 +47,7 @@ boost::optional<vc::FeatureMatches> Matches(const vc::FeatureImage& current_imag
                                             vc::LKOpticalFlowFeatureDetectorAndMatcher& detector_and_matcher) {
   const auto& matches = detector_and_matcher.Match(current_image, next_image);
   if (matches.size() < 5) {
-    LogError("Too few matches: " << matches.size() << ", current image keypoints: " << current_image.keypoints().size()
+    LogDebug("Too few matches: " << matches.size() << ", current image keypoints: " << current_image.keypoints().size()
                                  << ", next image keypoints: " << next_image.keypoints().size());
     return boost::none;
   }

--- a/localization/sparse_mapping/tools/utilities.h
+++ b/localization/sparse_mapping/tools/utilities.h
@@ -1,0 +1,51 @@
+/* Copyright (c) 2017, United States Government, as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ *
+ * All rights reserved.
+ *
+ * The Astrobee platform is licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+#ifndef LOCALIZATION_SPARSE_MAPPING_TOOLS_UTILITIES_H_
+#define LOCALIZATION_SPARSE_MAPPING_TOOLS_UTILITIES_H_
+
+#include <camera/camera_params.h>
+#include <vision_common/lk_optical_flow_feature_detector_and_matcher.h>
+
+#include <boost/optional.hpp>
+#include <Eigen/Core>
+#include <Eigen/Geometry>
+
+#include <string>
+#include <vector>
+
+namespace sparse_mapping {
+cv::Point2f CvPoint2(const Eigen::Vector2d& point);
+
+void CreateSubdirectory(const std::string& directory, const std::string& subdirectory);
+
+boost::optional<vision_common::FeatureMatches> Matches(
+  const vision_common::FeatureImage& current_image, const vision_common::FeatureImage& next_image,
+  vision_common::LKOpticalFlowFeatureDetectorAndMatcher& detector_and_matcher);
+
+Eigen::Affine3d EstimateAffine3d(const vision_common::FeatureMatches& matches,
+                                 const camera::CameraParameters& camera_params, std::vector<cv::DMatch>& inliers);
+
+vision_common::FeatureImage LoadImage(const int index, const std::vector<std::string>& image_names,
+                                      cv::Feature2D& detector);
+
+vision_common::LKOpticalFlowFeatureDetectorAndMatcherParams LoadParams();
+
+std::vector<std::string> GetImageNames(const std::string& image_directory, const std::string& image_extension = ".jpg");
+}  // namespace sparse_mapping
+
+#endif  // LOCALIZATION_SPARSE_MAPPING_TOOLS_UTILITIES_H_


### PR DESCRIPTION
Removes any rotation-only image sequences. Checks sequential images and removes the subsequent image if it fits a rotation-only movement model. Further prunes results by removing any images bounded within a provided threshold by detected rotations. Optionally saves results to subdirectories where each subdirectory contains a different sequence of non-rotation movement, where each sequence is separated by a set of removed rotation images.
Optional -v view mode shows debugging images, with matched points projected from one image to the next using the rotation model. Removed images are labeled with "removing", and a ratio of rotation model error to full pose model error is shown. Example provided below:
![remoe_rotation_removed](https://user-images.githubusercontent.com/1794282/198377480-5d006eed-4a40-4590-887e-b44ed4694c18.png)
@oleg-alexandrov @trey0 
