### PR TITLE
Remove unnecessary return; from last line of void functions

### DIFF
--- a/behaviors/arm/src/arm_nodelet.cc
+++ b/behaviors/arm/src/arm_nodelet.cc
@@ -1058,7 +1058,6 @@ class ArmNodelet : public ff_util::FreeFlyerNodelet {
   // Preempt the current action with a new action
   void PreemptCallback() {
     Result(RESPONSE::PREEMPTED);
-    return;
   }
 
   // A Cancellation request arrives

--- a/hardware/pico_driver/src/pico_driver.cc
+++ b/hardware/pico_driver/src/pico_driver.cc
@@ -627,7 +627,6 @@ class PicoDriverNodelet : public ff_util::FreeFlyerNodelet  {
   void InitFault(std::string const& msg ) {
     NODELET_ERROR_STREAM(msg);
     AssertFault(ff_util::INITIALIZATION_FAILED, msg);
-    return;
   }
 
  private:

--- a/hardware/speed_cam/src/speed_cam_node.cc
+++ b/hardware/speed_cam/src/speed_cam_node.cc
@@ -110,7 +110,6 @@ class SpeedCamNode : public ff_util::FreeFlyerNodelet {
   void InitFault(std::string const& msg ) {
     NODELET_ERROR_STREAM(msg);
     AssertFault(ff_util::INITIALIZATION_FAILED, msg);
-    return;
   }
 
   // Callback from speedcam when new a new scaled IMU measurement is produced

--- a/localization/sparse_mapping/src/sparse_mapping.cc
+++ b/localization/sparse_mapping/src/sparse_mapping.cc
@@ -855,8 +855,6 @@ void sparse_mapping::ParseCSV(std::string const& csv_file,
         (*cols)[col_names[col_pos]].push_back(v);
     }
   }
-
-  return;
 }
 
 // save size before protbuf, to save multiple protobufs in one file
@@ -1348,6 +1346,4 @@ void sparse_mapping::PoseInterpolation(std::vector<std::string> const& images,
     }
     it.close();
   }
-
-  return;
 }

--- a/localization/sparse_mapping/src/tensor.cc
+++ b/localization/sparse_mapping/src/tensor.cc
@@ -1449,8 +1449,6 @@ void MergeMaps(sparse_mapping::SparseMap * A_in,
   }
 
   LOG(INFO) << "Total number of tracks in the merged map: " << C.pid_to_xyz_.size();
-
-  return;
 }
 
 // Take a map. Form a map with only a subset of the images.
@@ -1560,8 +1558,6 @@ void ExtractSubmap(std::vector<std::string> * keep_ptr,
   LOG(INFO) << "Number of images in the extracted map: " << map.cid_to_filename_.size();
   LOG(INFO) << "Number of tracks in the extracted map: " << map.pid_to_cid_fid_.size();
   // map.Save(output_map + ".extracted.map");
-
-  return;
 }
 
 // Register a map to world coordinates from user-supplied data, or simply

--- a/localization/sparse_mapping/src/vocab_tree.cc
+++ b/localization/sparse_mapping/src/vocab_tree.cc
@@ -403,8 +403,6 @@ void QueryDB(std::string const& descriptor, VocabDB * vocab_db,
     // no database specified
     return;
   }
