### PR TITLE
Docker docs

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,44 +1,48 @@
 # Install
 
-## Quick start using the remote Astrobee Docker images
+## System requirements
 
-*The following has been tested on native Ubuntu systems using X11 (the default). Please see [these ROS pages](http://wiki.ros.org/docker/Tutorials#Tooling_with_Docker) for more resources.*
+Ubuntu 20.04 is the preferred host OS for most Astrobee developers to use.
 
-Make sure you have Docker installed in your Ubuntu system following the [installation instructions](https://docs.docker.com/engine/install/ubuntu/) and [post-installation steps for Linux](https://docs.docker.com/engine/install/linux-postinstall/).
+Here are the available host OS options with development roadmap details:
+- Ubuntu 20.04: This is the preferred host OS for most Astrobee developers to use. The Astrobee Facility team is currently preparing to upgrade the robots on ISS from Ubuntu 16.04 to Ubuntu 20.04, but we aren't yet ready to announce a deployment date for that upgrade.
+- Ubuntu 18.04: We are not aware of any current robot users that still need Ubuntu 18.04 support, and expect to discontinue support in the near future. New users should not select this host OS.
+- Ubuntu 16.04: The Astrobee robot hardware on ISS currently runs Ubuntu 16.04. Only developers with NASA internal access can cross-compile software to run on the robot, and must use 16.04 for that. Most developers shouldn't need to work with 16.04, especially when just getting started. Support will eventually be discontinued after the robot hardware on ISS is upgraded to Ubuntu 20.04.
 
-For some systems (with discrete graphics cards), you may need to install [additional software for hardware acceleration](http://wiki.ros.org/docker/Tutorials/Hardware%20Acceleration).
+Graphical interfaces will perform best if your host OS is running natively (not in a virtual machine).
 
-``` bash
-git clone https://github.com/nasa/astrobee.git
-cd astrobee
-./scripts/docker/run.sh --remote
-```
+Your host OS must have an X11 server installed if you want to use graphical applications, even if you are developing inside a Docker container (the X11 application running inside the container will forward its interface to the host's X11 server). X11 comes with Ubuntu Desktop by default.
+
+If you plan to develop inside Docker, see [this page on using ROS with Docker](http://wiki.ros.org/docker/Tutorials#Tooling_with_Docker) for more details.
+
+## Option 1: Install inside a Docker container
+
+1. Make sure you have Docker installed in your system by following:
+    - [Docker installation instructions](https://docs.docker.com/engine/install/ubuntu/)
+    - [Docker post-installation configuration for Linux](https://docs.docker.com/engine/install/linux-postinstall/)
+    - If your system has a discrete graphics card, you may need to install [additional software for hardware acceleration](http://wiki.ros.org/docker/Tutorials/Hardware%20Acceleration).
+
+2. Check out the Astrobee Robot Software with:
+    ```bash
+    export ASTROBEE_WS=$HOME/astrobee  # your choice where
+    git clone https://github.com/nasa/astrobee.git $ASTROBEE_WS/src
+    cd $ASTROBEE_WS/src
+    git submodule update --init --depth 1 description/media
+    ```
+
+3. Here is a quick-start command to install the Astrobee Robot Software inside a Docker container and start a simulation run:
+    ```bash
+    ./scripts/docker/run.sh --remote
+    ```
+
+There is also experimental support for using the Visual Studio Code Dev Containers plugin to access an integrated development environment running inside the Docker container!
 
 For much more discussion, see: \subpage install-docker.
 
-## Building the code natively
+## Option 2: Install in your native OS
 
-There are different ways to build and test the code.
+The native installation instructions below walk you through manually running the same steps that are fully automated in a Docker installation.
 
-### Non-NASA users
+- If you are an external developer, see: \subpage install-nonNASA
 
-If you are a non-NASA user the preferred supported method is to use Ubuntu 16 and ROS kinetic. Ubuntu 18 and ROS melodic instructions are included, but not officially supported. This method does not require VPN access.
-
-\subpage install-nonNASA
-
-
-### NASA users
-
-If you are a NASA user and want to install the cross-compiler for robot testing follow these instructions:
-
-\subpage install-NASA
-
-## Developing using Docker
-
-Docker builds are available for Ubuntu 16.04, 18.04 and 20.04.
-
-We recommend using Visual Studio Code Dev Containers extension that allows usage of a Docker container as a full-featured development environment. When you open the astrobee folder on vscode the prompt will show up to launch the dev container automatically.
-
-Instructions on how to build the images natively and run the containers are in:
-
-\subpage install-docker
+- If you have NASA internal access and need to cross-compile for the robot hardware, see: \subpage install-NASA

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,12 +1,12 @@
 # Install
 
-## Quick start using the remote Astrobee docker images
+## Quick start using the remote Astrobee Docker images
 
 *The following has been tested on native Ubuntu systems using X11 (the default). Please see [these ROS pages](http://wiki.ros.org/docker/Tutorials#Tooling_with_Docker) for more resources.*
 
 Make sure you have Docker installed in your Ubuntu system following the [installation instructions](https://docs.docker.com/engine/install/ubuntu/) and [post-installation steps for Linux](https://docs.docker.com/engine/install/linux-postinstall/).
 
-For some systems (with discrete graphics cards), you may need to install [additional software](http://wiki.ros.org/docker/Tutorials/Hardware%20Acceleration).
+For some systems (with discrete graphics cards), you may need to install [additional software for hardware acceleration](http://wiki.ros.org/docker/Tutorials/Hardware%20Acceleration).
 
 ``` bash
 git clone https://github.com/nasa/astrobee.git
@@ -14,7 +14,7 @@ cd astrobee
 ./scripts/docker/run.sh --remote
 ```
 
-For more options, see: \ref install-docker.
+For much more discussion, see: \subpage install-docker.
 
 ## Building the code natively
 
@@ -29,7 +29,7 @@ If you are a non-NASA user the preferred supported method is to use Ubuntu 16 an
 
 ### NASA users
 
-If you are a NASA user and want to install the cross-compiler for robot testing follow these instructions: 
+If you are a NASA user and want to install the cross-compiler for robot testing follow these instructions:
 
 \subpage install-NASA
 

--- a/scripts/docker/readme.md
+++ b/scripts/docker/readme.md
@@ -4,7 +4,7 @@
 
 Before running these instructions, make sure you visit the main Astrobee INSTALL page and:
 - Check the system requirements.
-- Follow the Docker-option install steps 1-2 (install Docker and check out the Astrobee Robot Software).
+- Follow the Docker-option install steps 1-2, install Docker and check out the Astrobee Robot Software (ARS).
 
 # Option 1: Using Visual Studio Code (experimental!)
 
@@ -40,7 +40,7 @@ cd $ASTROBEE_WS/src
 
 Or you can open the `$ASTROBEE_WS/src` folder through the VSCode graphical interface, and you should then see a popup dialog from the Dev Containers plugin. Click the "Reopen in Container" button.
 
-Either way, the Dev Containers plugin will download a pre-built Astrobee Robot Software Docker image from our official repository, start it running, and provide you with a development environment running inside the container.
+Either way, the Dev Containers plugin will download a pre-built ARS Docker image from our official repository, start it running, and provide you with a development environment running inside the container.
 
 You can manage your Dev Containers configuration using the files in the `.devcontainer` folder at the top level. For example, you can select a different Docker image to install from [the list on GitHub](https://github.com/nasa/astrobee/pkgs/container/astrobee) using the `FROM` command in the `Dockerfile`.
 
@@ -54,28 +54,28 @@ You can start by selecting `View->Terminal` in the VSCode graphical interface. T
 
 ## Quick start run
 
-You can install Astrobee Robot Software inside a Docker container and run a software simulation with:
+You can install ARS inside a Docker container and run a software simulation with:
 
 ```bash
 cd $ASTROBEE_WS/src
 ./scripts/docker/run.sh --remote
 ```
 
-Invoking `run.sh --remote` calls Docker with the right arguments such that it will download the latest pre-built complete Astrobee Robot Software image from our official Docker image repository, start it as a container, and invoke a default command inside the container (which runs the software simulation).
+Invoking `run.sh --remote` calls Docker with the right arguments such that it will download the latest pre-built complete ARS image from our official Docker image repository, start it as a container, and invoke a default command inside the container (which runs the software simulation).
 
 ## Quick start build (if needed)
 
-The fastest way to recompile the ARS software to reflect your local changes is:
+The fastest way to recompile ARS to reflect your local changes is:
 
 ```bash
 ./scripts/docker/build.sh --remote astrobee_quick
 ```
 
-Invoking `build.sh --remote` calls Docker with the right arguments such that it will download the latest pre-built complete Astrobee Robot Software image from our official Docker image repository. Then it will build the `astrobee_quick` target, which does a quick recompile of the ARS software to reflect your changes, accelerated by using previously cached compilation results.
+Invoking `build.sh --remote` calls Docker with the right arguments such that it will download the latest pre-built complete ARS image from our official Docker image repository. Then it will build the `astrobee_quick` target, which does a quick recompile of the ARS software to reflect your changes, accelerated by using previously cached compilation results.
 
 # Overview of Docker support scripts
 
-The Astrobee Robot Software provides two main support scripts for working with Docker.
+ARS provides two main support scripts for working with Docker.
 
 The `build.sh` script builds new ARS Docker images, with many configuration options described later. As discussed in the "Quick start run" section, you can always start by running one of our pre-built images. You only need to build your own new image if you've modified the software.
 

--- a/scripts/docker/readme.md
+++ b/scripts/docker/readme.md
@@ -1,25 +1,96 @@
-\page install-docker Docker build
+\page install-docker Developing with Docker
 
-# Usage instructions for Docker
+# System requirements
 
-Make sure you have Docker installed in your Ubuntu system following the [installation instructions](https://docs.docker.com/engine/install/ubuntu/) and [post-installation steps for Linux](https://docs.docker.com/engine/install/linux-postinstall/).
+The instructions below assume your host OS is Ubuntu 16.04, 18.04, or 20.04. As of this writing, Ubuntu 20.04 is the preferred host OS for most Astrobee developers to use, at least until you get to the point of needing to cross-compile your code for the robot hardware.
 
-Here there are instructions on how to build and run the FSW using Docker.
-First, clone the flight software repository and media:
+Make sure you have Docker installed in your system following the [installation instructions](https://docs.docker.com/engine/install/ubuntu/) and [post-installation steps for Linux](https://docs.docker.com/engine/install/linux-postinstall/).
 
-    git clone https://github.com/nasa/astrobee.git $SOURCE_PATH
+# Clone the Astrobee Robot Software
+
+The instructions below assume you have cloned the software with:
+
+    export ASTROBEE_WS=$HOME/astrobee  # your choice where
+    git clone https://github.com/nasa/astrobee.git $ASTROBEE_WS/src
+    cd $ASTROBEE_WS/src
     git submodule update --init --depth 1 description/media
 
-The docker image for the astrobee FSW is divided throughout 2 docker files:
+# Quick start
 
-- `astrobee_base.Dockerfile` - Contains installation of all astrobee dependencies (Ubuntu + ROS setup).
-- `astrobee.Dockerfile` - Builds the astrobee FSW code on top of astrobee_base.
+## Quick start run
 
-For rebuilding the FSW you can use:
+You can immediately run a software simulation of Astrobee as follows:
 
-- `astrobee_quick.Dockerfile` - Builds the astrobee FSW code using a previous astrobee image as a build cache (if you want to clear the cache use astrobee.Dockerfile instead). This dramatically speeds up build times for small changes.
+    cd $ASTROBEE_WS/src
+    ./scripts/docker/run.sh --remote
 
-The Docker files accept the following version args (note that they must match up):
+Invoking `run.sh --remote` calls Docker with the right arguments such that it will download the latest pre-built complete Astrobee Robot Software image from our official Docker image repository, start it as a container, and invoke a default command inside the container (which runs the software simulation).
+
+## Quick start build (if needed)
+
+The fastest way to recompile the ARS software to reflect your local changes is:
+
+    ./scripts/docker/build.sh --remote astrobee_quick
+
+Invoking `build.sh --remote` calls Docker with the right arguments such that it will download the latest pre-built complete Astrobee Robot Software image from our official Docker image repository. Then it will build the `astrobee_quick` target, which does a quick recompile of the ARS software to reflect your changes, accelerated by using previously cached compilation results.
+
+# Overview of Docker scripts
+
+The Astrobee Robot Software provides two main support scripts for working with Docker.
+
+The `build.sh` script builds new ARS Docker images, with many configuration options described later. As discussed in the "Quick start run" section, you can always start by running one of our pre-built images. You only need to build your own new image if you've modified the software.
+
+The `run.sh` script (optionally downloads and) runs ARS Docker images.
+
+The two scripts have similar options to make it easy to run the specific image you just built.
+
+# Building Docker images
+
+## Build stages
+
+Among the `build.sh` command-line arguments, you can list targets you want to build. Some of the targets correspond to Docker images at different build stages:
+
+- `astrobee_base` - Starts with a baseline Ubuntu distribution and installs the external dependencies of ARS, including a ROS distribution and many external libraries built from source.
+- `astrobee` - Starts with `astrobee_base` and builds the ARS software.
+- `astrobee_quick` - Starts with `astrobee` and does a quick rebuild of the ARS software.
+- `test_astrobee` - Starts with `astrobee` and runs the subset of ARS tests that are compatible with the Docker environment.
+
+For all of these cases, each new build stage starts from the results of the previous build stage. If you run `build.sh --remote`, it will attempt to fetch a pre-built image for the previous build stage from the official Astrobee Docker repository. Without `--remote`, it will assume you built the previous stage yourself and search for the image on your local system.
+
+If you've made changes to ARS, here's how to figure out what `build.sh` target to specify:
+
+- Most commonly, you can build `astrobee_quick`. This should rebuild the ARS instance within your container to reflect your changes, taking advantage of cached results from the most recent build of the `astrobee` image to speed up compilation. The ARS build system is designed to detect when cached results need to be rebuilt by comparing file timestamps. However, the detection is not perfect in all cases, and invalid cache contents can occasionally cause build errors.
+- You would most likely build the `astrobee` target when building `astrobee_quick` generates errors that might be due to invalid cache contents. Because building `astrobee` starts from the `astrobee_base` image with no previous ARS compilation results, building it effectively clears the cache. Another good use for the `astrobee` target is in continuous integration workflows where we want to have strict configuration management to make the output products more deterministic.
+- As an external developer, you generally shouldn't need to build the `astrobee_base` target. That's a good thing, because building the external libraries from source typically takes hours. As a NASA-internal developer, you may rarely need to build `astrobee_base` if you are modifying `astrobee_base.Dockerfile` to install new external dependencies needed by the `develop` and `master` branches.
+- The `test_astrobee` target is most commonly used in continuous integration workflows to check that software changes didn't introduce errors. Because it always runs on top of the `astrobee` image, the test results will not reflect any changes that you compiled only by building `astrobee_quick`. You can manually run the same tests in the `astrobee_quick` container like this:
+
+    $ ./scripts/docker/run.sh -i "quick-" -- bash  # enter astrobee_quick container
+    # /src/astrobee/src/scripts/run_tests.sh
+
+In order to execute each of these build stages, `build.sh` invokes `docker build` on the corresponding `Dockerfile` in the `scripts/docker` folder, such as `astrobee_base.Dockerfile`. These files can give you insight into the detailed build steps at each stage.
+
+## Other build targets
+
+The `build.sh` script provides two other targets that are not build stages, but rather actions that you can take with the resulting products:
+
+- `push_astrobee_base` - Pushes the locally built `astrobee_base` image to our official Docker image repository
+- `push_astrobee` - Pushes the locally built `astrobee` image to our official Docker image repository
+
+These targets are mostly used in continuous integration workflows.
+
+All pre-built remote images are available on [github here](https://github.com/nasa/astrobee/pkgs/container/astrobee)
+
+## Other build options
+
+By default, the build script will automatically detect your host's Ubuntu OS version and configure the Docker image to use the same version using `Dockerfile` `ARGS`.
+
+However, there is no requirement for the host OS and the Docker image OS to match.  You can override the default and select a specific Docker image Ubuntu version by specifying `--xenial`, `--bionic`, or `--focal` for Ubuntu 16.04, 18.04, or 20.04 docker images, respectively.
+
+For more information about all the build arguments:
+
+    ./scripts/docker/build.sh -h
+
+The `build.sh` script normally manages these `Dockerfile` `ARGS` but you can set them yourself if you run `docker build` manually:
 
 - `UBUNTU_VERSION` - The version of Ubuntu to use. Valid values are "16.04", "18.04", and "20.04".
 - `ROS_VERSION` - The version of ROS to use. Valid values are "kinetic", "melodic", and "noetic".
@@ -31,40 +102,14 @@ If `UBUNTU_VERSION` is `"20.04"`, `ROS_VERSION` and `PYTHON` must be `"neotic"` 
 
 The Docker files also accept args to use local or container registry images.
 
-- `REMOTE` - The repository where the dockerfile should derive its base. Valid values are `astrobee` (the default for local builds) or `ghcr.io/nasa` (the official repository).
-- `REMOTE_CACHED` - (Only for `astrobee_quick.dockerfile`, defaults to `${REMOTE}`). The repository for the build cache image. Valid values are `astrobee` (the default for local builds) or `ghcr.io/nasa` (the official repository).
+- `REMOTE` - The repository where the dockerfile should derive its base. Valid values are `astrobee` (the default for local builds) or `ghcr.io/nasa` (the official repository used with `--remote`).
+- `REMOTE_CACHED` - (Only for `astrobee_quick.dockerfile`, defaults to `${REMOTE}`). The repository for the build cache image. Valid values are the same as for `REMOTE`.
 
-All pre-built remote images are available on [github here](https://github.com/nasa/astrobee/pkgs/container/astrobee)
-
-## Optional: Build the docker image
-
-The fastest way to start running the software is to fetch a remote
-docker image by using the `--remote` option with the `run.sh` script
-described below. Building the docker images is not required.
-
-However, if you need to build a local copy of the docker images, run:
-
-    ./scripts/docker/build.sh
-
-By default, the build script will automatically detect your host's
-Ubuntu OS version and configure the docker image to use the same
-version using the Dockerfile variables `UBUNTU_VERSION`,
-`ROS_VERSION`, and `PYTHON`.
-
-However, there is no requirement for the host OS and the docker image
-OS to match.  You can override the default and select a specific
-docker image Ubuntu version by specifying `--xenial`, `--bionic`, or
-`--focal` for Ubuntu 16.04, 18.04, or 20.04 docker images,
-respectively.
-
-For more information about all the arguments:
-
-    ./scripts/docker/build.sh -h
-
+# Running Docker containers
 
 ## Run the Astrobee simulator in the container
 
-For some systems (with discrete graphics cards), you may need to install [additional software](http://wiki.ros.org/docker/Tutorials/Hardware%20Acceleration).
+For some systems (with discrete graphics cards), you may need to install [additional software for hardware acceleration](http://wiki.ros.org/docker/Tutorials/Hardware%20Acceleration).
 
 To run the Astrobee simulator in the container:
 
@@ -74,8 +119,7 @@ For more information about all the arguments:
 
     ./scripts/docker/run.sh -h
 
-There are available options sucha as `--args` that allow you to add to the default sim arguments (`dds:=false robot:=sim_pub`) such as to open rviz or gazebo (`--args "rviz:=true sviz:=true"`).
-
+There are available options such as `--args` that allow you to add to the default sim arguments (`dds:=false robot:=sim_pub`) such as to open rviz or gazebo (`--args "rviz:=true sviz:=true"`).
 
 To open another terminal inside the same docker container:
 
@@ -158,6 +202,42 @@ will need to rebuild that locally as well:
 
     ./scripts/docker/build.sh astrobee_base astrobee test_astrobee
 
+# Using Visual Studio Code to develop inside a Docker container (experimental!)
+
+You may find it helpful to use VSCode's Docker integration to help you interactively develop inside the Docker container.
+
+Our team is tentatively moving in the direction of encouraging all developers to work this way, but our VSCode approach is still considered highly experimental and could change a lot.
+
+## Install VSCode and plugin
+
+There are many valid ways to install VSCode. These commands are for an APT-style installation on Ubuntu:
+
+    wget -q https://packages.microsoft.com/keys/microsoft.asc -O- | sudo apt-key add -
+    sudo add-apt-repository "deb [arch=amd64] https://packages.microsoft.com/repos/vscode stable main"
+    sudo apt-get update
+    sudo apt-get install -y code
+
+Docker integration is based on the Remote Containers plugin, which you can install with:
+
+    code --install-extension ms-vscode-remote.remote-containers
+
+## Use VSCode to open the folder inside the Docker container
+
+You can open the Astrobee folder inside the Docker container like this ([per the discussion here](https://github.com/microsoft/vscode-remote-release/issues/2133#issuecomment-1212180962)):
+
+    cd $ASTROBEE_WS/src
+    (path=$(pwd) && p=$(printf "%s" "$path" | xxd -p) && code --folder-uri "vscode-remote://dev-container+${p//[[:space:]]/}/src/astrobee/src")
+
+Or you can open the folder through the VSCode graphical interface, and you should then see a popup dialog from the Remote Containers plugin. Click the "Reopen in Container" button.
+
+## Interactively develop inside the Docker container
+
+A starting point is selecting `View->Terminal` in the VSCode graphical interface. This will display a terminal session inside the Docker container, much like `run.sh`, where you can run arbitrary commands. Your container will persist throughout your VSCode session, and changes you make using the VSCode editor will be reflected inside the container, making it easy to do quick interactive edit/build/test cycles.
+
+(Going forward, we could add a lot of tips here about how best to use VSCode inside the container.)
+
+# Advanced build options (NASA users only)
+
 ## Cross-compile Astrobee (NASA users only)
 
 To cross-compile Astrobee, you will need
@@ -194,7 +274,6 @@ where $DIR is the directory where the cross_compile.sh script is located.
 If you already cross-compiled once and just wish to rebuild the code, run:
 
     ./scripts/docker/cross_compile/rebuild_cross_compile.sh
-
 
 ## Building an Astrobee Debian (NASA users only)
 


### PR DESCRIPTION
Relates to #556 

This started as writing some initial docs for VSCode inside a Docker container (probably could be improved a lot). In the process, I ended up doing some reorganizing so the flow made more sense. And provided more clarity about OS versions. And made lots of style fixes.

It's probably easiest to review if you look at the GitHub-rendered Markdown:
- https://github.com/trey0/astrobee/blob/docker_docs/INSTALL.md
- https://github.com/trey0/astrobee/blob/docker_docs/scripts/docker/readme.md