### PR TITLE
Camera model fixes

### DIFF
--- a/shared/msg_conversions/include/msg_conversions/msg_conversions.h
+++ b/shared/msg_conversions/include/msg_conversions/msg_conversions.h
@@ -62,6 +62,7 @@ Eigen::Affine3d ros_pose_to_eigen_transform(const geometry_msgs::Pose& p);
 Eigen::Affine3d ros_to_eigen_transform(const geometry_msgs::Transform& p);
 geometry_msgs::Pose ros_transform_to_ros_pose(const geometry_msgs::Transform& p);
 geometry_msgs::Pose tf2_transform_to_ros_pose(const tf2::Transform& p);
+geometry_msgs::Pose eigen_transform_to_ros_pose(const Eigen::Affine3d& p);
 geometry_msgs::Transform eigen_transform_to_ros_transform(const Eigen::Affine3d& p);
 tf2::Transform ros_tf_to_tf2_transform(const geometry_msgs::Transform& p);
 tf2::Transform ros_pose_to_tf2_transform(const geometry_msgs::Pose& p);

--- a/shared/msg_conversions/src/msg_conversions.cc
+++ b/shared/msg_conversions/src/msg_conversions.cc
@@ -270,6 +270,13 @@ geometry_msgs::Pose tf2_transform_to_ros_pose(const tf2::Transform& p) {
   return transform;
 }
 
+geometry_msgs::Pose eigen_transform_to_ros_pose(const Eigen::Affine3d& p) {
+  geometry_msgs::Pose transform;
+  transform.position = eigen_to_ros_point(p.translation());
+  transform.orientation = eigen_to_ros_quat((Eigen::Quaterniond)p.linear());
+  return transform;
+}
+
 geometry_msgs::Transform eigen_transform_to_ros_transform(const Eigen::Affine3d& p) {
   geometry_msgs::Transform transform;
   transform.translation = eigen_to_ros_vector(p.translation());


### PR DESCRIPTION
- fixing some distortion conversions missing and some int->double castings that were resulting in rounding of results in Ray() output (results are normalized vectors, so it was always 0.0.1 regardless of input, we prob didn't see this in the past because it's only used in mock data generation)