### PR TITLE
Namespaced robots were not moving in Granite world

### DIFF
--- a/description/description/urdf/model_carriage.urdf.xacro
+++ b/description/description/urdf/model_carriage.urdf.xacro
@@ -25,13 +25,13 @@
       <!-- ixx and iyy are dummy values                        -->
       <inertia ixx="0.694860833" ixy="0.0" ixz="0.0" iyy="0.694860833" iyz="0.0" izz="0.0923"/>
     </inertial>
-    <visual name="carriage_visual">
+    <visual>
       <origin xyz="0 0 -0.02" rpy="0 0 0" />
       <geometry>
         <mesh filename="package://astrobee_freeflyer/meshes/carriage.dae"/>
       </geometry>
     </visual>
-    <collision name="carriage_collision">
+    <collision>
       <origin xyz="0 0 -0.02" rpy="0 0 0" />
       <geometry>
         <mesh filename="package://astrobee_freeflyer/meshes/carriage.dae"/>
@@ -49,7 +49,7 @@
     <child
       link="${prefix}carriage" />
   </joint>
-  <gazebo reference="carriage">
+  <gazebo reference="${prefix}carriage">
     <kp>100000.0</kp>
     <kd>100000.0</kd>
     <mu1>0.0</mu1>


### PR DESCRIPTION
### Identified problem: 
The carriage link's gazebo parameters (kp, kd) were not being read by Gazebo, hence the robots were not moving (sliding through the floor) when namespaced. They worked fine if no namespace was used.

### Test:
1. Start the world alone: `roslaunch astrobee sim.launch default_robot:=false world:=granite rviz:=true sviz:=true`
2. Add wannabee namespaced: `roslaunch astrobee spawn.launch ns:=wannabee dds:=false robot:=sim_pub pose:="0 0.3 -0.7 0 0 0 1" world:=granite`
3. Move the robot: `rosrun executive teleop_tool -move -relative -pos "0.3 0.0 0.0" -ns wannabee`

### Additional note:
 If you use bsharp namespaced, the Gazebo sim will not work. This is due to a couple of lines in the astrobee_gazebo.cc file:
```
  if (ns == "bsharp")
    ns = "/";
```
These lines assume that when the robot is named bsharp, no namespace is used. This assumption is born from the astrobee_spawn launch file, which sets the name of the gazebo model to bsharp when no namespace is used. I've locally gotten rid of those conditionals and I am able to use bsharp and wannabee namespaced. I didn't add this change to this PR because I see that "bsharp" is the default robot name in a few files, so I don't want to mess with this assumption.