-
-  return;
 }
 
 void BuildDBforDBoW2(SparseMap* map, std::string const& descriptor,

--- a/management/access_control/src/access_control.cc
+++ b/management/access_control/src/access_control.cc
@@ -154,7 +154,6 @@ void AccessControl::HandleGrabControl(ff_msgs::CommandStampedConstPtr const&
 
   PublishState();
   PublishAck(cmd->cmd_id);
-  return;
 }
 
 void AccessControl::HandleRequestControl(ff_msgs::CommandStampedConstPtr const&

--- a/management/cpu_mem_monitor/src/cpu_mem_monitor.cc
+++ b/management/cpu_mem_monitor/src/cpu_mem_monitor.cc
@@ -370,7 +370,6 @@ void CpuMemMonitor::GetPIDs(ros::TimerEvent const &te) {
       it->second = std::stoi(pid);
     }
   }
-  return;
 }
 
 int CpuMemMonitor::CollectCPUStats() {

--- a/mobility/choreographer/include/choreographer/planner.h
+++ b/mobility/choreographer/include/choreographer/planner.h
@@ -203,7 +203,6 @@ class PlannerImplementation : public ff_util::FreeFlyerNodelet {
   void InitFault(std::string const& msg ) {
     NODELET_ERROR_STREAM(msg);
     AssertFault(ff_util::INITIALIZATION_FAILED, msg);
-    return;
   }
 
   // Finish this action

--- a/mobility/choreographer/test/test_obstacle.cc
+++ b/mobility/choreographer/test/test_obstacle.cc
@@ -70,8 +70,6 @@ void StateCallback(const ff_msgs::EkfStateConstPtr& state) {
     sub_ekf_.shutdown();
   sleep(1);
   stable_ = true;
-
-  return;
 }
 
 // Keepout zone test

--- a/mobility/choreographer/test/test_zones_keepin.cc
+++ b/mobility/choreographer/test/test_zones_keepin.cc
@@ -68,7 +68,6 @@ void StateCallback(const ff_msgs::EkfStateConstPtr& state) {
     sub_ekf_.shutdown();
   sleep(1);
   stable_ = true;
-  return;
 }
 
 // Keepout zone test

--- a/mobility/choreographer/test/test_zones_keepout.cc
+++ b/mobility/choreographer/test/test_zones_keepout.cc
@@ -70,7 +70,6 @@ void StateCallback(const ff_msgs::EkfStateConstPtr& state) {
     sub_ekf_.shutdown();
   sleep(1);
   stable_ = true;
-  return;
 }
 
 // Keepout zone test

--- a/mobility/choreographer/test/test_zones_nominal.cc
+++ b/mobility/choreographer/test/test_zones_nominal.cc
@@ -69,8 +69,6 @@ void StateCallback(const ff_msgs::EkfStateConstPtr& state) {
     sub_ekf_.shutdown();
   sleep(1);
   stable_ = true;
-
-  return;
 }
 
 // Keepout zone test

--- a/mobility/framestore/src/framestore.cc
+++ b/mobility/framestore/src/framestore.cc
@@ -118,7 +118,6 @@ class FrameStore : public ff_util::FreeFlyerNodelet {
   void InitFault(std::string const& msg ) {
     NODELET_ERROR_STREAM(msg);
     AssertFault(ff_util::INITIALIZATION_FAILED, msg);
-    return;
   }
 
  protected:

--- a/mobility/mapper/src/polynomials.cc
+++ b/mobility/mapper/src/polynomials.cc
@@ -299,7 +299,6 @@ void Trajectory3D::TrajectoryAtTime(const double time,
   // return the value of the polynomial some time after tf (extrapolation)
   segments_poly_[n_segments_-1].SegmentAtTime(time, result);
   ROS_WARN("Time extrapolation when returning polynomial!");
-  return;
 }
 
 void Trajectory3D::TrajectoryAtTime(const double time,
@@ -316,7 +315,6 @@ void Trajectory3D::TrajectoryAtTime(const double time,
   // return the value of the polynomial some time after tf (extrapolation)
   segments_poly_[n_segments_-1].SegmentAtTime(time, result);
   ROS_WARN("Time extrapolation when returning polynomial!");
-  return;
 }
 
 }  // namespace polynomials

--- a/mobility/planner_qp/planner_qp/src/planner_qp.cc
+++ b/mobility/planner_qp/planner_qp/src/planner_qp.cc
@@ -363,7 +363,6 @@ class Planner : public planner::PlannerImplementation {
     plan_result.response = RESPONSE::SUCCESS;
     PlanResult(plan_result);
     timer_fb_.stop();
-    return;
   }
 
   // Called to interrupt the process

--- a/shared/ff_util/src/ff_nodelet/ff_nodelet.cc
+++ b/shared/ff_util/src/ff_nodelet/ff_nodelet.cc
@@ -195,8 +195,6 @@ void FreeFlyerNodelet::ReadConfig() {
       faults_[fault_key] = fault_id;
     }
   }
-
-  return;
 }
 
 void FreeFlyerNodelet::AssertFault(FaultKeys enum_key,


### PR DESCRIPTION
Checked through the code for unnecessary `return;` statements on the last line of `void` functions, which are not required.

Improves code consistency (most void functions in astrobee do not include a `return;` on the final line).

No impact on code logic.