### PR TITLE
vocab db: report memory usage

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -49,7 +49,7 @@ Depends: ${misc:Depends}
   ${ros-python},
   astrobee-config (>= ${binary:Version}),
   astrobee-comms (>= ${binary:Version}),
-  libalvar2 (>=2.0), libdbow21 (>=0.1), libgtsam (>=4.0), libopenmvg1 (>=1.0), libroyale1 (>=1.0),
+  libalvar2 (>=2.0), libdbow21 (>=0.1-6), libgtsam (>=4.0), libopenmvg1 (>=1.0), libroyale1 (>=1.0),
   libceres1 (>=1.0), rti (>=1.0), libmiro0 (>=0.1), libsoracore1 (>=1.0),
   libdecomputil0 (>=0.1), libjps3d0 (>=0.1),
   libluajit-5.1-2,

--- a/scripts/setup/debians/dbow2/changelog
+++ b/scripts/setup/debians/dbow2/changelog
@@ -1,3 +1,9 @@
+libdbow2 (0.1-6) unstable; urgency=medium
+
+  * Added reportMemoryUsage() methods.
+
+ -- Trey Smith <nospam@nospam.org>  Thu, 16 Mar 2023 13:31:16 -0500
+
 libdbow2 (0.1-5) unstable; urgency=medium
 
   * Ros moved opencv library which broke build, fixed it.

--- a/scripts/setup/debians/dbow2/patches/report_memory_usage.patch
+++ b/scripts/setup/debians/dbow2/patches/report_memory_usage.patch
@@ -1,5 +1,5 @@
 diff --git a/include/DBoW2/TemplatedDatabase.h b/include/DBoW2/TemplatedDatabase.h
-index 96cbe8e..444863b 100644
+index 96cbe8e..f9eac9a 100644
 --- a/include/DBoW2/TemplatedDatabase.h
 +++ b/include/DBoW2/TemplatedDatabase.h
 @@ -16,6 +16,7 @@
@@ -19,7 +19,7 @@ index 96cbe8e..444863b 100644
  protected:
    
    /// Query with L1 scoring
