### PR TITLE
Partition Image Files into Movement Sequences

### DIFF
--- a/localization/sparse_mapping/CMakeLists.txt
+++ b/localization/sparse_mapping/CMakeLists.txt
@@ -184,10 +184,10 @@ add_dependencies(remove_low_movement_images ${catkin_EXPORTED_TARGETS})
 target_link_libraries(remove_low_movement_images
   sparse_mapping ${catkin_LIBRARIES})
 
-## Declare a C++ executable: remove_rotation_only_images
-add_executable(remove_rotation_only_images tools/remove_rotation_only_images.cc tools/utilities.cc)
-add_dependencies(remove_rotation_only_images ${catkin_EXPORTED_TARGETS})
-target_link_libraries(remove_rotation_only_images
+## Declare a C++ executable: partition_image_sequences
+add_executable(partition_image_sequences tools/partition_image_sequences.cc tools/utilities.cc)
+add_dependencies(partition_image_sequences ${catkin_EXPORTED_TARGETS})
+target_link_libraries(partition_image_sequences
   sparse_mapping ${catkin_LIBRARIES})
 
 endif (NOT USE_CTC)

--- a/localization/sparse_mapping/build_map.md
+++ b/localization/sparse_mapping/build_map.md
@@ -58,17 +58,16 @@ temporarily modify the above files to reflect your camera's parameters
 More details on these and other environmental variables can be found
 in the \ref astrobee configuration documentation.
 
-## Reduce the number of images and remove images that might cause errors during bundle-adjustment 
+## Partition the files into movement sequences and reduce the number of images to improve bundle-adjustment accuracy
+Partition image files into sequences:
+    rosrun sparse_mapping partition_image_sequences image_directory_name config_path
+
+Partitions a sequentially ordered set of image files into valid, rotation, and invalid sequences. During bundle adjustment, it is useful to avoid adding pure rotation sequences initially as these cause errors for monocular systems. The resulting sequences can be individually bundle-adjusted and merged as described later, generally starting with the valid (non-rotation) sequences and optionally adding rotations at the end once enough matches exist in the map. See 'rosrun sparse_mapping partition_image_sequences -h' for more usage details, options, and instructions.
 
 Remove low movement images:
     rosrun sparse_mapping remove_low_movement_images image_directory_name
 
 This will delete subsequent images with low movement from that directory to improve mapping performance and accuracy. 
-
-Remove rotation-only movement images:
-    rosrun sparse_mapping remove_rotation_only_images image_directory_name config_path
-
-Removes rotation only image sequences and optionally saves different movement sequences to different subdirectories. See 'rosrun sparse_mapping remove_rotation_only_images -h' for more usage details, options, and instructions.
 
 These are non-reversible operations, so they should be invoked on a copy
 of the images.
@@ -76,7 +75,7 @@ of the images.
 If possible, the robot should have some translation motion (in addition to any rotation) when
 the data is acquired.
 
-Removing low movement and rotation only movement images helps the accuracy of bundle adjustment, which struggles to optimize camera poses with small or no translation changes.
+Removing low movement images and initially only adding valid movement images helps the accuracy of bundle adjustment, which struggles to optimize camera poses with small or no translation changes.
 
 ## Building a map
 

--- a/localization/sparse_mapping/theia_map.md
+++ b/localization/sparse_mapping/theia_map.md
@@ -130,15 +130,15 @@ double-precision seconds since epoch), which provides for a rather
 unique name, as compared to using the image index in the bag without
 that option.
 
+Partition image files into sequences:
+    rosrun sparse_mapping partition_image_sequences image_directory_name config_path
+
+Partitions a sequentially ordered set of image files into valid, rotation, and invalid sequences. During bundle adjustment, it is useful to avoid adding pure rotation sequences initially as these cause errors for monocular systems. The resulting sequences can be individually bundle-adjusted and merged as described later, generally starting with the valid (non-rotation) sequences and optionally adding rotations at the end once enough matches exist in the map. See 'rosrun sparse_mapping partition_image_sequences -h' for more usage details, options, and instructions.
+
 Remove low movement images:
     rosrun sparse_mapping remove_low_movement_images image_directory_name
 
 This will delete subsequent images with low movement from that directory to improve mapping performance and accuracy. 
-
-Remove rotation-only movement images:
-    rosrun sparse_mapping remove_rotation_only_images image_directory_name config_path
-
-Removes rotation only image sequences and optionally saves different movement sequences to different subdirectories. See 'rosrun sparse_mapping remove_rotation_only_images -h' for more usage details, options, and instructions.
 
 These are non-reversible operations, so they should be invoked on a copy
 of the images.
@@ -146,7 +146,7 @@ of the images.
 If possible, the robot should have some translation motion (in addition to any rotation) when
 the data is acquired.
 
-Removing low movement and rotation only movement images helps the accuracy of bundle adjustment, which struggles to optimize camera poses with small or no translation changes.
+Removing low movement images and initially only adding valid movement images helps the accuracy of bundle adjustment, which struggles to optimize camera poses with small or no translation changes.
 
 Put the selected images in a list:
 

--- a/localization/sparse_mapping/tools/remove_rotation_only_images.cc
+++ b/localization/sparse_mapping/tools/remove_rotation_only_images.cc
@@ -241,9 +241,8 @@ void ClusterResults(const int min_separation_between_sets, const ResultType& typ
       result.cluster_start_index = *start_index;
       current_separation = 0;
       continue;
-    } else if (++current_separation > min_separation_between_sets) {
+    } else if (++current_separation > min_separation_between_sets) {  // NOLINT
       start_index = boost::none;
-    } else {
     }
   }
 }

