### PR TITLE
fix rosbag_topic_filter.py args

### DIFF
--- a/tools/bag_processing/scripts/rosbag_topic_filter.py
+++ b/tools/bag_processing/scripts/rosbag_topic_filter.py
@@ -127,31 +127,25 @@ if __name__ == "__main__":
     )
     parser.add_argument("inbag", nargs="+", help="Input bagfile with bayer images.")
     parser.add_argument(
-        "-o",
-        "--output",
-        help="path for output bag",
-        default="filtered_{inbag}",
+        "-o", "--output", help="path for output bag", default="filtered_{inbag}"
     )
     parser.add_argument(
         "-a",
         "--accept",
-        nargs="*",
+        nargs="?",
         help="Add topic pattern to accept list",
         default=[],
+        action="append",
     )
     parser.add_argument(
         "-r",
         "--reject",
-        nargs="*",
+        nargs="?",
         help="Add topic pattern to reject list",
         default=[],
+        action="append",
     )
-    parser.add_argument(
-        "-v",
-        "--verbose",
-        help="Print debug info",
-        action="store_true",
-    )
+    parser.add_argument("-v", "--verbose", help="Print debug info", action="store_true")
 
     args = parser.parse_args()
 


### PR DESCRIPTION
In the documentation for using `rosbag_topic_filter.py` there are examples like this:
```bash
rosrun bag_processing rosbag_topic_filter.py in.bag -a accept1 -a accept2 -o out.bag
```

But the argument parsing was (unintentionally?) changed so you would need to do this instead:
```bash
rosrun bag_processing rosbag_topic_filter.py in.bag -a accept1 accept2 -o out.bag
```

Unfortunately, when you run the example from the documentation with the modified argument parsing, it doesn't complain but it does something different! (Instead of applying both accept1 and accept2, it overwrites accept1 with accept2.) As a result, I just spent a while tracking down why some messages were missing in a filtered bag.

I would like to revert to stay consistent with the documentation and avoid this bad subtle failure mode. I also think the previous syntax was a bit better in terms of clarity of what the arguments mean.

(Note the linter forced me to make some other insignificant changes because the previous version of the file was not 100% `black` formatted.)