### PR TITLE
Fixed Gazebo IMU transform

### DIFF
--- a/description/description/urdf/sensor_imu.urdf.xacro
+++ b/description/description/urdf/sensor_imu.urdf.xacro
@@ -20,7 +20,7 @@
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
   <gazebo reference="${prefix}body">
     <sensor name="imu" type="imu">
-      <pose>0 0 0 0 0 0</pose>
+      <pose>0.0386 0.0247 -0.01016 0 0 1.5707963</pose>
       <always_on>true</always_on>
       <update_rate>62.5</update_rate>
       <visualize>0</visualize>


### PR DESCRIPTION
Currently the IMU sensor transform for gazebo is identity. This differs from the ISS bumble.config IMU transform, and this discontinuity causes the localizer to handle it incorrectly. Oddly, when changing the .xacro file though, gazebo doesn't seem to alter the IMU location. This was attempted even with crazy transforms that swap x with z axes, and this gave the same result in gazebo.