### PR TITLE
Release 0.19.0

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,9 @@
 # Releases
 
+## Release 0.19.0
+
+  * New split localizer
+
 ## Release 0.18.0
 
   * Astrobee now using OpenCV 4! Please see install updates in INSTALL.md

--- a/astrobee.doxyfile
+++ b/astrobee.doxyfile
@@ -39,7 +39,7 @@ PROJECT_NAME           = "NASA Astrobee Robot Software"
 # control system is used.
 
 
-PROJECT_NUMBER         = 0.18.0
+PROJECT_NUMBER         = 0.19.0
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/astrobee/CMakeLists.txt
+++ b/astrobee/CMakeLists.txt
@@ -18,7 +18,7 @@
 cmake_minimum_required(VERSION 3.0)
 project(astrobee)
 
-set(ASTROBEE_VERSION 0.18.0)
+set(ASTROBEE_VERSION 0.19.0)
 
 ## Compile as C++14, supported in ROS Kinetic and newer
 add_compile_options(-std=c++14)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+astrobee (0.19.0) testing; urgency=medium
+
+  * New split localizer
+
+ -- Astrobee Flight Software <astrobee-fsw@nx.arc.nasa.gov>  Mon, 10 Jun 2024 09:54:26 -0700
+
 astrobee (0.18.0) testing; urgency=medium
 
   * Astrobee now using OpenCV 4! Please see install updates in INSTALL.md

--- a/debian/control
+++ b/debian/control
@@ -16,7 +16,7 @@ Depends: astrobee0 (= ${binary:Version}), ${misc:Depends}
   libace-dev, libqt4-dev | qtbase5-dev,
   protobuf-compiler, libv4l-dev, libeigen3-dev, libluajit-5.1-dev,
   libjsoncpp-dev, libtinyxml-dev, libyaml-cpp-dev, libusb-1.0-0-dev,
-  libalvar-dev, libdbow2-dev, libgtsam-dev, libopenmvg-dev, libroyale-dev, libceres-dev, rti-dev,
+  ros-noetic-ar-track-alvar, libdbow2-dev, libgtsam-dev, libopenmvg-dev, libroyale-dev, libceres-dev, rti-dev,
   libsoracore-dev, libmiro-dev, libdecomputil-dev, libjps3d-dev
 Description: Astrobee flight software development files.
  The Astrobee flight software development files.
@@ -49,7 +49,7 @@ Depends: ${misc:Depends}
   ${ros-python},
   astrobee-config (>= ${binary:Version}),
   astrobee-comms (>= ${binary:Version}),
-  libalvar2 (>=2.0), libdbow21 (>=0.1-6), libgtsam (>=4.0), libopenmvg1 (>=1.0), libroyale1 (>=1.0),
+  ros-noetic-ar-track-alvar, libdbow21 (>=0.1-6), libgtsam (>=4.0), libopenmvg1 (>=1.0), libroyale1 (>=1.0),
   libceres1 (>=1.0), rti (>=1.0), libmiro0 (>=0.1), libsoracore1 (>=1.0),
   libdecomputil0 (>=0.1), libjps3d0 (>=0.1),
   libluajit-5.1-2,
@@ -66,7 +66,7 @@ Depends: ${misc:Depends}
   ros-${ros-distro}-rosnode, ros-${ros-distro}-rosout, ros-${ros-distro}-rosparam,
   ros-${ros-distro}-rosservice, ros-${ros-distro}-rostopic, ros-${ros-distro}-roswtf,
   ros-${ros-distro}-std-srvs, ros-${ros-distro}-topic-tools, ros-${ros-distro}-xmlrpcpp,
-  libopencv-core, libopencv-calib3d, libopencv-highgui, libopencv-imgcodecs, libopencv-imgproc, libopencv-features2d, libopencv-xfeatures2d,
+  libopencv-core4.2, libopencv-calib3d4.2, libopencv-highgui4.2, libopencv-imgcodecs4.2, libopencv-imgproc4.2, libopencv-features2d4.2, libopencv-xfeatures2d,
   libjsoncpp1, libprotoc9v5 | libprotoc17, libgoogle-glog0v5,
   libtinyxml2.6.2v5, libyaml-cpp0.5v5 | libyaml-cpp0.6
 Description: Astrobee flight software.


### PR DESCRIPTION
https://babelfish.arc.nasa.gov/confluence/display/FFFSW/IRG-FFTEST302+-+2024-06-10+-++0.19.0+-+Astrobee+Release+Testing

There is a commit changing the control file. This was done on the 0.18.0 release but I must have forgotten to push before merging it, so the 0.18.0 debians use the fix.