### PR TITLE
Added output to system monitor.

### DIFF
--- a/management/sys_monitor/src/sys_monitor.cc
+++ b/management/sys_monitor/src/sys_monitor.cc
@@ -564,6 +564,8 @@ void SysMonitor::StartupTimerCallback(ros::TimerEvent const& te) {
   for (auto it = watch_dogs_.begin(); it != watch_dogs_.end(); ++it) {
     // Try restarting nodelet if we never received a heartbeat from it
     if (!it->second->heartbeat_started()) {
+      ROS_WARN_STREAM(it->first <<
+          " never published a heartbeat! Trying to start it manually.");
       // Only need to set the name. Everything else will be looked up from the
       // config
       load_req.name = it->first;


### PR DESCRIPTION
When the system monitor detects that it didn't receive an initial heartbeat from a node in the system, it assumes the node didn't startup and it tries to start it manually. This works great on the robot but in simulation, it generates cryptic errors when trying to start hardware nodes. The added output should help the user figure out what is going on.