### PR TITLE
fix fov calculation, not considering distortion

### DIFF
--- a/localization/camera/src/camera_model.cc
+++ b/localization/camera/src/camera_model.cc
@@ -70,12 +70,12 @@ void CameraModel::SetTransform(const Eigen::Affine3d & cam_t_global) {
 
 double CameraModel::GetFovX(void) const {
   // This is an approximation since it doesn't take in account lens distortion
-  return atan(1.0 / (params_.GetFocalVector()[0] * params_.GetDistortedHalfSize()[0])) * 2;
+  return atan(params_.GetDistortedHalfSize()[0] / params_.GetFocalVector()[0] ) * 2;
 }
 
 double CameraModel::GetFovY(void) const {
   // This is an approximation since it doesn't take in account lens distortion
-  return atan(1.0 / (params_.GetFocalVector()[1] * params_.GetDistortedHalfSize()[1])) * 2;
+  return atan(params_.GetDistortedHalfSize()[1] / params_.GetFocalVector()[1] ) * 2;
 }
 
 const camera::CameraParameters& CameraModel::GetParameters() const {


### PR DESCRIPTION
The previous formula was just not correct. Fixed it to be accurate without distortion.
This can be further refined by using https://github.com/nasa/isaac/blob/master/astrobee/behaviors/inspection/scripts/field_of_view_calculator.py but I figured we fix it first since some isaac code depends on it to run well