### PR TITLE
fix: use join function instead using write function and using write f…

### DIFF
--- a/hardware/eps_driver/tools/eps_aux.py
+++ b/hardware/eps_driver/tools/eps_aux.py
@@ -11,7 +11,7 @@ def callback(data):
             aux = c.value
         if c.name.find("SYSTEM_I") >= 0:
             system = c.value
-    print(("system= %.3fA | aux= %.3fA " % (system, aux)))
+    print(f"system= {system:.3f}A | aux= {aux:.3f}A")
 
 
 def listener():

--- a/scripts/build/luaTable.py
+++ b/scripts/build/luaTable.py
@@ -20,6 +20,7 @@ Output Python data structure as a Lua table constructor.
 """
 
 import sys
+from typing import Any, Dict, List, Tuple, Union
 
 try:
     from cStringIO import StringIO  # fmt: skip
@@ -31,63 +32,52 @@ if sys.version_info.major > 2:
     basestring = (str, bytes)
 
 
-def q(s):
-    return '"%s"' % s
+def q(s: str) -> str:
+    return f'"{s}"'
 
 
-def ind(lvl):
+def ind(lvlL: int) -> str:
     return " " * (lvl * 2)
 
 
-def dumpStream(out, d, lvl=0):
+def dumpStream(out: StringIO, d: Any, lvl: int = 0) -> None:
+    lines = []
     def w(s):
-        out.write(s)
+        out.append(s)
 
     if isinstance(d, basestring):
-
         w(q(d))
     # fmt: skip
 
     elif isinstance(d, (list, tuple)):
         if d:
-            w("{\n")
-            n = len(d)
-            for i, elt in enumerate(d):
+            w("{")
+            for elt in d:
                 w(ind(lvl + 1))
                 dumpStream(out, elt, lvl + 1)
-                if i < n - 1:
-                    w(",")
-                w("\n")
-            w(ind(lvl))
-            w("}")
+                w(",")
+            w(ind(lvl) + "}")
         else:
             w("{}")
 
     elif isinstance(d, dict):
         if d:
             w("{\n")
-            n = len(d)
-            keys = list(d.keys())
-            keys.sort()
-            for i, k in enumerate(keys):
+            keys = sorted(d.keys())
+            for k in keys:
                 v = d[k]
                 w(ind(lvl + 1))
                 w(k)
                 w("=")
                 dumpStream(out, v, lvl + 1)
-                if i < n - 1:
-                    w(",")
-                w("\n")
-            w(ind(lvl))
-            w("}")
         else:
             w("{}")
-
     else:
         w(str(d))
+    out.write("\n".join(lines))
 
 
-def dumps(d):
+def dumps(d: Any) -> str:
     out = StringIO()
     dumpStream(out, d, 0)
     return out.getvalue()


### PR DESCRIPTION
improvement on ``eps_aux.py``:
- using f string for print format instead using old style python ``%``, and make more concise and readable formatting code, reference: [PEP 498](https://peps.python.org/pep-0498/)

improvement on ``luaTable.py``
- using f string for print format instead using old style python ``%``, and make more concise and readable formatting code, reference: [PEP 498](https://peps.python.org/pep-0498/)
- using ``join`` for concatenating lines instead of repeatedly calling ``write`` for each line, using ``join`` to concatenate the lines and write them in a single call
- adding type hinting to the function parameters, reference [PEP484](https://peps.python.org/pep-0484/)