### PR TITLE
alias python to python3 for compatibility with astrobee scripts

### DIFF
--- a/scripts/docker/ros2/ros2_rolling_base.Dockerfile
+++ b/scripts/docker/ros2/ros2_rolling_base.Dockerfile
@@ -79,3 +79,6 @@ RUN pip3 install -U \
 #     x-window-system \
 #     ros-rolling-gazebo-ros-pkgs \
 #     && rm -rf /var/lib/apt/lists/*
+
+# make python run python3 for compatibility with astrobee scripts
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 1


### PR DESCRIPTION
Our baseline approach for Astrobee Python scripts is that they should be compatible with both Python 2 (for Ubuntu 16.04) and Python 3 (for 20.04) and start with the line `#!/usr/bin/env python`.

However, Ubuntu's consistent default across distros is that `python` runs Python 2 (if installed) or otherwise gives an error. In the latter case we need to alias `python` to run Python 3.

This is already handled in [`install_desktop_packages.sh`](https://github.com/nasa/astrobee/blob/271b6906c626ca874ebba4106444995d44092aab/scripts/setup/install_desktop_packages.sh#L84), but since that script isn't currently invoked during setup on the `ros2` branch, we can do it in the `Dockerfile` instead.

(Eventually, the Python scripts can be changed to run `#!/usr/bin/env python3` and drop Python 2 compatibility, at which point the alias would no longer be needed, but it seems simpler to wait on that until after completing the ROS2 migration.)