### PR TITLE
Use fabs to calculate time drift

### DIFF
--- a/management/sys_monitor/src/sys_monitor.cc
+++ b/management/sys_monitor/src/sys_monitor.cc
@@ -187,11 +187,11 @@ void SysMonitor::HeartbeatCallback(ff_msgs::HeartbeatConstPtr const& hb) {
       // This fault only applies to clock skew between the MLP and the LLP since
       // this skew causes navigation failures.
       float time_diff_sec = (time_now - hb->header.stamp).toSec();
-      if (abs(time_diff_sec) > time_drift_thres_sec_) {
+      if (fabs(time_diff_sec) > time_drift_thres_sec_) {
         if (!time_diff_fault_triggered_) {
           std::string key = ff_util::fault_keys[ff_util::TIME_DIFF_TOO_HIGH];
           unsigned int id = faults_[key];
-          AddFault(id, ("Time diff is: " + std::to_string(abs(time_diff_sec))));
+          AddFault(id, ("Time diff is: " + std::to_string(fabs(time_diff_sec))));
           PublishFaultResponse(id);
           time_diff_fault_triggered_ = true;
         }


### PR DESCRIPTION
Function abs from cmath conflicts with other implementations when using Ubuntu 16.

This causes abs to remove decimals from the time drift calculation. Therefore sys_monitor can only detect drift greater than 1 second.

Use fabs to remove ambiguity