### PR TITLE
putting ros2 changes back into develop to minimize code differences

### DIFF
--- a/gnc/pmc/src/fam.cc
+++ b/gnc/pmc/src/fam.cc
@@ -120,8 +120,7 @@ void Fam::UpdateCOM(const Eigen::Vector3f & com) {
   Eigen::Matrix<float, 6, 12> thrust2forcetorque;
   thrust2forcetorque << thrust2force_, thrust2torque_;
   forcetorque2thrust_ = Eigen::MatrixXf::Identity(12, 6);
-  Eigen::JacobiSVD<Eigen::MatrixXf> svd(thrust2forcetorque, Eigen::ComputeThinU | Eigen::ComputeThinV);
-  forcetorque2thrust_ = svd.solve(forcetorque2thrust_);
+  forcetorque2thrust_ = pseudoInverse(thrust2forcetorque);
 }
 
 void Fam::CalcThrustMatrices(const Eigen::Vector3f & force, const Eigen::Vector3f & torque,

--- a/mobility/choreographer/src/choreographer_nodelet.cc
+++ b/mobility/choreographer/src/choreographer_nodelet.cc
@@ -1177,6 +1177,12 @@ class ChoreographerNodelet : public ff_util::FreeFlyerNodelet {
       path.poses.push_back(ps);
     }
     pub_segment_.publish(path);
+
+    // Initialize timers
+    tolerance_pos_timer_ = ros::Time::now();
+    tolerance_att_timer_ = ros::Time::now();
+    tolerance_vel_timer_ = ros::Time::now();
+    tolerance_omega_timer_ = ros::Time::now();
     // Success!
     return true;
   }
@@ -1190,7 +1196,7 @@ class ChoreographerNodelet : public ff_util::FreeFlyerNodelet {
       if (flight_mode_.tolerance_pos > 0.0 &&
           feedback->error_position > flight_mode_.tolerance_pos) {
         // If tolerance is present more that the allowable time
-        if ((ros::Time::now() - tolerance_pos_timer).toSec() > tolerance_max_time_) {
+        if ((ros::Time::now() - tolerance_pos_timer_).toSec() > tolerance_max_time_) {
           NODELET_DEBUG_STREAM("Position tolerance violated");
           NODELET_DEBUG_STREAM("- Value: " << feedback->error_position
                                           << ", Thresh: "
@@ -1200,13 +1206,13 @@ class ChoreographerNodelet : public ff_util::FreeFlyerNodelet {
         }
       } else {
         // If there is no tolerance violation, reset time
-        tolerance_pos_timer = ros::Time::now();
+        tolerance_pos_timer_ = ros::Time::now();
       }
       // Check attitude tolerance
       if (flight_mode_.tolerance_att > 0.0 &&
           feedback->error_attitude > flight_mode_.tolerance_att) {
         // If tolerance is present more that the allowable time
-        if ((ros::Time::now() - tolerance_att_timer).toSec() > tolerance_max_time_) {
+        if ((ros::Time::now() - tolerance_att_timer_).toSec() > tolerance_max_time_) {
           NODELET_DEBUG_STREAM("Attitude tolerance violated");
           NODELET_DEBUG_STREAM("- Value: " << feedback->error_attitude
                                           << ", Thresh: "
@@ -1216,13 +1222,13 @@ class ChoreographerNodelet : public ff_util::FreeFlyerNodelet {
         }
       } else {
         // If there is no tolerance violation, reset time
-        tolerance_att_timer = ros::Time::now();
+        tolerance_att_timer_ = ros::Time::now();
       }
       // Check velocity tolerance
       if (flight_mode_.tolerance_vel > 0.0 &&
           feedback->error_velocity > flight_mode_.tolerance_vel) {
         // If tolerance is present more that the allowable time
-        if ((ros::Time::now() - tolerance_vel_timer).toSec() > tolerance_max_time_) {
+        if ((ros::Time::now() - tolerance_vel_timer_).toSec() > tolerance_max_time_) {
           NODELET_DEBUG_STREAM("Velocity tolerance violated");
           NODELET_DEBUG_STREAM("- Value: " << feedback->error_velocity
                                           << ", Thresh: "
@@ -1232,13 +1238,13 @@ class ChoreographerNodelet : public ff_util::FreeFlyerNodelet {
         }
       } else {
         // If there is no tolerance violation, reset time
-        tolerance_vel_timer = ros::Time::now();
+        tolerance_vel_timer_ = ros::Time::now();
       }
       // Check angular velocity tolerance
       if (flight_mode_.tolerance_omega > 0.0 &&
           feedback->error_omega > flight_mode_.tolerance_omega) {
         // If tolerance is present more that the allowable time
-        if ((ros::Time::now() - tolerance_omega_timer).toSec() > tolerance_max_time_) {
+        if ((ros::Time::now() - tolerance_omega_timer_).toSec() > tolerance_max_time_) {
           NODELET_DEBUG_STREAM("Angular velocity tolerance violated");
           NODELET_DEBUG_STREAM("- Value: " << feedback->error_omega
                                           << ", Thresh: "
@@ -1248,7 +1254,7 @@ class ChoreographerNodelet : public ff_util::FreeFlyerNodelet {
         }
       } else {
         // If there is no tolerance violation, reset time
-        tolerance_omega_timer = ros::Time::now();
+        tolerance_omega_timer_ = ros::Time::now();
       }
     // Send progress in stopping/idling/replanning
     case STATE::STOPPING:
@@ -1416,8 +1422,8 @@ class ChoreographerNodelet : public ff_util::FreeFlyerNodelet {
   double tolerance_max_time_;
   // Position error
   double pos_error_;
-  ros::Time tolerance_pos_timer, tolerance_att_timer,
-                tolerance_vel_timer, tolerance_omega_timer;
+  ros::Time tolerance_pos_timer_, tolerance_att_timer_,
+                tolerance_vel_timer_, tolerance_omega_timer_;
   // Cached number of replan attempts
   int replan_attempts_;
 };


### PR DESCRIPTION
I didn't see a difference in the printed FAM, and the timer not being initialized is not a problem in ROS1 (was a problem in ROS2 because you can't subtract 2 different types of time). But figured I would put the changes in develop too for consistency