### PR TITLE
Code auto-generation improvements

### DIFF
--- a/doc/general_documentation/adding_a_command.md
+++ b/doc/general_documentation/adding_a_command.md
@@ -34,19 +34,10 @@ plan schema, please follow the next three subsections to generate the files.
 
 ## Setup
 
-To use the scripts, you will need to checkout the xgds2 repo and install some
-python and geocam tools.
+The scripts for auto-generating source code files from the command dictionary
+depend on the `xgds_planner2` library, which can be installed as follows:
 
-    cd astrobee/commands/
-    git clone https://github.com/xgds/xgds_planner2.git
-    sudo apt-get install python-pip python-iso8601
-    sudo pip install git+https://github.com/geocam/geocamUtilWeb
-
-In order to generate the Android files, the xpjson planner parser needs to be
-changed to keep the parent field for each command parameter. To do this, open
-the astrobee/commands/xgds_planner2/xgds_planner2/xpjson.py file in your
-preferred text editor. Find the KEEP_PARAM_PARENT parameter (around line 114)
-and set it to true. Then save and close the file.
+    sudo pip install git+https://github.com/trey0/xgds_planner2.git@just_xpjson
 
 ## Generate FSW files
 

--- a/scripts/build/luaTable.py
+++ b/scripts/build/luaTable.py
@@ -26,14 +26,15 @@ is no easy way to guarantee the python 3 compatibility changes
 continue to generate the fsw files correctly.
 """
 
+import sys
+
 try:
     from cStringIO import StringIO  # fmt: skip
 except ImportError:
     # Python 3
     from io import StringIO
 
-if not hasattr(__builtins__, "basestring"):
-    # Python 3
+if sys.version_info.major > 2:
     basestring = (str, bytes)
 
 

--- a/scripts/build/luaTable.py
+++ b/scripts/build/luaTable.py
@@ -17,13 +17,6 @@
 
 """
 Output Python data structure as a Lua table constructor.
-PLEASE NOTE: This script currently only works with python 2.
-The python script that imports this script and generates the
-astrobee fsw files uses a repo that is only compatible with
-python 2. Until that repo is updated to work with python 3,
-this script will only be compatible with python 2 since there
-is no easy way to guarantee the python 3 compatibility changes
-continue to generate the fsw files correctly.
 """
 
 import sys

--- a/scripts/build/xpjsonAstrobee.py
+++ b/scripts/build/xpjsonAstrobee.py
@@ -68,4 +68,5 @@ def loadDocument(path):
     """
     xpjson.CHECK_UNKNOWN_FIELDS = False  # suppress some warnings
     xpjson.KEEP_PARAM_SPECS = True  # inhibit deletion of paramSpecs during load
+    xpjson.KEEP_PARAM_PARENT = True  # inhibit deletion of paramSpec parent during load
     return xpjson.loadDocument(path)


### PR DESCRIPTION
- Use more reliable approach for Python version detection (old version worked in some environments but not others).
- Set `KEEP_PARAM_PARENT` to `True` by default in `xpjsonAstrobee.py` to simplify `astrobee_android` auto-gen script install instructions. (It doesn't affect `astrobee` auto-gen scripts.)
- Document simplified install instructions.
- Remove obsolete comment about lack of Python 3 support in `luaTable.py`.