-@@ -1345,6 +1348,65 @@ std::ostream& operator<<(std::ostream &os,
+@@ -1345,6 +1348,59 @@ std::ostream& operator<<(std::ostream &os,
  
  // --------------------------------------------------------------------------
  
@@ -34,42 +34,36 @@ index 96cbe8e..444863b 100644
 +  size_t num_rows = m_ifile.size();
 +  FF_REPORT(num_rows);
 +
-+  size_t num_ifpairs = std::accumulate(m_ifile.begin(), m_ifile.end(), 0,
-+                                     [](size_t accum, const std::list<IFPair>& r) {
-+                                       return accum + r.size();
-+                                     });
++  size_t num_ifpairs = 0;
++  for (typename InvertedFile::const_iterator it = m_ifile.begin(); it != m_ifile.end(); it++) {
++    num_ifpairs += it->size();
++  }
 +  FF_REPORT(num_ifpairs);
 +
 +  std::cout << std::endl;
 +
 +  // typedef std::list<IFPair> IFRow;
 +  // typedef std::vector<IFRow> InvertedFile;
-+  size_t m_ifile_bytes =
-+    m_ifile.size() * sizeof(std::list<IFPair>)
-+    + std::accumulate(m_ifile.begin(), m_ifile.end(), 0,
-+                      [](size_t accum, const std::list<IFPair>& r) {
-+                        constexpr size_t list_bytes_per_node = 2 * sizeof(void *);
-+                        return accum + r.size() * (list_bytes_per_node + sizeof(IFPair));
-+                      });
++  const size_t list_bytes_per_node = 2 * sizeof(void *);
++  size_t m_ifile_bytes = m_ifile.size() * sizeof(std::list<IFPair>);
++  for (typename InvertedFile::const_iterator it = m_ifile.begin(); it != m_ifile.end(); it++) {
++    m_ifile_bytes += it->size() * (list_bytes_per_node + sizeof(IFPair));
++  }
 +  FF_REPORT(m_ifile_bytes);
 +
 +
 +  // class FeatureVector: public std::map<NodeId, std::vector<unsigned int> >
 +  // typedef std::vector<FeatureVector> DirectFile;
 +  // some of this is platform- and data-dependent, just rough approximation
-+  const int map_node_bytes = sizeof(int) + 3 * sizeof(void *); // red/black tree node ~overhead
-+  size_t m_dfile_bytes =
-+    m_dfile.size() * sizeof(FeatureVector)
-+    + std::accumulate(m_dfile.begin(), m_dfile.end(), 0,
-+                      [](size_t accum, const FeatureVector& v) {
-+                        size_t v_bytes =
-+                          v.size() * (map_node_bytes + sizeof(NodeId) + sizeof(std::vector<unsigned int>))
-+                          + std::accumulate(v.begin(), v.end(), 0,
-+                                            [](size_t acc, const std::pair<NodeId, std::vector<unsigned int> >& x) {
-+                                              return acc + x.second.size() * sizeof(unsigned int);
-+                                            });
-+                        return accum + v_bytes;
-+                      });
++  const size_t map_node_bytes = sizeof(int) + 3 * sizeof(void *); // red/black tree node ~overhead
++  size_t m_dfile_bytes = m_dfile.size() * sizeof(FeatureVector);
++  for (typename DirectFile::const_iterator it = m_dfile.begin(); it != m_dfile.end(); it++) {
++    m_dfile_bytes += it->size()
++      * (map_node_bytes + sizeof(NodeId) + sizeof(std::vector<unsigned int>));
++    for (typename FeatureVector::const_iterator jt = it->begin(); jt != it->end(); jt++) {
++      m_dfile_bytes += jt->second.size() * sizeof(unsigned int);
++    }
++  }
 +  FF_REPORT(m_dfile_bytes);
 +
 +  std::cout << std::endl;
@@ -86,7 +80,7 @@ index 96cbe8e..444863b 100644
  
  #endif
 diff --git a/include/DBoW2/TemplatedVocabulary.h b/include/DBoW2/TemplatedVocabulary.h
-index 53a0e30..028745e 100644
+index 53a0e30..d8f98a5 100644
 --- a/include/DBoW2/TemplatedVocabulary.h
 +++ b/include/DBoW2/TemplatedVocabulary.h
 @@ -17,6 +17,7 @@
@@ -106,7 +100,7 @@ index 53a0e30..028745e 100644
  protected:
  
    /// Pointer to descriptor
-@@ -1524,6 +1527,40 @@ std::ostream& operator<<(std::ostream &os,
+@@ -1524,6 +1527,39 @@ std::ostream& operator<<(std::ostream &os,
    return os;
  }
  
@@ -128,11 +122,10 @@ index 53a0e30..028745e 100644
 +
 +  std::cout << std::endl;
 +
-+  size_t m_nodes_bytes = m_nodes.size() * sizeof(Node)
-+    + std::accumulate(m_nodes.begin(), m_nodes.end(), 0,
-+                      [](size_t accum, const Node& n) {
-+                        return accum + n.children.size() * sizeof(NodeId);
-+                      });
++  size_t m_nodes_bytes = m_nodes.size() * sizeof(Node);
++  for (typename std::vector<Node>::const_iterator it = m_nodes.begin(); it != m_nodes.end(); it++) {
++    m_nodes_bytes += it->children.size() * sizeof(NodeId);
++  }
 +  FF_REPORT(m_nodes_bytes);
 +
 +  size_t m_words_bytes = m_words.size() * sizeof(Node*);

--- a/scripts/setup/debians/dbow2/patches/report_memory_usage.patch
+++ b/scripts/setup/debians/dbow2/patches/report_memory_usage.patch
@@ -1,0 +1,149 @@
+diff --git a/include/DBoW2/TemplatedDatabase.h b/include/DBoW2/TemplatedDatabase.h
+index 96cbe8e..444863b 100644
+--- a/include/DBoW2/TemplatedDatabase.h
++++ b/include/DBoW2/TemplatedDatabase.h
+@@ -16,6 +16,7 @@
+ #include <string>
+ #include <list>
+ #include <set>
++#include <iomanip>
+ 
+ #include "TemplatedVocabulary.h"
+ #include "QueryResults.h"
+@@ -223,6 +224,8 @@ public:
+   virtual void load(const cv::FileStorage &fs, 
+     const std::string &name = "database");
+ 
++  size_t reportMemoryUsage();
++
+ protected:
+   
+   /// Query with L1 scoring
+@@ -1345,6 +1348,65 @@ std::ostream& operator<<(std::ostream &os,
+ 
+ // --------------------------------------------------------------------------
+ 
++template<class TDescriptor, class F>
++size_t TemplatedDatabase<TDescriptor,F>::reportMemoryUsage()
++{
++#define FF_REPORT(field) \
++  std::cout << "  " << std::setw(12) << field << "   " << #field << std::endl;
++
++  std::cout << "  DBoW database:" << std::endl;
++
++  size_t num_rows = m_ifile.size();
++  FF_REPORT(num_rows);
++
++  size_t num_ifpairs = std::accumulate(m_ifile.begin(), m_ifile.end(), 0,
++                                     [](size_t accum, const std::list<IFPair>& r) {
++                                       return accum + r.size();
++                                     });
++  FF_REPORT(num_ifpairs);
++
++  std::cout << std::endl;
++
++  // typedef std::list<IFPair> IFRow;
++  // typedef std::vector<IFRow> InvertedFile;
++  size_t m_ifile_bytes =
++    m_ifile.size() * sizeof(std::list<IFPair>)
++    + std::accumulate(m_ifile.begin(), m_ifile.end(), 0,
++                      [](size_t accum, const std::list<IFPair>& r) {
++                        constexpr size_t list_bytes_per_node = 2 * sizeof(void *);
++                        return accum + r.size() * (list_bytes_per_node + sizeof(IFPair));
++                      });
++  FF_REPORT(m_ifile_bytes);
++
++
++  // class FeatureVector: public std::map<NodeId, std::vector<unsigned int> >
++  // typedef std::vector<FeatureVector> DirectFile;
++  // some of this is platform- and data-dependent, just rough approximation
++  const int map_node_bytes = sizeof(int) + 3 * sizeof(void *); // red/black tree node ~overhead
++  size_t m_dfile_bytes =
++    m_dfile.size() * sizeof(FeatureVector)
++    + std::accumulate(m_dfile.begin(), m_dfile.end(), 0,
++                      [](size_t accum, const FeatureVector& v) {
++                        size_t v_bytes =
++                          v.size() * (map_node_bytes + sizeof(NodeId) + sizeof(std::vector<unsigned int>))
++                          + std::accumulate(v.begin(), v.end(), 0,
++                                            [](size_t acc, const std::pair<NodeId, std::vector<unsigned int> >& x) {
++                                              return acc + x.second.size() * sizeof(unsigned int);
++                                            });
++                        return accum + v_bytes;
++                      });
++  FF_REPORT(m_dfile_bytes);
++
++  std::cout << std::endl;
++  size_t m_voc_bytes  = m_voc->reportMemoryUsage();
++
++#undef FF_REPORT
++
++  return m_ifile_bytes + m_dfile_bytes + m_voc_bytes;
++}
++
++// --------------------------------------------------------------------------
++
+ } // namespace DBoW2
+ 
+ #endif
+diff --git a/include/DBoW2/TemplatedVocabulary.h b/include/DBoW2/TemplatedVocabulary.h
+index 53a0e30..028745e 100644
+--- a/include/DBoW2/TemplatedVocabulary.h
++++ b/include/DBoW2/TemplatedVocabulary.h
+@@ -17,6 +17,7 @@
+ #include <fstream>
+ #include <string>
+ #include <algorithm>
++#include <iomanip>
+ #include <opencv2/core.hpp>
+ 
+ #include "FeatureVector.h"
+@@ -266,6 +267,8 @@ public:
+    */
+   virtual int stopWords(double minWeight);
+ 
++  virtual size_t reportMemoryUsage();
++
+ protected:
+ 
+   /// Pointer to descriptor
+@@ -1524,6 +1527,40 @@ std::ostream& operator<<(std::ostream &os,
+   return os;
+ }
+ 
++// --------------------------------------------------------------------------
++
++template<class TDescriptor, class F>
++size_t TemplatedVocabulary<TDescriptor,F>::reportMemoryUsage()
++{
++#define FF_REPORT(field) \
++  std::cout << "  " << std::setw(12) << field << "   " << #field << std::endl;
++
++  std::cout << "  DBoW vocabulary:" << std::endl;
++
++  size_t num_nodes = m_nodes.size();
++  FF_REPORT(num_nodes);
++
++  size_t num_words = m_words.size();
++  FF_REPORT(num_words);
++
++  std::cout << std::endl;
++
++  size_t m_nodes_bytes = m_nodes.size() * sizeof(Node)
++    + std::accumulate(m_nodes.begin(), m_nodes.end(), 0,
++                      [](size_t accum, const Node& n) {
++                        return accum + n.children.size() * sizeof(NodeId);
++                      });
++  FF_REPORT(m_nodes_bytes);
++
++  size_t m_words_bytes = m_words.size() * sizeof(Node*);
++  FF_REPORT(m_words_bytes);
++
++#undef FF_REPORT
++
++  return m_nodes_bytes + m_words_bytes;
++}
++
++
+ } // namespace DBoW2
+ 
+ #endif

--- a/scripts/setup/debians/dbow2/patches/report_memory_usage.patch
+++ b/scripts/setup/debians/dbow2/patches/report_memory_usage.patch
@@ -1,5 +1,5 @@
 diff --git a/include/DBoW2/TemplatedDatabase.h b/include/DBoW2/TemplatedDatabase.h
-index 96cbe8e..f9eac9a 100644
+index 96cbe8e..10fe5b4 100644
 --- a/include/DBoW2/TemplatedDatabase.h
 +++ b/include/DBoW2/TemplatedDatabase.h
 @@ -16,6 +16,7 @@
@@ -10,26 +10,35 @@ index 96cbe8e..f9eac9a 100644
  
  #include "TemplatedVocabulary.h"
  #include "QueryResults.h"
-@@ -223,6 +224,8 @@ public:
+@@ -223,6 +224,13 @@ public:
    virtual void load(const cv::FileStorage &fs, 
      const std::string &name = "database");
  
-+  size_t reportMemoryUsage();
++  /**
++   * Estimates memory usage of the database.
++   * @param partsOutput Statistics concerning parts of the data structure will be appended to this vector.
++   * @return Estimated total usage.
++   */
++  size_t reportMemoryUsage(std::vector<std::pair<std::string, size_t> >& partsOutput);
 +
  protected:
    
    /// Query with L1 scoring
-@@ -1345,6 +1348,59 @@ std::ostream& operator<<(std::ostream &os,
+@@ -1345,6 +1353,64 @@ std::ostream& operator<<(std::ostream &os,
  
  // --------------------------------------------------------------------------
  
 +template<class TDescriptor, class F>
-+size_t TemplatedDatabase<TDescriptor,F>::reportMemoryUsage()
++size_t TemplatedDatabase<TDescriptor,F>::reportMemoryUsage(std::vector<std::pair<std::string, size_t> >& partsOutput)
 +{
-+#define FF_REPORT(field) \
-+  std::cout << "  " << std::setw(12) << field << "   " << #field << std::endl;
++  typedef std::pair<std::string, size_t> PartsEntry;
 +
-+  std::cout << "  DBoW database:" << std::endl;
++#define FF_REPORT(field) \
++  partsOutput.push_back(PartsEntry(#field, field));
++#define FF_COMMENT(label) \
++  partsOutput.push_back(PartsEntry("*" label, 0));
++
++  FF_COMMENT("  DBow database:");
 +
 +  size_t num_rows = m_ifile.size();
 +  FF_REPORT(num_rows);
@@ -40,7 +49,7 @@ index 96cbe8e..f9eac9a 100644
 +  }
 +  FF_REPORT(num_ifpairs);
 +
-+  std::cout << std::endl;
++  FF_COMMENT("");
 +
 +  // typedef std::list<IFPair> IFRow;
 +  // typedef std::vector<IFRow> InvertedFile;
@@ -66,10 +75,11 @@ index 96cbe8e..f9eac9a 100644
 +  }
 +  FF_REPORT(m_dfile_bytes);
 +
-+  std::cout << std::endl;
-+  size_t m_voc_bytes  = m_voc->reportMemoryUsage();
++  FF_COMMENT("");
++  size_t m_voc_bytes  = m_voc->reportMemoryUsage(partsOutput);
 +
 +#undef FF_REPORT
++#undef FF_COMMENT
 +
 +  return m_ifile_bytes + m_dfile_bytes + m_voc_bytes;
 +}
@@ -80,7 +90,7 @@ index 96cbe8e..f9eac9a 100644
  
  #endif
 diff --git a/include/DBoW2/TemplatedVocabulary.h b/include/DBoW2/TemplatedVocabulary.h
-index 53a0e30..d8f98a5 100644
+index 53a0e30..55d2dec 100644
 --- a/include/DBoW2/TemplatedVocabulary.h
 +++ b/include/DBoW2/TemplatedVocabulary.h
 @@ -17,6 +17,7 @@
@@ -91,28 +101,45 @@ index 53a0e30..d8f98a5 100644
  #include <opencv2/core.hpp>
  
  #include "FeatureVector.h"
-@@ -266,6 +267,8 @@ public:
+@@ -30,6 +31,7 @@ namespace DBoW2 {
+ /// @param TDescriptor class of descriptor
+ /// @param F class of descriptor functions
+ template<class TDescriptor, class F>
++
+ /// Generic Vocabulary
+ class TemplatedVocabulary
+ {		
+@@ -266,6 +268,13 @@ public:
     */
    virtual int stopWords(double minWeight);
  
-+  virtual size_t reportMemoryUsage();
++  /**
++   * Estimates memory usage of the vocabulary.
++   * @param partsOutput Statistics concerning parts of the data structure will be appended to this vector.
++   * @return Estimated total usage.
++   */
++  virtual size_t reportMemoryUsage(std::vector<std::pair<std::string, size_t> >& partsOutput);
 +
  protected:
  
    /// Pointer to descriptor
-@@ -1524,6 +1527,39 @@ std::ostream& operator<<(std::ostream &os,
+@@ -1524,6 +1533,44 @@ std::ostream& operator<<(std::ostream &os,
    return os;
  }
  
 +// --------------------------------------------------------------------------
 +
 +template<class TDescriptor, class F>
-+size_t TemplatedVocabulary<TDescriptor,F>::reportMemoryUsage()
++size_t TemplatedVocabulary<TDescriptor,F>::reportMemoryUsage(std::vector<std::pair<std::string, size_t> >& partsOutput)
 +{
-+#define FF_REPORT(field) \
-+  std::cout << "  " << std::setw(12) << field << "   " << #field << std::endl;
++  typedef std::pair<std::string, size_t> PartsEntry;
 +
-+  std::cout << "  DBoW vocabulary:" << std::endl;
++#define FF_REPORT(field) \
++  partsOutput.push_back(PartsEntry(#field, field));
++#define FF_COMMENT(label) \
++  partsOutput.push_back(PartsEntry("*" label, 0));
++
++  FF_COMMENT("  DBow vocabulary:");
 +
 +  size_t num_nodes = m_nodes.size();
 +  FF_REPORT(num_nodes);
@@ -120,7 +147,7 @@ index 53a0e30..d8f98a5 100644
 +  size_t num_words = m_words.size();
 +  FF_REPORT(num_words);
 +
-+  std::cout << std::endl;
++  FF_COMMENT("");
 +
 +  size_t m_nodes_bytes = m_nodes.size() * sizeof(Node);
 +  for (typename std::vector<Node>::const_iterator it = m_nodes.begin(); it != m_nodes.end(); it++) {
@@ -132,6 +159,7 @@ index 53a0e30..d8f98a5 100644
 +  FF_REPORT(m_words_bytes);
 +
 +#undef FF_REPORT
++#undef FF_COMMENT
 +
 +  return m_nodes_bytes + m_words_bytes;
 +}

--- a/scripts/setup/debians/dbow2/patches/series
+++ b/scripts/setup/debians/dbow2/patches/series
@@ -1,3 +1,4 @@
 fix_opencv.patch
 bytes_descriptor.patch
 fix_path.patch
+report_memory_usage.patch


### PR DESCRIPTION
Added methods to report approximate memory usage of protected class members in the bag of words data structures. The methods are designed to be called from a higher-level `ReportMemoryUsage()` function in the `sparse_mapping` package.

This PR needs to be merged into `master` and deployed to `astrobee_base` before the higher-level code will pass tests.

The larger aim is to figure out the main contributors to sparse map memory usage so we can evaluate possible optimizations.