### PR TITLE
Fix dds_ros_bridge shutdown so it exits cleanly

### DIFF
--- a/communications/dds_ros_bridge/include/dds_ros_bridge/dds_ros_bridge.h
+++ b/communications/dds_ros_bridge/include/dds_ros_bridge/dds_ros_bridge.h
@@ -229,8 +229,8 @@ class DdsRosBridge : public ff_util::FreeFlyerNodelet {
   ros::Publisher robot_name_pub_;
   ros::ServiceServer srv_set_telem_rate_;
 
-  std::map<std::string, ff::RosSubRapidPubPtr> ros_sub_rapid_pubs_;
   std::shared_ptr<kn::DdsEntitiesFactorySvc> dds_entities_factory_;
+  std::map<std::string, ff::RosSubRapidPubPtr> ros_sub_rapid_pubs_;
   std::string agent_name_, participant_name_;
   std::vector<ff::RapidPubPtr> rapid_pubs_;
   std::vector<ff::RapidSubRosPubPtr> rapid_sub_ros_pubs_;


### PR DESCRIPTION
Nodelet caused segfault on shutdown/unload which prevented its reload (manager died with it).

DDS objects were attempting read/close operations after factory was destroyed leading to segfault inside soraCore.

Order of declaration matters, this change lets the factory be the last soraCore reference to be destroyed.