### PR TITLE
exit or return in case pushd or popd fails

### DIFF
--- a/scripts/build/build_gnc_autocode_p4.sh
+++ b/scripts/build/build_gnc_autocode_p4.sh
@@ -18,7 +18,7 @@
 # under the License.
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-pushd $DIR/../../gnc/matlab/Prototypes/Proto_4/ > /dev/null
+pushd "$DIR"/../../gnc/matlab/Prototypes/Proto_4/ > /dev/null || exit
 matlab-2016b -nosplash -nodisplay -r "build_Proto4; exit"
-popd > /dev/null
+popd > /dev/null || exit
 


### PR DESCRIPTION
Line 21:
"$DIR" Double quote to prevent globbing and word splitting.
Use 'pushd ... || exit' or 'pushd ... || return' in case pushd fails. 

Line 23:
Use 'popd ... || exit' or 'popd ... || return' in case popd fails.