--- a/localization/sparse_mapping/tools/remove_rotation_only_images.cc
+++ b/localization/sparse_mapping/tools/remove_rotation_only_images.cc
@@ -324,6 +324,8 @@ std::vector<Result> RemoveRotationOnlyImages(const std::vector<std::string>& ima
     if (current_image_index >= image_names.size() - 1) break;
     next_image = sm::LoadImage(++next_image_index, image_names, detector);
   }
+
+  return results;
 }
 
 int main(int argc, char** argv) {

--- a/localization/sparse_mapping/tools/remove_rotation_only_images.cc
+++ b/localization/sparse_mapping/tools/remove_rotation_only_images.cc
@@ -259,6 +259,47 @@ void OrderClusters(std::vector<Result>& results) {
   }
 }
 
+int CountResults(const std::vector<Result>& results, const ResultType type) {
+  int count = 0;
+  for (const auto& result : results) {
+    if (result.type == type) ++count;
+  }
+  return count;
+}
+
+void MarkSmallSequencesInvalid(const int min_sequence_size, std::vector<Result>& results) {
+  std::vector<ResultType> types = {ResultType::kValid, ResultType::kRotation};
+  for (const auto type : types) {
+    int current_cluster_size = 0;
+    boost::optional<int> first_cluster_index;
+    int last_cluster_index;
+    for (int i = 0; i < results.size(); ++i) {
+      const auto& result = results[i];
+      if (result.type == type) {
+        if (!first_cluster_index) {
+          first_cluster_index = result.cluster_start_index;
+          ++current_cluster_size;
+        } else if (result.cluster_start_index !=
+                   *first_cluster_index) {  // New cluster started, check size of previous cluster
+          // Mark cluster as invalid if it is too small
+          if (current_cluster_size < min_sequence_size) {
+            for (int j = *first_cluster_index; j <= last_cluster_index; ++j) {
+              auto& result = results[j];
+              if (result.type == type) {
+                result.type = ResultType::kInvalid;
+              }
+            }
+          }
+          first_cluster_index = result.cluster_start_index;
+          current_cluster_size = 1;
+        } else {
+          ++current_cluster_size;
+        }
+      }
+    }
+  }
+}
+
 void MoveResultsToSubdirectories(const std::string& image_directory, const int min_separation_between_sets,
                                  std::vector<Result>& results) {
   ClusterResults(min_separation_between_sets, ResultType::kValid, results);
@@ -417,9 +458,21 @@ int main(int argc, char** argv) {
 
   LogInfo("Removing rotation sequences, max allowed separation: " + std::to_string(max_separation_in_sequence));
   RemoveRotationSequences(max_separation_in_sequence, results);
+  {
+    const int valid_count = CountResults(results, ResultType::kValid);
+    const int invalid_count = CountResults(results, ResultType::kInvalid);
+    const int rotation_count = CountResults(results, ResultType::kRotation);
+    LogInfo("pre small seq Valid images: " << valid_count << " , rotation images: " << rotation_count
+                                           << ", invalid images: " << invalid_count);
+  }
+  // TODO(rsoussan): make this a param
+  const int min_sequence_size = 5;
+  MarkSmallSequencesInvalid(min_sequence_size, results);
   LogInfo("Moving results to subdirectories.");
+  const int valid_count = CountResults(results, ResultType::kValid);
+  const int invalid_count = CountResults(results, ResultType::kInvalid);
+  const int rotation_count = CountResults(results, ResultType::kRotation);
   MoveResultsToSubdirectories(image_directory, min_separation_between_sets, results);
-  const int num_rotation_or_invalid_images = 0;
-  LogInfo("Total rotation or invalid images: " << num_rotation_or_invalid_images << " of " << num_original_images
-                                               << ".");
+  LogInfo("Valid images: " << valid_count << " , rotation images: " << rotation_count
+                           << ", invalid images: " << invalid_count);
 }

--- a/localization/sparse_mapping/tools/utilities.cc
+++ b/localization/sparse_mapping/tools/utilities.cc
@@ -107,13 +107,24 @@ vc::LKOpticalFlowFeatureDetectorAndMatcherParams LoadParams() {
   return params;
 }
 
+// Order absolute paths using just the filename
+struct filename_ordering {
+  inline bool operator()(const std::string& filepath_a, const std::string& filepath_b) {
+    const auto path_a = fs::path(filepath_a);
+    const std::string file_a = path_a.filename().string();
+    const auto path_b = fs::path(filepath_b);
+    const std::string file_b = path_b.filename().string();
+    return (file_a < file_b);
+  }
+};
+
 std::vector<std::string> GetImageNames(const std::string& image_directory, const std::string& image_extension) {
   std::vector<std::string> image_names;
   for (const auto& file : fs::recursive_directory_iterator(image_directory)) {
     if (fs::is_regular_file(file) && file.path().extension() == image_extension)
       image_names.emplace_back(fs::absolute(file.path()).string());
   }
-  std::sort(image_names.begin(), image_names.end());
+  std::sort(image_names.begin(), image_names.end(), filename_ordering());
   LogInfo("Found " << image_names.size() << " images.");
   return image_names;
 }


### PR DESCRIPTION
Changed the rotation detection script to partition a set of sequential image files around rotation/invalid movement.  This attempts to automate what we have been doing manually with each bagfile, splitting into sets of valid movements before running bundle-adjustment and merging.  The sequences are split around rotations and each sequence is saved in numeric order. Thus, valid sequences can be bundle-adjusted and merged first, and rotation sequences can optionally be added later when there is enough valid data in the map to handle them. Many of these changes stem from a discussion with Andres about how the tools are currently used for map creation.
The result can still be paired with removing low image movements.
@amoravargas  