### PR TITLE
Improve is_camera robustness, primarily thread safety fixes

### DIFF
--- a/hardware/is_camera/include/is_camera/camera.h
+++ b/hardware/is_camera/include/is_camera/camera.h
@@ -46,11 +46,11 @@ struct V4LStruct;
 
 class PeriodicTrigger {
  public:
-  inline PeriodicTrigger(unsigned int period) : period_(period), counter_(0) {}
+  inline explicit PeriodicTrigger(unsigned int period) : period_(period), counter_(0) {}
   inline bool IsTriggered() { return counter_ == 0; }
   inline bool Tick() {
     bool result = IsTriggered();
-    counter_ = (counter_ + 1 ) % period_;
+    counter_ = (counter_ + 1) % period_;
     return result;
   }
   inline void SetPeriod(unsigned int period) {

--- a/hardware/is_camera/src/camera.cc
+++ b/hardware/is_camera/src/camera.cc
@@ -32,7 +32,6 @@
 #include <linux/videodev2.h>
 #include <sys/mman.h>
 #include <sys/ioctl.h>
-#include <algorithm>
 
 namespace is_camera {
 
@@ -178,8 +177,8 @@ namespace is_camera {
     auto_exposure_(false),
     err_p_(0),
     err_i_(0),
-    read_params_trigger_(frames_per_second), // 1 Hz
-    auto_exposure_trigger_(frames_per_second) // 1 Hz
+    read_params_trigger_(frames_per_second),  // 1 Hz
+    auto_exposure_trigger_(frames_per_second)  // 1 Hz
     {}
 
   CameraNodelet::~CameraNodelet() {


### PR DESCRIPTION
Summary of changes:
- Removed `ros::spinOnce()` call at the end of `PublishLoop()`. There is a comment to explain why. I consider this change experimental and could probably be convinced to revert it... perhaps there's something I'm not understanding about the ROS nodelet threading model.
- Switched from using ROS timers (which run callbacks in a thread from the nodelet manager's thread pool) to `PeriodicTrigger` instances (which are used to invoke functions in the same thread as `PublishLoop()`). This avoids potential thread safety issues. V4L2 is supposed to be thread-safe but the community wisdom seems to be that it is vendor-specific and you shouldn't count on it. Beyond strict thread safety, a more subtle point is that synchronizing events to happen at a particular point in the frame loop is likely to make the behavior more reliable by avoiding rare corner cases. (For example, what happens if the syscall to adjust the exposure is executed while the camera is in the middle of grabbing a frame? We can eliminate cases like these by syncing the syscall to only happen at a particular point in the loop.)
- Changed newer `ioctl()` calls to use `xioctl()` wrapper, consistent with the rest of the driver.
- Added guards that skip the exposure parameter adjustment syscalls if the actual value was not modified. It's great to avoid syscalls when possible because they typically require a context switch, which adds some latency. (There was also a comment that suggested making too many exposure adjustment calls reduces the frame rate, so it may have more impact than just a context switch.)
- Fixed a bug in modulo arithmetic. The C++ modulo operator preserves the sign of its first operand. You might think that `(i - 1) % k` always evaluates to a number between 0 and k - 1, suitable for indexing into a length-k ring buffer, but in fact it evaluates to -1 when i is 0 and causes an invalid memory reference. The formula should be `(i + k - 1) % k`.

This PR is marked as draft because it should definitely be tested on the granite table before being merged into `develop`. The testing should include applying manual exposure adjustments like we have done in past ISAAC procedures. I don't think there is a huge rush on this. There may be other changes we want to make and test together.
