### PR TITLE
Add /signals topic to fix_message_definition_topic_patterns

### DIFF
--- a/communications/ff_msgs/bmr/rosbag_rewrite_types_rules.json
+++ b/communications/ff_msgs/bmr/rosbag_rewrite_types_rules.json
@@ -3,10 +3,11 @@
     ],
     "fix_message_definition_topic_patterns": [
         "/gs/*",
-	"/command",
+        "/command",
         "/hw/cam_sci/compressed",
         "/hw/cam_sci_info",
         "/mgt/disk_monitor/state",
-        "/mgt/cpu_monitor/state"
+        "/mgt/cpu_monitor/state",
+        "/signals"
     ]
 }


### PR DESCRIPTION
Jonathan found another bad topic in a Kibo-RPC telemetry bag, added to fix list.

Also random style fix: replace tabs with spaces for consistency.