### PR TITLE
sparse map: report memory usage

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -49,7 +49,7 @@ Depends: ${misc:Depends}
   ${ros-python},
   astrobee-config (>= ${binary:Version}),
   astrobee-comms (>= ${binary:Version}),
-  libalvar2 (>=2.0), libdbow21 (>=0.1), libgtsam (>=4.0), libopenmvg1 (>=1.0), libroyale1 (>=1.0),
+  libalvar2 (>=2.0), libdbow21 (>=0.1-6), libgtsam (>=4.0), libopenmvg1 (>=1.0), libroyale1 (>=1.0),
   libceres1 (>=1.0), rti (>=1.0), libmiro0 (>=0.1), libsoracore1 (>=1.0),
   libdecomputil0 (>=0.1), libjps3d0 (>=0.1),
   libluajit-5.1-2,

--- a/localization/sparse_mapping/include/sparse_mapping/sparse_map.h
+++ b/localization/sparse_mapping/include/sparse_mapping/sparse_map.h
@@ -262,6 +262,11 @@ struct SparseMap {
 
   std::string GetDetectorName() { return detector_.GetDetectorName(); }
 
+  /**
+   * Report data structure memory usage to stdout.
+   **/
+  void ReportMemoryUsage();
+
   // stored in map file
   std::vector<std::string> cid_to_filename_;
   // TODO(bcoltin) replace Eigen2Xd everywhere with one keypoint class

--- a/localization/sparse_mapping/include/sparse_mapping/vocab_tree.h
+++ b/localization/sparse_mapping/include/sparse_mapping/vocab_tree.h
@@ -82,6 +82,7 @@ namespace sparse_mapping {
     ~VocabDB();
     void SaveProtobuf(google::protobuf::io::ZeroCopyOutputStream* output) const;
     void LoadProtobuf(google::protobuf::io::ZeroCopyInputStream* input, int db_type);
+    size_t ReportMemoryUsage();
   };
 
   void DBSanityChecks(std::string const& db_type,
@@ -103,6 +104,7 @@ namespace sparse_mapping {
   void BuildDBforDBoW2(sparse_mapping::SparseMap* map,
                        std::string const& descriptor,
                        int depth, int branching_factor, int restarts);
+
 }  // namespace sparse_mapping
 
 #endif  // SPARSE_MAPPING_VOCAB_TREE_H_

--- a/localization/sparse_mapping/include/sparse_mapping/vocab_tree.h
+++ b/localization/sparse_mapping/include/sparse_mapping/vocab_tree.h
@@ -60,6 +60,7 @@
 #include <vector>
 #include <string>
 #include <map>
+#include <utility>
 
 namespace cv {
   class Mat;
@@ -82,7 +83,7 @@ namespace sparse_mapping {
     ~VocabDB();
     void SaveProtobuf(google::protobuf::io::ZeroCopyOutputStream* output) const;
     void LoadProtobuf(google::protobuf::io::ZeroCopyInputStream* input, int db_type);
-    size_t ReportMemoryUsage();
+    size_t ReportMemoryUsage(std::vector<std::pair<std::string, size_t> >& partsOutput);
   };
 
   void DBSanityChecks(std::string const& db_type,

--- a/localization/sparse_mapping/src/sparse_map.cc
+++ b/localization/sparse_mapping/src/sparse_map.cc
@@ -1072,7 +1072,20 @@ void SparseMap::ReportMemoryUsage() {
   SM_REPORT(cid_fid_to_pid_bytes);
 
   std::cout << std::endl;
-  size_t vocab_db_bytes = vocab_db_.ReportMemoryUsage();
+
+  std::vector<std::pair<std::string, size_t> > partsOutput;
+  size_t vocab_db_bytes = vocab_db_.ReportMemoryUsage(partsOutput);
+  for (auto it = partsOutput.begin(); it != partsOutput.end(); it++) {
+    const std::string& label = it->first;
+    size_t value = it->second;
+    if (label.rfind("*", 0) == 0) {
+      // if the label starts with * just print the comment
+      std::cout << label.substr(1) << std::endl;
+    } else {
+      // print label and value in standard format
+      std::cout << "  " << std::setw(12) << value << "   " << label << std::endl;
+    }
+  }
   std::cout << std::endl;
   SM_REPORT(vocab_db_bytes);
 

--- a/localization/sparse_mapping/src/sparse_map.cc
+++ b/localization/sparse_mapping/src/sparse_map.cc
@@ -1021,11 +1021,10 @@ void SparseMap::ReportMemoryUsage() {
   size_t num_pid = pid_to_xyz_.size();
   SM_REPORT(num_pid);
 
-  size_t num_features =
-    std::accumulate(cid_to_descriptor_map_.begin(), cid_to_descriptor_map_.end(), 0,
-                    [](size_t accum, const cv::Mat& M) {
-                      return accum + M.rows;
-                    });
+  size_t num_features = 0;
+  for (auto it = cid_to_descriptor_map_.begin(); it != cid_to_descriptor_map_.end(); it++) {
+    num_features += it->rows;
+  }
   SM_REPORT(num_features);
 
   std::cout << std::endl;
@@ -1033,30 +1032,24 @@ void SparseMap::ReportMemoryUsage() {
   size_t sparse_map_bytes = sizeof(SparseMap);
   SM_REPORT(sparse_map_bytes);
 
-  size_t cid_to_filename_bytes =
-    cid_to_filename_.size() * sizeof(std::string)
-    + std::accumulate(cid_to_filename_.begin(), cid_to_filename_.end(), 0,
-                      [](size_t accum, const std::string& s) {
-                        return accum + s.size();
-                      });
+  size_t cid_to_filename_bytes = cid_to_filename_.size() * sizeof(std::string);
+  for (auto it = cid_to_filename_.begin(); it != cid_to_filename_.end(); it++) {
+    cid_to_filename_bytes += it->size();
+  }
   SM_REPORT(cid_to_filename_bytes);
 
-  size_t cid_to_keypoint_map_bytes =
-    cid_to_keypoint_map_.size() * sizeof(Eigen::Matrix2Xd)
-    + std::accumulate(cid_to_keypoint_map_.begin(), cid_to_keypoint_map_.end(), 0,
-                      [](size_t accum, const Eigen::Matrix2Xd& M) {
-                        return accum + 2 * M.cols() * sizeof(double);
-                      });
+  size_t cid_to_keypoint_map_bytes = cid_to_keypoint_map_.size() * sizeof(Eigen::Matrix2Xd);
+  for (auto it = cid_to_keypoint_map_.begin(); it != cid_to_keypoint_map_.end(); it++) {
+    cid_to_keypoint_map_bytes += 2 * it->cols() * sizeof(double);
+  }
   SM_REPORT(cid_to_keypoint_map_bytes);
 
   // some of this is platform- and data-dependent, just rough approximation
   const int map_node_bytes = sizeof(int) + 3 * sizeof(void*);  // red/black tree node ~overhead
-  size_t pid_to_cid_fid_bytes =
-    pid_to_cid_fid_.size() * sizeof(std::map<int, int>)
-    + std::accumulate(pid_to_cid_fid_.begin(), pid_to_cid_fid_.end(), 0,
-                      [](size_t accum, const std::map<int, int>& m) {
-                        return accum + m.size() * (map_node_bytes + 2 * sizeof(int));
-                      });
+  size_t pid_to_cid_fid_bytes = pid_to_cid_fid_.size() * sizeof(std::map<int, int>);
+  for (auto it = pid_to_cid_fid_.begin(); it != pid_to_cid_fid_.end(); it++) {
+    pid_to_cid_fid_bytes += it->size() * (map_node_bytes + 2 * sizeof(int));
+  }
   SM_REPORT(pid_to_cid_fid_bytes);
 
   size_t pid_to_xyz_bytes = pid_to_xyz_.size() * sizeof(Eigen::Vector3d);
@@ -1066,20 +1059,16 @@ void SparseMap::ReportMemoryUsage() {
     cid_to_cam_t_global_.size() * sizeof(Eigen::Affine3d);
   SM_REPORT(cid_to_cam_t_global_bytes);
 
-  size_t cid_to_descriptor_map_bytes =
-    cid_to_descriptor_map_.size() * sizeof(cv::Mat)
-    + std::accumulate(cid_to_descriptor_map_.begin(), cid_to_descriptor_map_.end(), 0,
-                      [](size_t accum, const cv::Mat& M) {
-                        return accum + M.rows * M.cols * M.elemSize();
-                      });
+  size_t cid_to_descriptor_map_bytes = cid_to_descriptor_map_.size() * sizeof(cv::Mat);
+  for (auto it = cid_to_descriptor_map_.begin(); it != cid_to_descriptor_map_.end(); it++) {
+    cid_to_descriptor_map_bytes += it->rows * it->cols * it->elemSize();
+  }
   SM_REPORT(cid_to_descriptor_map_bytes);
 
-  size_t cid_fid_to_pid_bytes =
-    cid_fid_to_pid_.size() * sizeof(std::map<int, int>)
-    + std::accumulate(cid_fid_to_pid_.begin(), cid_fid_to_pid_.end(), 0,
-                      [](size_t accum, const std::map<int, int>& m) {
-                        return accum + m.size() * (map_node_bytes + 2 * sizeof(int));
-                      });
+  size_t cid_fid_to_pid_bytes = cid_fid_to_pid_.size() * sizeof(std::map<int, int>);
+  for (auto it = cid_fid_to_pid_.begin(); it != cid_fid_to_pid_.end(); it++) {
+    cid_fid_to_pid_bytes += it->size() * (map_node_bytes + 2 * sizeof(int));
+  }
   SM_REPORT(cid_fid_to_pid_bytes);
 
   std::cout << std::endl;

--- a/localization/sparse_mapping/src/vocab_tree.cc
+++ b/localization/sparse_mapping/src/vocab_tree.cc
@@ -309,8 +309,8 @@ void VocabDB::LoadProtobuf(google::protobuf::io::ZeroCopyInputStream* input, int
   }
 }
 
-size_t VocabDB::ReportMemoryUsage() {
-  return binary_db->reportMemoryUsage();
+size_t VocabDB::ReportMemoryUsage(std::vector<std::pair<std::string, size_t> >& partsOutput) {
+  return binary_db->reportMemoryUsage(partsOutput);
 }
 
 void BuildDB(std::string const& map_file,

--- a/localization/sparse_mapping/src/vocab_tree.cc
+++ b/localization/sparse_mapping/src/vocab_tree.cc
@@ -309,6 +309,10 @@ void VocabDB::LoadProtobuf(google::protobuf::io::ZeroCopyInputStream* input, int
   }
 }
 
+size_t VocabDB::ReportMemoryUsage() {
+  return binary_db->reportMemoryUsage();
+}
+
 void BuildDB(std::string const& map_file,
                              std::string const& descriptor,
                              int depth, int branching_factor, int restarts) {

--- a/scripts/setup/debians/dbow2/changelog
+++ b/scripts/setup/debians/dbow2/changelog
@@ -1,3 +1,9 @@
+libdbow2 (0.1-6) unstable; urgency=medium
+
+  * Added reportMemoryUsage() methods.
+
+ -- Trey Smith <nospam@nospam.org>  Thu, 16 Mar 2023 13:31:16 -0500
+
 libdbow2 (0.1-5) unstable; urgency=medium
 
   * Ros moved opencv library which broke build, fixed it.

--- a/scripts/setup/debians/dbow2/patches/report_memory_usage.patch
+++ b/scripts/setup/debians/dbow2/patches/report_memory_usage.patch
@@ -1,5 +1,5 @@
 diff --git a/include/DBoW2/TemplatedDatabase.h b/include/DBoW2/TemplatedDatabase.h
-index 96cbe8e..444863b 100644
+index 96cbe8e..f9eac9a 100644
 --- a/include/DBoW2/TemplatedDatabase.h
 +++ b/include/DBoW2/TemplatedDatabase.h
 @@ -16,6 +16,7 @@
@@ -19,7 +19,7 @@ index 96cbe8e..444863b 100644
  protected:
    
    /// Query with L1 scoring
-@@ -1345,6 +1348,65 @@ std::ostream& operator<<(std::ostream &os,
+@@ -1345,6 +1348,59 @@ std::ostream& operator<<(std::ostream &os,
  
  // --------------------------------------------------------------------------
  
@@ -34,42 +34,36 @@ index 96cbe8e..444863b 100644
 +  size_t num_rows = m_ifile.size();
 +  FF_REPORT(num_rows);
 +
-+  size_t num_ifpairs = std::accumulate(m_ifile.begin(), m_ifile.end(), 0,
-+                                     [](size_t accum, const std::list<IFPair>& r) {
-+                                       return accum + r.size();
-+                                     });
++  size_t num_ifpairs = 0;
++  for (typename InvertedFile::const_iterator it = m_ifile.begin(); it != m_ifile.end(); it++) {
++    num_ifpairs += it->size();
++  }
 +  FF_REPORT(num_ifpairs);
 +
 +  std::cout << std::endl;
 +
 +  // typedef std::list<IFPair> IFRow;
 +  // typedef std::vector<IFRow> InvertedFile;
-+  size_t m_ifile_bytes =
-+    m_ifile.size() * sizeof(std::list<IFPair>)
-+    + std::accumulate(m_ifile.begin(), m_ifile.end(), 0,
-+                      [](size_t accum, const std::list<IFPair>& r) {
-+                        constexpr size_t list_bytes_per_node = 2 * sizeof(void *);
-+                        return accum + r.size() * (list_bytes_per_node + sizeof(IFPair));
-+                      });
++  const size_t list_bytes_per_node = 2 * sizeof(void *);
++  size_t m_ifile_bytes = m_ifile.size() * sizeof(std::list<IFPair>);
++  for (typename InvertedFile::const_iterator it = m_ifile.begin(); it != m_ifile.end(); it++) {
++    m_ifile_bytes += it->size() * (list_bytes_per_node + sizeof(IFPair));
++  }
 +  FF_REPORT(m_ifile_bytes);
 +
 +
 +  // class FeatureVector: public std::map<NodeId, std::vector<unsigned int> >
 +  // typedef std::vector<FeatureVector> DirectFile;
 +  // some of this is platform- and data-dependent, just rough approximation
-+  const int map_node_bytes = sizeof(int) + 3 * sizeof(void *); // red/black tree node ~overhead
-+  size_t m_dfile_bytes =
-+    m_dfile.size() * sizeof(FeatureVector)
-+    + std::accumulate(m_dfile.begin(), m_dfile.end(), 0,
-+                      [](size_t accum, const FeatureVector& v) {
-+                        size_t v_bytes =
-+                          v.size() * (map_node_bytes + sizeof(NodeId) + sizeof(std::vector<unsigned int>))
-+                          + std::accumulate(v.begin(), v.end(), 0,
-+                                            [](size_t acc, const std::pair<NodeId, std::vector<unsigned int> >& x) {
-+                                              return acc + x.second.size() * sizeof(unsigned int);
-+                                            });
-+                        return accum + v_bytes;
-+                      });
++  const size_t map_node_bytes = sizeof(int) + 3 * sizeof(void *); // red/black tree node ~overhead
++  size_t m_dfile_bytes = m_dfile.size() * sizeof(FeatureVector);
++  for (typename DirectFile::const_iterator it = m_dfile.begin(); it != m_dfile.end(); it++) {
++    m_dfile_bytes += it->size()
++      * (map_node_bytes + sizeof(NodeId) + sizeof(std::vector<unsigned int>));
++    for (typename FeatureVector::const_iterator jt = it->begin(); jt != it->end(); jt++) {
++      m_dfile_bytes += jt->second.size() * sizeof(unsigned int);
++    }
++  }
 +  FF_REPORT(m_dfile_bytes);
 +
 +  std::cout << std::endl;
@@ -86,7 +80,7 @@ index 96cbe8e..444863b 100644
  
  #endif
 diff --git a/include/DBoW2/TemplatedVocabulary.h b/include/DBoW2/TemplatedVocabulary.h
-index 53a0e30..028745e 100644
+index 53a0e30..d8f98a5 100644
 --- a/include/DBoW2/TemplatedVocabulary.h
 +++ b/include/DBoW2/TemplatedVocabulary.h
 @@ -17,6 +17,7 @@
@@ -106,7 +100,7 @@ index 53a0e30..028745e 100644
  protected:
  
    /// Pointer to descriptor
-@@ -1524,6 +1527,40 @@ std::ostream& operator<<(std::ostream &os,
+@@ -1524,6 +1527,39 @@ std::ostream& operator<<(std::ostream &os,
    return os;
  }
  
@@ -128,11 +122,10 @@ index 53a0e30..028745e 100644
 +
 +  std::cout << std::endl;
 +
-+  size_t m_nodes_bytes = m_nodes.size() * sizeof(Node)
-+    + std::accumulate(m_nodes.begin(), m_nodes.end(), 0,
-+                      [](size_t accum, const Node& n) {
-+                        return accum + n.children.size() * sizeof(NodeId);
-+                      });
++  size_t m_nodes_bytes = m_nodes.size() * sizeof(Node);
++  for (typename std::vector<Node>::const_iterator it = m_nodes.begin(); it != m_nodes.end(); it++) {
++    m_nodes_bytes += it->children.size() * sizeof(NodeId);
++  }
 +  FF_REPORT(m_nodes_bytes);
 +
 +  size_t m_words_bytes = m_words.size() * sizeof(Node*);

--- a/scripts/setup/debians/dbow2/patches/report_memory_usage.patch
+++ b/scripts/setup/debians/dbow2/patches/report_memory_usage.patch
@@ -1,0 +1,149 @@
+diff --git a/include/DBoW2/TemplatedDatabase.h b/include/DBoW2/TemplatedDatabase.h
+index 96cbe8e..444863b 100644
+--- a/include/DBoW2/TemplatedDatabase.h
++++ b/include/DBoW2/TemplatedDatabase.h
+@@ -16,6 +16,7 @@
+ #include <string>
+ #include <list>
+ #include <set>
++#include <iomanip>
+ 
+ #include "TemplatedVocabulary.h"
+ #include "QueryResults.h"
+@@ -223,6 +224,8 @@ public:
+   virtual void load(const cv::FileStorage &fs, 
+     const std::string &name = "database");
+ 
++  size_t reportMemoryUsage();
++
+ protected:
+   
+   /// Query with L1 scoring
+@@ -1345,6 +1348,65 @@ std::ostream& operator<<(std::ostream &os,
+ 
+ // --------------------------------------------------------------------------
+ 
++template<class TDescriptor, class F>
++size_t TemplatedDatabase<TDescriptor,F>::reportMemoryUsage()
++{
++#define FF_REPORT(field) \
++  std::cout << "  " << std::setw(12) << field << "   " << #field << std::endl;
++
++  std::cout << "  DBoW database:" << std::endl;
++
++  size_t num_rows = m_ifile.size();
++  FF_REPORT(num_rows);
++
++  size_t num_ifpairs = std::accumulate(m_ifile.begin(), m_ifile.end(), 0,
++                                     [](size_t accum, const std::list<IFPair>& r) {
++                                       return accum + r.size();
++                                     });
++  FF_REPORT(num_ifpairs);
++
++  std::cout << std::endl;
++
++  // typedef std::list<IFPair> IFRow;
++  // typedef std::vector<IFRow> InvertedFile;
++  size_t m_ifile_bytes =
++    m_ifile.size() * sizeof(std::list<IFPair>)
++    + std::accumulate(m_ifile.begin(), m_ifile.end(), 0,
++                      [](size_t accum, const std::list<IFPair>& r) {
++                        constexpr size_t list_bytes_per_node = 2 * sizeof(void *);
++                        return accum + r.size() * (list_bytes_per_node + sizeof(IFPair));
++                      });
++  FF_REPORT(m_ifile_bytes);
++
++
++  // class FeatureVector: public std::map<NodeId, std::vector<unsigned int> >
++  // typedef std::vector<FeatureVector> DirectFile;
++  // some of this is platform- and data-dependent, just rough approximation
++  const int map_node_bytes = sizeof(int) + 3 * sizeof(void *); // red/black tree node ~overhead
++  size_t m_dfile_bytes =
++    m_dfile.size() * sizeof(FeatureVector)
++    + std::accumulate(m_dfile.begin(), m_dfile.end(), 0,
++                      [](size_t accum, const FeatureVector& v) {
++                        size_t v_bytes =
++                          v.size() * (map_node_bytes + sizeof(NodeId) + sizeof(std::vector<unsigned int>))
++                          + std::accumulate(v.begin(), v.end(), 0,
++                                            [](size_t acc, const std::pair<NodeId, std::vector<unsigned int> >& x) {
++                                              return acc + x.second.size() * sizeof(unsigned int);
++                                            });
++                        return accum + v_bytes;
++                      });
++  FF_REPORT(m_dfile_bytes);
++
++  std::cout << std::endl;
++  size_t m_voc_bytes  = m_voc->reportMemoryUsage();
++
++#undef FF_REPORT
++
++  return m_ifile_bytes + m_dfile_bytes + m_voc_bytes;
++}
++
++// --------------------------------------------------------------------------
++
+ } // namespace DBoW2
+ 
+ #endif
+diff --git a/include/DBoW2/TemplatedVocabulary.h b/include/DBoW2/TemplatedVocabulary.h
+index 53a0e30..028745e 100644
+--- a/include/DBoW2/TemplatedVocabulary.h
++++ b/include/DBoW2/TemplatedVocabulary.h
+@@ -17,6 +17,7 @@
+ #include <fstream>
+ #include <string>
+ #include <algorithm>
++#include <iomanip>
+ #include <opencv2/core.hpp>
+ 
+ #include "FeatureVector.h"
+@@ -266,6 +267,8 @@ public:
+    */
+   virtual int stopWords(double minWeight);
+ 
++  virtual size_t reportMemoryUsage();
++
+ protected:
+ 
+   /// Pointer to descriptor
+@@ -1524,6 +1527,40 @@ std::ostream& operator<<(std::ostream &os,
+   return os;
+ }
+ 
++// --------------------------------------------------------------------------
++
++template<class TDescriptor, class F>
++size_t TemplatedVocabulary<TDescriptor,F>::reportMemoryUsage()
++{
++#define FF_REPORT(field) \
++  std::cout << "  " << std::setw(12) << field << "   " << #field << std::endl;
++
++  std::cout << "  DBoW vocabulary:" << std::endl;
++
++  size_t num_nodes = m_nodes.size();
++  FF_REPORT(num_nodes);
++
++  size_t num_words = m_words.size();
++  FF_REPORT(num_words);
++
++  std::cout << std::endl;
++
++  size_t m_nodes_bytes = m_nodes.size() * sizeof(Node)
++    + std::accumulate(m_nodes.begin(), m_nodes.end(), 0,
++                      [](size_t accum, const Node& n) {
++                        return accum + n.children.size() * sizeof(NodeId);
++                      });
++  FF_REPORT(m_nodes_bytes);
++
++  size_t m_words_bytes = m_words.size() * sizeof(Node*);
++  FF_REPORT(m_words_bytes);
++
++#undef FF_REPORT
++
++  return m_nodes_bytes + m_words_bytes;
++}
++
++
+ } // namespace DBoW2
+ 
+ #endif

--- a/scripts/setup/debians/dbow2/patches/report_memory_usage.patch
+++ b/scripts/setup/debians/dbow2/patches/report_memory_usage.patch
@@ -1,5 +1,5 @@
 diff --git a/include/DBoW2/TemplatedDatabase.h b/include/DBoW2/TemplatedDatabase.h
-index 96cbe8e..f9eac9a 100644
+index 96cbe8e..10fe5b4 100644
 --- a/include/DBoW2/TemplatedDatabase.h
 +++ b/include/DBoW2/TemplatedDatabase.h
 @@ -16,6 +16,7 @@
@@ -10,26 +10,35 @@ index 96cbe8e..f9eac9a 100644
  
  #include "TemplatedVocabulary.h"
  #include "QueryResults.h"
-@@ -223,6 +224,8 @@ public:
+@@ -223,6 +224,13 @@ public:
    virtual void load(const cv::FileStorage &fs, 
      const std::string &name = "database");
  
-+  size_t reportMemoryUsage();
++  /**
++   * Estimates memory usage of the database.
++   * @param partsOutput Statistics concerning parts of the data structure will be appended to this vector.
++   * @return Estimated total usage.
++   */
++  size_t reportMemoryUsage(std::vector<std::pair<std::string, size_t> >& partsOutput);
 +
  protected:
    
    /// Query with L1 scoring
-@@ -1345,6 +1348,59 @@ std::ostream& operator<<(std::ostream &os,
+@@ -1345,6 +1353,64 @@ std::ostream& operator<<(std::ostream &os,
  
  // --------------------------------------------------------------------------
  
 +template<class TDescriptor, class F>
-+size_t TemplatedDatabase<TDescriptor,F>::reportMemoryUsage()
++size_t TemplatedDatabase<TDescriptor,F>::reportMemoryUsage(std::vector<std::pair<std::string, size_t> >& partsOutput)
 +{
-+#define FF_REPORT(field) \
-+  std::cout << "  " << std::setw(12) << field << "   " << #field << std::endl;
++  typedef std::pair<std::string, size_t> PartsEntry;
 +
-+  std::cout << "  DBoW database:" << std::endl;
++#define FF_REPORT(field) \
++  partsOutput.push_back(PartsEntry(#field, field));
++#define FF_COMMENT(label) \
++  partsOutput.push_back(PartsEntry("*" label, 0));
++
++  FF_COMMENT("  DBow database:");
 +
 +  size_t num_rows = m_ifile.size();
 +  FF_REPORT(num_rows);
@@ -40,7 +49,7 @@ index 96cbe8e..f9eac9a 100644
 +  }
 +  FF_REPORT(num_ifpairs);
 +
-+  std::cout << std::endl;
++  FF_COMMENT("");
 +
 +  // typedef std::list<IFPair> IFRow;
 +  // typedef std::vector<IFRow> InvertedFile;
@@ -66,10 +75,11 @@ index 96cbe8e..f9eac9a 100644
 +  }
 +  FF_REPORT(m_dfile_bytes);
 +
-+  std::cout << std::endl;
-+  size_t m_voc_bytes  = m_voc->reportMemoryUsage();
++  FF_COMMENT("");
++  size_t m_voc_bytes  = m_voc->reportMemoryUsage(partsOutput);
 +
 +#undef FF_REPORT
++#undef FF_COMMENT
 +
 +  return m_ifile_bytes + m_dfile_bytes + m_voc_bytes;
 +}
@@ -80,7 +90,7 @@ index 96cbe8e..f9eac9a 100644
  
  #endif
 diff --git a/include/DBoW2/TemplatedVocabulary.h b/include/DBoW2/TemplatedVocabulary.h
-index 53a0e30..d8f98a5 100644
+index 53a0e30..55d2dec 100644
 --- a/include/DBoW2/TemplatedVocabulary.h
 +++ b/include/DBoW2/TemplatedVocabulary.h
 @@ -17,6 +17,7 @@
@@ -91,28 +101,45 @@ index 53a0e30..d8f98a5 100644
  #include <opencv2/core.hpp>
  
  #include "FeatureVector.h"
-@@ -266,6 +267,8 @@ public:
+@@ -30,6 +31,7 @@ namespace DBoW2 {
+ /// @param TDescriptor class of descriptor
+ /// @param F class of descriptor functions
+ template<class TDescriptor, class F>
++
+ /// Generic Vocabulary
+ class TemplatedVocabulary
+ {		
+@@ -266,6 +268,13 @@ public:
     */
    virtual int stopWords(double minWeight);
  
-+  virtual size_t reportMemoryUsage();
++  /**
++   * Estimates memory usage of the vocabulary.
++   * @param partsOutput Statistics concerning parts of the data structure will be appended to this vector.
++   * @return Estimated total usage.
++   */
++  virtual size_t reportMemoryUsage(std::vector<std::pair<std::string, size_t> >& partsOutput);
 +
  protected:
  
    /// Pointer to descriptor
-@@ -1524,6 +1527,39 @@ std::ostream& operator<<(std::ostream &os,
+@@ -1524,6 +1533,44 @@ std::ostream& operator<<(std::ostream &os,
    return os;
  }
  
 +// --------------------------------------------------------------------------
 +
 +template<class TDescriptor, class F>
-+size_t TemplatedVocabulary<TDescriptor,F>::reportMemoryUsage()
++size_t TemplatedVocabulary<TDescriptor,F>::reportMemoryUsage(std::vector<std::pair<std::string, size_t> >& partsOutput)
 +{
-+#define FF_REPORT(field) \
-+  std::cout << "  " << std::setw(12) << field << "   " << #field << std::endl;
++  typedef std::pair<std::string, size_t> PartsEntry;
 +
-+  std::cout << "  DBoW vocabulary:" << std::endl;
++#define FF_REPORT(field) \
++  partsOutput.push_back(PartsEntry(#field, field));
++#define FF_COMMENT(label) \
++  partsOutput.push_back(PartsEntry("*" label, 0));
++
++  FF_COMMENT("  DBow vocabulary:");
 +
 +  size_t num_nodes = m_nodes.size();
 +  FF_REPORT(num_nodes);
@@ -120,7 +147,7 @@ index 53a0e30..d8f98a5 100644
 +  size_t num_words = m_words.size();
 +  FF_REPORT(num_words);
 +
-+  std::cout << std::endl;
++  FF_COMMENT("");
 +
 +  size_t m_nodes_bytes = m_nodes.size() * sizeof(Node);
 +  for (typename std::vector<Node>::const_iterator it = m_nodes.begin(); it != m_nodes.end(); it++) {
@@ -132,6 +159,7 @@ index 53a0e30..d8f98a5 100644
 +  FF_REPORT(m_words_bytes);
 +
 +#undef FF_REPORT
++#undef FF_COMMENT
 +
 +  return m_nodes_bytes + m_words_bytes;
 +}

--- a/scripts/setup/debians/dbow2/patches/series
+++ b/scripts/setup/debians/dbow2/patches/series
@@ -1,3 +1,4 @@
 fix_opencv.patch
 bytes_descriptor.patch
 fix_path.patch
+report_memory_usage.patch


### PR DESCRIPTION
Added methods to report approximate memory usage of the sparse map data structures. This is *not* the same as the sparse map file size on disk because the in-memory representation is different from the file serialization, and memory usage also varies depending on the architecture we're running on.

This PR relies on bag of words memory usage reporting methods in #702. It's not expected to pass tests until #702 is merged to `master` and deployed to `astrobee_base`.

The larger aim is to figure out the main contributors to sparse map memory usage so we can evaluate possible optimizations.

Here is example output for the `hamilton` map running on `x86_64`, will be different on `armhf`:
```
SparseMap::ReportMemoryUsage:
          1752 num_cid
        114504 num_pid
        349729 num_features

           736 sparse_map_bytes
        147652 cid_to_filename_bytes
             0 cid_to_keypoint_map_bytes
             0 pid_to_cid_fid_bytes
       2748096 pid_to_xyz_bytes
             0 cid_to_cam_t_global_bytes
      22550848 cid_to_descriptor_map_bytes
      12674340 cid_fid_to_pid_bytes

  DBoW database:
       1240609   num_rows
       1453996   num_ifpairs

      76302488   m_ifile_bytes
             0   m_dfile_bytes

  DBoW vocabulary:
       1511709   num_nodes
       1240609   num_words

     114889880   m_nodes_bytes
       9924872   m_words_bytes

     201117240 vocab_db_bytes
             0 db_to_cid_map_bytes
     239238912 total_bytes

             0 num_cid_to_cid
             0 num_user_cid
             0 num_user_pid

  num_entries_per_descriptor: 64
  descriptor_entry_bytes: 1
```