### PR TITLE
Added the volatile keyword to the count_ array declaration.

### DIFF
--- a/hardware/embedded/rpm_sensor_arduino/rpm_sensor_arduino.ino
+++ b/hardware/embedded/rpm_sensor_arduino/rpm_sensor_arduino.ino
@@ -5,6 +5,7 @@
  * If you want to use a different board other than Mega,
  * be careful about interrupt numbers.
  * Author: Jongwoon Yoo (jongwoon.yoo@nasa.gov)
+ * Modified: Serhii Trush (Techn0man1ac) 
  */
 
 #include <Wire.h>
@@ -15,7 +16,8 @@
 #define I2C_ADDR 0x0A
 
 // Interrupt counter.
-long int count_[NUM_MOTORS];
+// Using volatile ensures that the value is read from memory every time.
+volatile long int count_[NUM_MOTORS]; 
 
 void setup() {
   int i = 0;


### PR DESCRIPTION
**Why this is needed?**

The count_ variable is modified inside hardware interrupt service routines (update0 to update3) but is read inside the I2C request handler (handleEvent). Without volatile, the compiler might optimize the code and cache the values in CPU registers, leading to stale or missed RPM readings. This change ensures the microcontroller always reads the **actual value from RAM**.