### PR TITLE
Move ROS2 define to ff_ros header from cmake

### DIFF
--- a/mobility/framestore/CMakeLists.txt
+++ b/mobility/framestore/CMakeLists.txt
@@ -25,9 +25,6 @@ endif()
 
 set( CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -Wall -O3 -fPIC" )
 
-# Build for ROS2
-add_definitions(-DROS2)
-
 # Find amend and libraries
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)

--- a/mobility/framestore/tools/global_transforms.cc
+++ b/mobility/framestore/tools/global_transforms.cc
@@ -26,13 +26,12 @@
 #include <config_reader/config_reader.h>
 #include <msg_conversions/msg_conversions.h>
 
-#ifdef ROS2
 namespace geometry_msgs {
 typedef msg::TransformStamped TransformStamped;
 }  // namespace geometry_msgs
 
 static const rclcpp::Logger LOGGER = rclcpp::get_logger("framestore");
-#endif
+
 // Main entry point of application
 int main(int argc, char **argv) {
   ROS_CREATE_NODE("global_transforms");

--- a/shared/ff_common/CMakeLists.txt
+++ b/shared/ff_common/CMakeLists.txt
@@ -25,9 +25,6 @@ set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -Wall -O3 -fPIC")
 
 find_package(Eigen3 REQUIRED)
 
-# Build for ROS2
-add_definitions(-DROS2)
-
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(std_msgs REQUIRED)

--- a/shared/ff_common/include/ff_common/ff_ros.h
+++ b/shared/ff_common/include/ff_common/ff_ros.h
@@ -24,6 +24,10 @@
 #ifndef FF_COMMON_FF_ROS_H_
 #define FF_COMMON_FF_ROS_H_
 
+// This is the ROS2 astrobee branch. Check out the other branch for ros1.
+// We keep the definitions for both versions to reducing merging hassle.
+#define ROS2
+
 #if ROS1
 #include <ros/ros.h>
 

--- a/shared/msg_conversions/CMakeLists.txt
+++ b/shared/msg_conversions/CMakeLists.txt
@@ -27,7 +27,6 @@ set( CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -Wall -O3 -fPIC" )
 
 find_package(Eigen3 REQUIRED)
 
-add_definitions(-DROS2)
 # Find amend and libraries
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
@@ -49,7 +48,7 @@ find_package(tf2_geometry_msgs REQUIRED)
 # Your package locations should be listed before other locations
 include_directories(
   include
-  ${config_reader_INCLUDE_DIRS}  # ROS2
+  ${config_reader_INCLUDE_DIRS}
 )
 
 # Declare C++ libraries

--- a/simulation/CMakeLists.txt
+++ b/simulation/CMakeLists.txt
@@ -25,9 +25,6 @@ endif()
 
 set( CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -Wall -O3 -fPIC" )
 
-# Build for ROS2
-add_definitions(-DROS2)
-
 # Find amend and libraries
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)


### PR DESCRIPTION
I think it will be simpler like this so we don't have to put this over every cmake file.