### PR TITLE
Update brightness in setFlashlightBrightness example

### DIFF
--- a/hardware/flashlight/test_flashlight.md
+++ b/hardware/flashlight/test_flashlight.md
@@ -37,7 +37,7 @@ To turn the back flashlight off, run:
 
 The second way is to send a set flashlight brightness command to the executive. You can either do this by using the teleop command tab in GDS or publishing the command to the /command topic from the command line. To turn the front flashlight on, run:
 
-    rostopic pub --once /command ff_msgs/CommandStamped '{cmd_name: "setFlashlightBrightness", subsys_name: "Astrobee", args: [{data_type: 5, s: Front}, {data_type: 2, f: 100}]}'
+    rostopic pub --once /command ff_msgs/CommandStamped '{cmd_name: "setFlashlightBrightness", subsys_name: "Astrobee", args: [{data_type: 5, s: Front}, {data_type: 2, f: 1}]}'
 
 To turn the front flashlight off, run:
 
@@ -45,7 +45,7 @@ To turn the front flashlight off, run:
 
 To turn the back flashlight on, run:
 
-    rostopic pub --once /command ff_msgs/CommandStamped '{cmd_name: "setFlashlightBrightness", subsys_name: "Astrobee", args: [{data_type: 5, s: Back}, {data_type: 2, f: 100}]}'
+    rostopic pub --once /command ff_msgs/CommandStamped '{cmd_name: "setFlashlightBrightness", subsys_name: "Astrobee", args: [{data_type: 5, s: Back}, {data_type: 2, f: 1}]}'
 
 To turn the back flashlight off, run:
 


### PR DESCRIPTION
Using the executive to update the flashlight brightness requires the brightness be between [0 and 1](https://github.com/nasa/astrobee/blob/develop/management/executive/src/executive.cc#L2660-L2663).

Publishing the current example in the docs results in the command being rejected, as the brightness in the example of 100 is greater than 1.

This change updates the docs example to reflect this.
