### PR TITLE
set up astrobee_vnc docker example

### DIFF
--- a/scripts/docker/astrobee_vnc.Dockerfile
+++ b/scripts/docker/astrobee_vnc.Dockerfile
@@ -1,0 +1,34 @@
+# On top of the normal Astrobee image, this will set up a VNC server
+# running inside the Docker container so you can run graphical
+# applications and view them using a VNC client.
+
+ARG UBUNTU_VERSION=20.04
+ARG REMOTE=astrobee
+FROM ${REMOTE}/astrobee:latest-ubuntu${UBUNTU_VERSION}
+
+# Rationale for packages:
+#   xvfb: X server that doesn't need GPU or physical display
+#   x11vnc: VNC server that shares xvfb display with external VNC clients
+#   xfce4: lightweight window manager
+#   dbus-x11: inter-process communication needed by xfce
+#   x11-apps: X11 apps to demo such as xeyes
+#   x11-utils: debugging commands such as xdpyinfo
+#   x11-xserver-utils: setup commands such as xset
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    dbus-x11 \
+    x11-apps \
+    x11-utils \
+    x11-xserver-utils \
+    x11vnc \
+    xfce4 \
+    xvfb \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY ./scripts/start_vnc.sh /start_vnc.sh
+
+CMD ["/start_vnc.sh"]
+
+# Expose VNC server's port
+EXPOSE 5900

--- a/scripts/docker/build_vnc.sh
+++ b/scripts/docker/build_vnc.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+cd ${HOME}/astrobee/src
+docker build . -f ./scripts/docker/astrobee_vnc.Dockerfile --build-arg UBUNTU_VERSION=20.04 --build-arg REMOTE=ghcr.io/nasa -t astrobee/astrobee:latest-vnc-ubuntu20.04

--- a/scripts/docker/exec_vnc.sh
+++ b/scripts/docker/exec_vnc.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+cd ${HOME}/astrobee/src
+docker exec -it --env "DISPLAY=:0" astrobee-vnc bash

--- a/scripts/docker/readme_vnc.md
+++ b/scripts/docker/readme_vnc.md
@@ -1,0 +1,54 @@
+
+# Astrobee Docker container with graphical applications shared via VNC #
+
+These setup instructions assume you want to run graphical applications inside a Docker container running on a remote host, and view the graphics on your local display.
+
+We assume the remote host is an Ubuntu host where:
+- Docker has been installed and configured to be used by non-admin users.
+- You already have the Astrobee source checked out per `INSTALL.md`.
+
+We'll call the remote host `remotehost` and your local host `laptop`.
+
+On `remotehost`, run these commands to build and run the `astrobee-vnc` container:
+```bash
+cd $ASTROBEE_WS/src/scripts/docker
+./build_vnc.sh
+./run_vnc.sh
+```
+
+Note that the `run_vnc.sh` command will spout a bunch of warnings that you can safely ignore, and it should keep running indefinitely. If you Ctrl-C out of it you will stop the container.
+
+In another terminal on `remotehost`, run:
+```bash
+remotehost$ cd $ASTROBEE_WS/src/scripts/docker
+remotehost$ ./exec_vnc.sh
+docker# xeyes &
+```
+
+Note that `exec_vnc.sh` opens up a shell session inside the container. The `xeyes` command demonstrates running an arbitrary X11 application inside the container that will connect to the display of the X server running inside the container.
+
+On `laptop`, run:
+```bash
+REMOTE_HOST=remotehost.ndc.nasa.gov  # choose your host
+ssh -L 127.0.0.1:5900:localhost:5900 $REMOTE_HOST -N
+```
+
+This will set up port forwarding between port 5900 of the `laptop` loopback interface and port 5900 of the `remotehost` loopback interface (note: explicitly restricting the forwarding to the loopback interface `127.0.0.1` is important for security). In turn, the Docker daemon will forward port 5900 of the `remotehost` loopback interface to port 5900 of the container where the VNC server is listening. That will allow us to run a VNC client on `laptop` and connect to the VNC server using localhost port 5900 with no fuss.
+
+Note that the `ssh` port forwarding command should keep running indefinitely. If you Ctrl-C out of it you will stop the port forwarding.
+
+In another terminal on `laptop`, run:
+```bash
+sudo apt-get install xtightvncviewer
+vncviewer localhost::5900 -encodings "copyrect tight hextile zlib corre rre raw"
+```
+
+The VNC client should show you an X11 desktop running the Xfce lightweight window manager and the `xeyes` example app we ran earlier. Success! This is the end of the demo.
+
+Note that the `-encodings` argument to `vncviewer` tells it to prefer more compressed encodings for low-bandwidth network connections. If you leave it out, `vncviewer` will notice that it is connecting to a VNC server on localhost, decide it doesn't need to worry about bandwidth, and default to an uncompressed `raw` encoding with poor network performance.
+
+## Limitations ##
+
+The `xvfb` server by default will probably not support modern X extensions such as RANDR and GLX that may be used by 3D-heavy applications like Gazebo and the Astrobee GDS Control Station. There are known workarounds for this, but it's currently left for future work. (Potential untested workaround: enable the extensions at the `xvfb` command line, install VirtualGL, and run the apps that need the extensions under `vglrun`.)
+
+The port should be configurable. Hard coding 5900 will cause conflicts if multiple users work on the same remote host. The VNC server is currently not configured to require authentication once the port forwarding is set up, so in theory you could join another user`s graphical session (is that a bug or a feature?).

--- a/scripts/docker/run_vnc.sh
+++ b/scripts/docker/run_vnc.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+cd ${HOME}/astrobee/src
+
+# Note: Explicitly specifying loopback interface (127.0.0.1) in -p is
+# important for security. Otherwise the VNC server will be accessible
+# from outward-facing network interfaces and you should expect a
+# warning from network security admins when it is found in a port scan.
+docker run -it --rm --name astrobee-vnc -p 127.0.0.1:5900:5900 astrobee/astrobee:latest-vnc-ubuntu20.04

--- a/scripts/start_vnc.sh
+++ b/scripts/start_vnc.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+# This script is designed to be run inside the container (Dockerfile "CMD") to start up the necessary daemons.
+
+export DISPLAY=${DISPLAY:-:0} # Select screen 0 by default.
+x11vnc -bg -forever -nopw -quiet -display WAIT$DISPLAY &
+Xvfb $DISPLAY -screen 0 1024x768x16 &
+sleep 1
+
+xdpyinfo
+
+# disable screen saver and power management
+xset -dpms &
+xset s noblank &
+xset s off &
+
+# start window manager
+/usr/bin/startxfce4 --replace > $HOME/wm.log &
+
+# CMD script should not exit
+sleep infinity


### PR DESCRIPTION
This PR is created as a working example for discussion.

Here's an overview: https://github.com/trey0/astrobee/blob/vnc/scripts/docker/readme_vnc.md

The point is to be able to run graphical applications on bartlett or other remote hosts and view the resulting display on your local host. This could be relevant for how we recommend future interns structure their dev environment!

This functionality may not belong as an extra `astrobee_vnc` layer on top of the normal `astrobee` images. It might be better to include it in the `astrobee` or `astrobee_base` Docker images instead. The current implementation optimizes for minimal changes and a quick build.

I didn't get to the point of trying all of the main applications we care about in the container. Marina's challenge was "show me xeyes", so here it is :)