### PR TITLE
Update flashlight service name in scripts and docs

### DIFF
--- a/hardware/flashlight/test_flashlight.md
+++ b/hardware/flashlight/test_flashlight.md
@@ -21,19 +21,19 @@ If running on P4C, please change the dev flag from /dev/i2c-1 to /dev/i2c-0
 
 There are two ways to set the flashlight brightness in the fsw. The fsw is set up such that setting brightness to 0 turns the flashlight off and setting the brightness anywhere from 1 to 200 turns the flashlight on. The first way is by calling the set flashlight service from the command line. To turn the front flashlight on, run:
 
-    rosservice call /hw/light_front/control 100
+    rosservice call /hw/flashlight_front/control 100
 
 To turn the front flashlight off, run:
 
-    rosservice call /hw/light_front/control 0
+    rosservice call /hw/flashlight_front/control 0
 
 To turn the back flashlight on, run:
 
-    rosservice call /hw/light_aft/control 100
+    rosservice call /hw/flashlight_aft/control 100
 
 To turn the back flashlight off, run:
 
-    rosservice call /hw/light_aft/control 0
+    rosservice call /hw/flashlight_aft/control 0
 
 The second way is to send a set flashlight brightness command to the executive. You can either do this by using the teleop command tab in GDS or publishing the command to the /command topic from the command line. To turn the front flashlight on, run:
 

--- a/scripts/helpers/hri
+++ b/scripts/helpers/hri
@@ -42,17 +42,17 @@ case $1 in
   fr*)
     if [[ "$2" = "1" ]] || [[ "$2" = "on" ]]
     then
-      rosservice call /hw/light_front/control 1
+      rosservice call /hw/flashlight_front/control 1
     else
-      rosservice call /hw/light_front/control 0
+      rosservice call /hw/flashlight_front/control 0
     fi
     ;;
   af*)
     if [[ "$2" = "1" ]] || [[ "$2" = "on" ]]
     then
-      rosservice call /hw/light_aft/control 1
+      rosservice call /hw/flashlight_aft/control 1
     else
-      rosservice call /hw/light_aft/control 0
+      rosservice call /hw/flashlight_aft/control 0
     fi
     ;;
   im*)

--- a/simulation/advanced_sim_info.md
+++ b/simulation/advanced_sim_info.md
@@ -92,8 +92,8 @@ Customization: description/description/model_eps.urdf.xacro
 
 This simulates front and aft facing flashlights. Unfortunately, Gazebo doesn't support model-fixed flashlights. So, for each flashlight a free-floating spot light is created in Gazebo, and the model plugin dynamically positions this light to be rigidly attached to the Free Flyer. To set the brightness of each light you can use the following commands:
 
-    rosservice call /%ns%/hw/light_front/control "brightness: 0"
-    rosservice call /%ns%/hw/light_aft/control "brightness: 200"
+    rosservice call /%ns%/hw/flashlight_front/control "brightness: 0"
+    rosservice call /%ns%/hw/flashlight_aft/control "brightness: 200"
 
 Customization: description/description/model_flashlights.urdf.xacro
     rate:   doesn't do anything (should this be removed?)


### PR DESCRIPTION
As of #254, the flashlight service name was changed from:
`/hw/light_front/control` and `/hw/light_aft/control` (see [these lines from aacc34d](https://github.com/nasa/astrobee/blob/aacc34d89cf001d89ae68e2a9ebeefc13048ef2f/shared/ff_util/include/ff_util/ff_names.h#L434-L435))

to `/hw/flashlight_front/control` and `/hw/flashlight_aft/control` (see [these lines from develop](https://github.com/nasa/astrobee/blob/ce579297dcb91788f470e7d8ba373ed5b10f302f/shared/ff_common/include/ff_common/ff_names.h#L447-L448)).

Some scripts and docs reference the service name from before this change,