### PR TITLE
make CI work on ros2 branch

### DIFF
--- a/astrobee/CMakeLists.txt
+++ b/astrobee/CMakeLists.txt
@@ -24,10 +24,12 @@ set(ASTROBEE_VERSION 0.16.6)
 add_compile_options(-std=c++14)
 
 # Verify the user has the pre-commit hook
-execute_process(
-  COMMAND cp ../scripts/git/pre-commit ../.git/hooks
-  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-  )
+# (This functionality has been moved to configure.sh to avoid
+# depending on having the .git folder present.)
+#execute_process(
+#  COMMAND cp ../scripts/git/pre-commit ../.git/hooks
+#  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+#  )
 
 # Build for ROS1
 if("$ENV{ROS_VERSION}" STREQUAL "1")

--- a/scripts/docker/astrobee.Dockerfile
+++ b/scripts/docker/astrobee.Dockerfile
@@ -7,6 +7,7 @@ ARG REMOTE=astrobee
 FROM ${REMOTE}/astrobee:latest-base-ubuntu${UBUNTU_VERSION}
 
 ARG ROS_VERSION=kinetic
+ARG PYTHON=''
 
 RUN apt-get update \
   && apt-get install -y python${PYTHON}-jinja2 \

--- a/scripts/docker/astrobee.Dockerfile
+++ b/scripts/docker/astrobee.Dockerfile
@@ -8,6 +8,10 @@ FROM ${REMOTE}/astrobee:latest-base-ubuntu${UBUNTU_VERSION}
 
 ARG ROS_VERSION=kinetic
 
+RUN apt-get update \
+  && apt-get install -y python${PYTHON}-jinja2 \
+  && rm -rf /var/lib/apt/lists/*
+
 COPY . /src/astrobee/git_src/
 RUN . /opt/ros/${ROS_VERSION}/setup.sh \
 	&& cd /src/astrobee \

--- a/scripts/docker/astrobee.Dockerfile
+++ b/scripts/docker/astrobee.Dockerfile
@@ -8,10 +8,10 @@ FROM ${REMOTE}/astrobee:latest-base-ubuntu${UBUNTU_VERSION}
 
 ARG ROS_VERSION=kinetic
 
-COPY . /src/astrobee/src/
+COPY . /src/astrobee/git_src/
 RUN . /opt/ros/${ROS_VERSION}/setup.sh \
 	&& cd /src/astrobee \
-	&& ./src/scripts/configure.sh -l -F -D -T \
+	&& ./git_src/scripts/configure.sh -l -F -D -T \
 	&& CMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH:/src/astrobee/src/cmake \
 	&& catkin build --no-status --force-color
 

--- a/scripts/docker/astrobee_base.Dockerfile
+++ b/scripts/docker/astrobee_base.Dockerfile
@@ -53,10 +53,6 @@ COPY ./scripts/setup/packages_*.lst /setup/astrobee/
 RUN /setup/astrobee/install_desktop_packages.sh \
   && rm -rf /var/lib/apt/lists/*
 
-RUN apt-get update \
-  && apt-get install -y python${PYTHON}-jinja2 \
-  && rm -rf /var/lib/apt/lists/*
-
 #Add the entrypoint for docker
 RUN echo "#!/bin/bash\nset -e\n\nsource \"/opt/ros/${ROS_VERSION}/setup.bash\"\nsource \"/src/astrobee/devel/setup.bash\"\nexport ASTROBEE_CONFIG_DIR=\"/src/astrobee/src/astrobee/config\"\nexec \"\$@\"" > /astrobee_init.sh && \
   chmod +x /astrobee_init.sh && \

--- a/scripts/docker/astrobee_base.Dockerfile
+++ b/scripts/docker/astrobee_base.Dockerfile
@@ -53,6 +53,10 @@ COPY ./scripts/setup/packages_*.lst /setup/astrobee/
 RUN /setup/astrobee/install_desktop_packages.sh \
   && rm -rf /var/lib/apt/lists/*
 
+RUN apt-get update \
+  && apt-get install -y python${PYTHON}-jinja2 \
+  && rm -rf /var/lib/apt/lists/*
+
 #Add the entrypoint for docker
 RUN echo "#!/bin/bash\nset -e\n\nsource \"/opt/ros/${ROS_VERSION}/setup.bash\"\nsource \"/src/astrobee/devel/setup.bash\"\nexport ASTROBEE_CONFIG_DIR=\"/src/astrobee/src/astrobee/config\"\nexec \"\$@\"" > /astrobee_init.sh && \
   chmod +x /astrobee_init.sh && \


### PR DESCRIPTION
This is a temporary fix for the CI on the `ros2` branch until we remove the universal package stuff. It installs Jinja2 in the `astrobee_base` Docker image (again, temporarily) and fixes some issues in `configure.sh`.

Because the CI testing uses the base Docker image, this PR is not expected to initially pass CI testing, but it should pass after it's merged and the CI action to push the base Docker image is manually invoked. (You can see it passed CI testing here https://github.com/trey0/astrobee/actions/runs/3641004701 )